### PR TITLE
Feature/issue 53

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14.0 as alpine
 FROM alpine as downloader
 # When updating, 
 # * also update the checksum found at https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl.sha256
-# * also update k8s-related versions in vars.tf and init-cluster.sh
+# * also update k8s-related versions in vars.tf, init-cluster.sh and apply.sh
 ARG K8S_VERSION=1.21.2
 ARG KUBECTL_CHECKSUM=55b982527d76934c2f119e70bf0d69831d3af4985f72bb87cd4924b1c7d528da
 # When updating, also update the checksum found at https://github.com/helm/helm/releases

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ TLDR; You can run a local k8s cluster with the GitOps playground installed with 
 ```shell
 bash <(curl -s \
   https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh) \
-&& docker run --rm -it -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
-  --net=host \
-  ghcr.io/cloudogu/gitops-playground
+  && docker run --rm -it -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
+    --net=host \
+    ghcr.io/cloudogu/gitops-playground --yes
 ```
 
 This command will also print URLs of the [applications](#applications) inside the cluster to get you started. 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,18 @@ This command will also print URLs of the [applications](#applications) inside th
 
 # Table of contents
 
-<!-- Update with `doctoc --notitle README.md --maxlevel 5`. See https://github.com/thlorenz/doctoc -->
+<!-- Update with `doctoc --notitle README.md --maxlevel 4`. See https://github.com/thlorenz/doctoc -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [What is the GitOps Playground?](#what-is-the-gitops-playground)
 - [Installation](#installation)
   - [Create Cluster](#create-cluster)
-  - [Apply apps to cluster](#apply-apps-to-cluster)
-    - [Apply via kubectl](#apply-via-kubectl)
-    - [Apply via local container](#apply-via-local-container)
-    - [Apply via script](#apply-via-script)
-    - [Parameters](#parameters)
-    - [Override default images used in the gitops-build-lib](#override-default-images-used-in-the-gitops-build-lib)
-  - [Remove apps from cluster](#remove-apps-from-cluster)
+  - [Apply playground](#apply-playground)
+    - [Apply via Docker (local cluster)](#apply-via-docker-local-cluster)
+    - [Apply via kubectl (remote cluster)](#apply-via-kubectl-remote-cluster)
+    - [Additional parameters](#additional-parameters)
+  - [Remove playground](#remove-playground)
 - [Applications](#applications)
   - [Credentials](#credentials)
   - [Jenkins](#jenkins)
@@ -44,15 +42,8 @@ This command will also print URLs of the [applications](#applications) inside th
   - [ArgoCD UI](#argocd-ui)
   - [Demo applications](#demo-applications)
     - [Flux V1](#flux-v1)
-      - [PetClinic with plain k8s resources](#petclinic-with-plain-k8s-resources)
-      - [PetClinic with helm](#petclinic-with-helm)
-      - [3rd Party app (NGINX) with helm](#3rd-party-app-nginx-with-helm)
     - [Flux V2](#flux-v2)
-      - [PetClinic with plain k8s resources](#petclinic-with-plain-k8s-resources-1)
     - [ArgoCD](#argocd)
-      - [PetClinic with plain k8s resources](#petclinic-with-plain-k8s-resources-2)
-      - [PetClinic with helm](#petclinic-with-helm-1)
-      - [3rd Party app (NGINX) with helm](#3rd-party-app-nginx-with-helm-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -105,20 +96,36 @@ If you don't have a demo cluster at hand we provide scripts to create either
 * or almost any k8s cluster.  
   Note that if you want to deploy Jenkins inside the cluster, Docker is required as container runtime.
 
-### Apply apps to cluster
+### Apply playground
 
 You can apply the playground to your cluster using our container image `ghcr.io/cloudogu/gitops-playground`.  
 On success, the container prints a little intro on how to get started with the GitOps playground.
 
 There are several options for running the container: 
 
-* The most convenient way is to run the image inside a pod of the target cluster via `kubectl`. 
-* For some setups, like a local k3d cluster running the image as a local container is als possible. 
-* Another (discouraged) option would be to clone this repo and run the scripts locally. 
+* For local k3d cluster, we recommend running the image as a local container via `docker`  
+* For remote clusters (e.g. on GKE) you can run the image inside a pod of the target cluster via `kubectl`. 
 
-All options offer the same parameters, see [bellow](#parameters).
+All options offer the same parameters, see [bellow](#additional-parameters).
 
-#### Apply via kubectl
+#### Apply via Docker (local cluster)
+
+When connecting to k3d it is easiest to apply the playground via a local container in the host network and pass
+k3d's kubeconfig.
+
+```shell
+CLUSTER_NAME=gitops-playground
+docker run --rm -it -v ~/.k3d/kubeconfig-${CLUSTER_NAME}.yaml:/home/.kube/config \
+  --net=host \
+  ghcr.io/cloudogu/gitops-playground # additional parameters go here
+``` 
+
+Using the host network makes it possible to determine `localhost` and to use k3d's kubeconfig without altering, as it 
+access the API server via a port bound to localhost.
+
+#### Apply via kubectl (remote cluster)
+
+For remote clusters it is easiest to apply the playground via kubectl.
 
 ```shell
 # Create a temporary ServiceAccount and authorize via RBAC. This is needed to install CRDs, etc.
@@ -128,81 +135,42 @@ kubectl create clusterrolebinding gitops-playground-job-executer \
   --serviceaccount=default:gitops-playground-job-executer
 
 # Then start apply the playground with the following command
+# The --remote parameter exposes Jenkins, SCMM and argo on well-known ports for example, 
+# so you don't have to remember the individual ports
 kubectl run gitops-playground -i --tty --restart=OnFailure \
   --overrides='{ "spec": { "serviceAccount": "gitops-playground-job-executer" } }' \
   --image ghcr.io/cloudogu/gitops-playground \
-  -- --yes # additional parameters go here
+  -- --yes --remote # additional parameters go here
 
 # If everything succeeded, remove the objects
 kubectl delete clusterrolebinding/gitops-playground-job-executer \
   sa/gitops-playground-job-executer pods/gitops-playground -n default  
 ```
 
-#### Apply via local container
+In general `docker run` should work here as well. But GKE, for example, uses gcloud and python in their kubeconfig.
+Running inside the cluster avoids these kinds of issues.
 
-You could also apply the playground to kubernetes from a local container.
+#### Additional parameters
 
-When connecting to k3d it's easiest to run the container in the host network:
+The following describes more parameters and use cases.
 
-```shell
-CLUSTER_NAME=gitops-playground
-docker run --rm -it -v ~/.k3d/kubeconfig-${CLUSTER_NAME}.yaml:/home/.kube/config \
-  --net=host \
-  ghcr.io/cloudogu/gitops-playground # additional parameters go here
-``` 
-
-Alternatively, you can run the container in the network of the k3d cluster:
-`--network=k3d-gitops-playground`,  
-but you'll have to replace `0.0.0.0:PORT` in `~/.k3d/kubeconfig-gitops-playground.yaml` by the actual IP address of the 
-k3d API server and port 6443:   
-
-```shell
-CLUSTER_NAME=gitops-playground
-IP_ADDRESS="$(docker inspect -f \
-  '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-${CLUSTER_NAME}-server-0)"
-sed -i -r \
-  "s/0.0.0.0([^0-9]+[0-9]*|$)/${IP_ADDRESS}:6443/g" \
-  ~/.k3d/kubeconfig-gitops-playground.yaml
-```
-
-#### Apply via script
-
-For now, the playground can also be applied to the currently active kube context by executing the script from the repo 
-directly. This option might be removed in the future. 
-
-```shell
-scripts/apply.sh # additional parameters go here
-```
-
-To do so, clone the repo and execute the script on your local linux computer or VM.
-It requires the following binaries:
-* curl,
-* jq,
-* htpasswd,
-* envsubst,
-* kubectl,
-* helm.
-
-#### Parameters
-
-The following describes the most common parameters.
-
-The following command returns a list of all options:
+You can get a full list of all options like so:
 
 ```shell
 docker run --rm ghcr.io/cloudogu/gitops-playground --help
 ```
 
-* Start on [local k3d cluster](docs/k3d.md): No parameters needed
-* Deploying specific GitOps operators only:
-  * `--argocd` - deploy only argoCD GitOps operator
-  * `--fluxv1` - deploy only Flux v1 GitOps operator
-  * `--fluxv2` - deploy only Flux v2 GitOps operator
-* Start on a remote k8s cluster: `--remote`.
-  This exposes Jenkins, SCMM and argo on well-known ports for example, so you don't have to remember the ports.
-* Start with local Cloudogu Ecosystem.  
-  See our [Quickstart Guide](https://cloudogu.com/en/ecosystem/quick-start-guide/?mtm_campaign=gitops-playground&mtm_kwd=ces&mtm_source=github&mtm_medium=link) on how to set up the instance.  
-  Then set the following parameters.
+##### Deploy specific GitOps operators only
+
+* `--argocd` - deploy only argoCD GitOps operator
+* `--fluxv1` - deploy only Flux v1 GitOps operator
+* `--fluxv2` - deploy only Flux v2 GitOps operator
+
+##### Deploy with local Cloudogu Ecosystem
+
+See our [Quickstart Guide](https://cloudogu.com/en/ecosystem/quick-start-guide/?mtm_campaign=gitops-playground&mtm_kwd=ces&mtm_source=github&mtm_medium=link) on how to set up the instance.  
+Then set the following parameters.
+
 ```shell
 # Note: 
 # * In this case --password only sets the argocd admin password (Jenkins and SCMM are external)
@@ -216,8 +184,15 @@ docker run --rm ghcr.io/cloudogu/gitops-playground --help
 --password=yourpassword \
 --insecure
 ```
-* Start with productive Cloudogu Ecosystem and Google Container Registry.  
-  Note that you can get a free CES demo instance set up with a Kubernetes Cluster as GitOps Playground [here](https://cloudogu.com/en/ecosystem/demo-appointment/?mtm_campaign=gitops-playground&mtm_kwd=ces&mtm_source=github&mtm_medium=link).
+
+##### Deploy with productive Cloudogu Ecosystem and GCR
+
+Using Google Container Registry (GCR) fits well with our cluster creation example via Terraform on Google Kubernetes Engine 
+(GKE), see our [docs](docs/gke.md).
+
+Note that you can get a free CES demo instance set up with a Kubernetes Cluster as GitOps Playground 
+[here](https://cloudogu.com/en/ecosystem/demo-appointment/?mtm_campaign=gitops-playground&mtm_kwd=ces&mtm_source=github&mtm_medium=link).
+
 ```shell
 # Note:
 # In this case --password only sets the argocd admin password (Jenkins and SCMM are external) 
@@ -234,9 +209,10 @@ docker run --rm ghcr.io/cloudogu/gitops-playground --help
 --registry-password="$( cat account.json | sed 's/"/\\"/g' )" 
 ```
 
-#### Override default images used in the gitops-build-lib
+##### Override default images used in the gitops-build-lib
 
 Images used by the gitops-build-lib are set in the `gitopsConfig` in each `Jenkinsfile` of an application like that:
+
 ```
 def gitopsConfig = [
     ...
@@ -248,14 +224,16 @@ def gitopsConfig = [
             yamllint: 'cytopia/yamllint:1.25-0.7'
     ],...
 ```
+
 To override each image in all the applications you can use following parameters:
+
 * `--kubectl-image someRegistry/someImage:1.0.0`
 * `--helm-image someRegistry/someImage:1.0.0`
 * `--kubeval-image someRegistry/someImage:1.0.0`
 * `--helmkubeval-image someRegistry/someImage:1.0.0`
 * `--yamllint-image someRegistry/someImage:1.0.0`
 
-### Remove apps from cluster
+### Remove playground
 
 For k3d, you can just `k3d cluster delete gitops-playground`.
 
@@ -291,14 +269,16 @@ There is also a convenience script `scripts/get-remote-url`. The script waits, i
 You could use this conveniently like so:
 ```shell
 bash <(curl -s \
-  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/get-remote-url) jenkins default
+  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/get-remote-url) \
+  jenkins default
 ```
 
 You can open the application in the browser right away, like so for example:
 
 ```shell
 xdg-open $(bash <(curl -s \
-  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/get-remote-url) jenkins default)
+  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/get-remote-url) \
+   jenkins default)
 ```
 ### Credentials
 
@@ -324,7 +304,7 @@ Note that this only works when using `localhost` or `https://`.
 ###### External Jenkins
 
 You can set an external jenkins server via the following parameters when applying the playground.
-See [Parameters](#parameters) for examples.
+See [Parameters](#additional-parameters) for examples.
 
 * `--jenkins-url`, 
 * `--jenkins-username`, 
@@ -349,7 +329,7 @@ SCM-Manager is available at
 ###### External SCM-Manager
 
 You can set an external SCM-Manager via the following parameters when applying the playground. 
-See [Parameters](#parameters) for examples.
+See [Parameters](#additional-parameters) for examples.
 
 * `--scmm-url`,
 * `--scmm-username`,

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ Jenkins is available at
 * http://localhost:9090 (k3d)
 * `scripts/get-remote-url jenkins default` (remote k8s) 
 
-Note: You can enable browser notifications about build results via a button in the lower right corner of Jenkins Web UI.
+You can enable browser notifications about build results via a button in the lower right corner of Jenkins Web UI.
+
+Note that this only works when using `localhost` or `https://`. 
 
 ![Enable Jenkins Notifications](docs/jenkins-enable-notifications.png)
 

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -3,7 +3,6 @@ server:
   ## Server service configuration
   service:
     type: LoadBalancer
-    # Actual "nodePort" number cannot be set via the helm chart. 
-    # So we use LB for k3d and set well-know port numbers for remote cluster via apply.sh.
-    servicePortHttp: 9092
-    servicePortHttps: 9093
+    # Is ignored when type is LoadBalancer. For local cluster we change the service type to NodePort
+    nodePortHttp: 9092
+    nodePortHttps: 9093

--- a/docs/k3d.md
+++ b/docs/k3d.md
@@ -9,13 +9,25 @@ The k3d cluster is started like so:
 ```shell
 bash <(curl -s https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh)
 ```
+
 ## Parameters
 
 * `--cluster-name` - default: `gitops-playground`
 * `--bind-localhost=false` - does not bind to localhost. That is, the URLs of the application will not be reachable via
-  localhost but via the IP address of the k3d docker container. Avoids port conflicts but is less convenient.
-  Note that right now, builds inside the playground using `docker push` are failing, when started with this parameter. 
-  See [#53](https://github.com/cloudogu/gitops-playground/issues/53).  
+  localhost but via the IP address of the k3d docker container. Avoids port conflicts but is less convenient. 
+  Only exception is the registry port, it must be bound to localhost, otherwise docker will use HTTPS, leading to errors
+  on `docker push` in the example application's Jenkins Jobs.   
+  Note that if you use this option and the registry's default port 30000 is already bound on localhost (e.g. when  
+  starting more than one instance of the playground) the registry port will be bound to an arbitrary free port on 
+  localhost.In this case, the port will be printed by the `init-cluster.sh` script but can also be queried via 
+  `docker inspect`(see bellow).  
+  This port has to be passed on when creating the playground via the `--internal-registry-port` parameter. For example: 
+
+```shell
+--internal-registry-port=$(docker inspect \
+  --format='{{ with (index .NetworkSettings.Ports "30000/tcp") }}{{ (index . 0).HostPort }}{{ end }}' \
+  k3d-${CLUSTER_NAME}-server-0)
+```
 
 ## Implementation details
 

--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -13,7 +13,6 @@ controller:
   # It seems that jenkins-plugin-cli 2.9.0 does not install plugin dependencies properly.
   # So we add them explicitly here, to avoid exception such as 
   #  Failed to load: Matrix Project Plugin (1.18)
-  #                   - Update required: JUnit Plugin (1.3) to be updated to 1.29 or higher
   # Background: When debugging, the following command
   #  jenkins-plugin-cli --war "/usr/share/jenkins/jenkins.war" --plugins matrix-project:1.18 --verbose
   # returns: matrix-project has no dependencies
@@ -23,10 +22,10 @@ controller:
   # Workaround: Install the plugins that cause these problems explicitly
   additionalPlugins:
     - matrix-project:1.19
-    - workflow-cps:2.92
-    - pipeline-model-api:1.8.5
+    - workflow-cps:2.93
+    - pipeline-model-api:1.9.1
     - workflow-job:2.41
-    - credentials-binding:1.26
+    - credentials-binding:1.27
 
   # Don't use controller for builds
   numExecutors: 0
@@ -99,7 +98,6 @@ persistence:
 
 agent:
   # We need JDK11 for our PetClinic example
-  #tag: "4.3-4-jdk11"
   tag: "4.6-1-jdk11"
   # In our local playground infrastructure builds are run in agent containers (pods). During the builds, more
   # containers are started via the Jenkins Docker Plugin (on the same docker host).

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -23,11 +23,13 @@ INTERNAL_REGISTRY=true
 JENKINS_URL_FOR_SCMM="http://jenkins"
 SCMM_URL_FOR_JENKINS="http://scmm-scm-manager.default.svc.cluster.local/scm"
 
-HELM_DEFAULT_IMAGE='ghcr.io/cloudogu/helm:3.5.4-1'
-KUBECTL_DEFAULT_IMAGE='lachlanevenson/k8s-kubectl:v1.19.3'
-KUBEVAL_DEFAULT_IMAGE='ghcr.io/cloudogu/helm:3.5.4-1'
-HELMKUBEVAL_DEFAULT_IMAGE='ghcr.io/cloudogu/helm:3.5.4-1'
+# When updating please also adapt k8s-related versions in Dockerfile, init-cluster.sh and vars.tf
+KUBECTL_DEFAULT_IMAGE='lachlanevenson/k8s-kubectl:v1.21.2'
 YAMLLINT_DEFAULT_IMAGE='cytopia/yamllint:1.25-0.7'
+HELM_DEFAULT_IMAGE='ghcr.io/cloudogu/helm:3.5.4-1'
+# cloudogu/helm also contains kubeval and helm kubeval plugin. Using the same image makes builds faster
+KUBEVAL_DEFAULT_IMAGE=${HELM_DEFAULT_IMAGE}
+HELMKUBEVAL_DEFAULT_IMAGE=${HELM_DEFAULT_IMAGE}
 
 SPRING_BOOT_HELM_CHART_REPO=${SPRING_BOOT_HELM_CHART_REPO:-'https://github.com/cloudogu/spring-boot-helm-chart.git'}
 SPRING_PETCLINIC_REPO=${SPRING_PETCLINIC_REPO:-'https://github.com/cloudogu/spring-petclinic.git'}

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -3,7 +3,7 @@
 # See https://github.com/rancher/k3d/releases
 # This variable is also read in Jenkinsfile
 K3D_VERSION=4.4.7
-# When updating please also adapt k8s-related versions in Dockerfile and vars.tf
+# When updating please also adapt k8s-related versions in Dockerfile, vars.tf and apply.sh
 K8S_VERSION=1.21.2
 K3S_VERSION="rancher/k3s:v${K8S_VERSION}-k3s1"
 

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -66,7 +66,7 @@ function createCluster() {
     # Internal Docker registry must be on localhost. Otherwise docker will use HTTPS, leading to errors on docker push 
     # in the example application's Jenkins Jobs.
     # If available, use default port for playground registry, because no parameter is required when applying
-    if ! netstat -an | grep 30000 | grep LISTEN >/dev/null 2>&1; then
+    if command -v netstat >/dev/null 2>&1 && ! netstat -an | grep 30000 | grep LISTEN >/dev/null 2>&1; then
       K3D_ARGS+=(
        '-p 30000:30000@server[0]'
       )

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -11,7 +11,7 @@ fi
 # Check for "Failed to load" in the Jenkins log and add or upgrade the plugins mentioned there appropriately.
 # In addition, check if the new helm chart version uses a newer agent.tag.
 # Note that we need JDK11 on the agents, whereas the helm chart uses JDK8 by default.
-JENKINS_HELM_CHART_VERSION=3.3.23
+JENKINS_HELM_CHART_VERSION=3.5.9
 
 SET_USERNAME="admin"
 SET_PASSWORD="admin"
@@ -93,11 +93,11 @@ function configureJenkins() {
 
   waitForJenkins
 
-  installPlugin "docker-workflow" "1.25"
-  installPlugin "docker-plugin" "1.2.1"
-  installPlugin "pipeline-utility-steps" "2.6.1"
-  installPlugin "junit" "1.48"
-  installPlugin "scm-manager" "1.7.3"
+  installPlugin "docker-workflow" "1.26"
+  installPlugin "docker-plugin" "1.2.2"
+  installPlugin "pipeline-utility-steps" "2.8.0"
+  installPlugin "junit" "1.51"
+  installPlugin "scm-manager" "1.7.5"
   installPlugin "html5-notifier-plugin" "1.5"
 
   safeRestart

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -40,10 +40,7 @@ function deployLocalJenkins() {
 
 function jenkinsHelmSettingsForLocalCluster() {
   if [[ $REMOTE_CLUSTER != true ]]; then
-    # Run Jenkins and Agent pods as the current user.
-    # Avoids file permission problems when accessing files on the host that were written from the pods
-
-    # We also need a host port, so jenkins can be reached via localhost:9090
+    # We need a host port, so jenkins can be reached via localhost:9090
     # But: This helm charts only uses the nodePort value, if the type is "NodePort". So change it for local cluster.
     echo "--set controller.serviceType=NodePort"
   fi

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -34,6 +34,6 @@ variable "k8s_version_prefix" {
   # So we use a version prefix hoping that the stable patch versions won't do unexpected things (which is unlikely!) 
   description = "Master and Node version prefix to setup"
   
-  # When updating please also adapt k8s-related versions in Dockerfile and init-cluster.sh
+  # When updating please also adapt k8s-related versions in Dockerfile, init-cluster.sh and apply.sh
   default = "1.21."
 }


### PR DESCRIPTION
Fixes #53 and #56.

While on it I also fixed this and that:
* Upgraded Jenkins Helm Chart (hoping to fix #55 which it didn't. Still latest version has less vulns)
* apply.sh: Print localhost instead of external IP.
* Make argo accessible via localhost:9092 (implied upgrade of argocd chart)
* README: Fix TLDR command.
* README: Reduce amount of options for sake of simplicity.