### PR TITLE
Feature/deterministic jenkins plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ WORKDIR /app
 
 ENTRYPOINT ["scripts/apply.sh"]
 
+# Unzip is needed for downloading docker plugins (install-plugins.sh)
 RUN apk update && apk upgrade && \
     apk add --no-cache \
      bash \
@@ -77,7 +78,8 @@ RUN apk update && apk upgrade && \
      apache2-utils \
      gettext \
      jq \
-     git
+     git \
+    unzip
 
 USER 1000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ ARG KUBECTL_CHECKSUM=55b982527d76934c2f119e70bf0d69831d3af4985f72bb87cd4924b1c7d
 # When updating, also update the checksum found at https://github.com/helm/helm/releases
 ARG HELM_VERSION=3.6.2
 ARG HELM_CHECKSUM=f3a4be96b8a3b61b14eec1a35072e1d6e695352e7a08751775abf77861a0bf54
+# bash curl unzip required for Jenkins downloader
 RUN apk add --no-cache \
       gnupg \
       outils-sha256 \
-      git
+      git \
+      bash curl unzip 
 
 RUN mkdir -p /dist/usr/local/bin
 ENV HOME=/dist/home
@@ -50,6 +52,9 @@ RUN git clone --bare https://github.com/cloudogu/ces-build-lib.git
 RUN git config --global user.email "hello@cloudogu.com" && \
     git config --global user.name "Cloudogu"
 
+# Download Jenkins Plugin
+COPY scripts/jenkins /jenkins
+RUN  /jenkins/plugins/download-plugins.sh /dist/gop/jenkins-plugins
 
 FROM alpine
 
@@ -64,7 +69,8 @@ ENV HOME=/home \
     SPRING_BOOT_HELM_CHART_REPO=/gop/repos/spring-boot-helm-chart.git \
     SPRING_PETCLINIC_REPO=/gop/repos/spring-petclinic.git \
     GITOPS_BUILD_LIB_REPO=/gop/repos/gitops-build-lib.git \
-    CES_BUILD_LIB_REPO=/gop/repos/ces-build-lib.git
+    CES_BUILD_LIB_REPO=/gop/repos/ces-build-lib.git \
+    JENKINS_PLUGIN_FOLDER=/gop/jenkins-plugins/
 
 WORKDIR /app
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import com.cloudogu.ces.cesbuildlib.*
 String getDockerRegistryBaseUrl() { 'ghcr.io' }
 String getDockerImageName() { 'cloudogu/gitops-playground' }
 String getTrivyVersion() { '0.18.3' }
-String getGroovyImage() { 'groovy:jdk11' }
+String getGroovyImage() { 'groovy:3.0.8-jre11' }
 
 properties([
     // Dont keep builds forever to preserve space
@@ -115,7 +115,7 @@ node('docker') {
         stage('Stop k3d') {
             if (clusterName) {
                 // Don't fail build if cleaning up fails
-                withEnv(["PATH=${WORKSPACE}/.kd3/bin:${PATH}"]) {
+                withEnv(["PATH=${WORKSPACE}/.k3d/bin:${PATH}"]) {
                     sh "k3d cluster delete ${clusterName} || true"
                 }
             }
@@ -151,14 +151,14 @@ def saveScanResultsOnVulenrabilities() {
 }
 
 def startK3d(clusterName) {
-    sh "mkdir -p ${WORKSPACE}/.kd3/bin"
+    sh "mkdir -p ${WORKSPACE}/.k3d/bin"
     
-    withEnv(["HOME=${WORKSPACE}", "PATH=${WORKSPACE}/.kd3/bin:${PATH}"]) { // Make k3d write kubeconfig to WORKSPACE
+    withEnv(["HOME=${WORKSPACE}", "PATH=${WORKSPACE}/.k3d/bin:${PATH}"]) { // Make k3d write kubeconfig to WORKSPACE
         // Install k3d binary to workspace in order to avoid concurrency issues
         sh "if ! command -v k3d >/dev/null 2>&1; then " +
                 "curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh |" +
                   'TAG=v$(sed -n "s/^K3D_VERSION=//p" scripts/init-cluster.sh) ' +
-                  "K3D_INSTALL_DIR=${WORKSPACE}/.kd3/bin " +
+                  "K3D_INSTALL_DIR=${WORKSPACE}/.k3d/bin " +
                      'bash -s -- --no-sudo; fi'
         sh "yes | ./scripts/init-cluster.sh --cluster-name=${clusterName} --bind-localhost=false"
     }

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -37,6 +37,8 @@ SPRING_PETCLINIC_REPO=${SPRING_PETCLINIC_REPO:-'https://github.com/cloudogu/spri
 GITOPS_BUILD_LIB_REPO=${GITOPS_BUILD_LIB_REPO:-'https://github.com/cloudogu/gitops-build-lib.git'}
 CES_BUILD_LIB_REPO=${CES_BUILD_LIB_REPO:-'https://github.com/cloudogu/ces-build-lib.git'}
 
+JENKINS_PLUGIN_FOLDER=${JENKINS_PLUGIN_FOLDER:-''}
+
 function main() {
   
   readParameters "$@"

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -164,7 +164,7 @@ function waitForNode() {
   # With TLDR command from readme "kubectl get node" might be executed right after cluster start, where no nodes are 
   # returned, resulting in 'error: the server doesn't have a resource type ""'
   local nodes=""
-  while [ -z ${nodes} ]; do
+  while [ -z "${nodes}" ]; do
     nodes=$(kubectl get node -oname)
     [ -z "${nodes}" ] && sleep 1
   done

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -78,7 +78,6 @@ class JenkinsHandler {
 
     JenkinsServer get() { return this.js }
 
-    // TODO: We should check if it's really a folder job. Currently we just assume it which is stupid - but _works_
     // Due to missing support of multibranch-pipelines in the java-jenkins-client we need to build up the jobs ourselves.
     // Querying the root folder and starting builds leads to a namespace scan.
     // After that we need to iterate through every job folder
@@ -90,8 +89,14 @@ class JenkinsHandler {
             // since there is no support for namespace scan; we call built on root folder and wait to discover branches.
             job.value.build(true)
             Thread.sleep(3000)
-
-            js.getFolderJob(job.value).get().getJobs().each { Map.Entry<String, Job> j ->
+            
+            def folderJob = js.getFolderJob(job.value)
+            if (!folderJob.isPresent()) {
+                println "Job ${job.value.name} seems not to be a folder job. Skipping."
+                return
+            }
+            
+            folderJob.get().getJobs().each { Map.Entry<String, Job> j ->
                 js.getFolderJob(j.value).get().getJobs().each { Map.Entry<String, Job> i ->
                     jobs.add(i.value.details())
                 }

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -58,8 +58,8 @@ class E2E {
             System.exit status
 
         } catch (Exception err) {
-            System.err << "Oh seems like something went wrong:\n"
-            System.err << "${err.getStackTrace()}"
+            System.err << "Unexpected error during execution of gitops playground e2e:\n"
+            err.printStackTrace(System.err);
             System.exit 1
         }
     }

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -73,13 +73,15 @@ function waitForJenkins() {
 }
 
 function configureJenkins() {
+  local SCMM_URL pluginFolder
+  
   JENKINS_URL="${1}"
   export JENKINS_URL
   JENKINS_USERNAME="${2}"
   export JENKINS_USERNAME
   JENKINS_PASSWORD="${3}"
   export JENKINS_PASSWORD
-  local SCMM_URL="${4}"
+  SCMM_URL="${4}"
   SCMM_PASSWORD="${5}"
   REGISTRY_URL="${6}"
   REGISTRY_PATH="${7}"
@@ -89,16 +91,18 @@ function configureJenkins() {
   INSTALL_FLUXV1="${11}"
   INSTALL_FLUXV2="${12}"
   INSTALL_ARGOCD="${13}"
-
+  
+  
   waitForJenkins
 
-  installPlugin "docker-workflow" "1.26"
-  installPlugin "docker-plugin" "1.2.2"
-  installPlugin "pipeline-utility-steps" "2.8.0"
-  installPlugin "junit" "1.51"
-  installPlugin "scm-manager" "1.7.5"
-  installPlugin "html5-notifier-plugin" "1.5"
+  pluginFolder=$(mktemp -d)
+  "${PLAYGROUND_DIR}"/scripts/jenkins/plugins/download-plugins.sh "${pluginFolder}" 
 
+  # Install all downloaded plugin files via HTTP
+  for pluginFile in "${pluginFolder}/plugins"/*; do 
+     installPlugin "${pluginFile}"
+  done
+ 
   safeRestart
   waitForJenkins
 

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -95,10 +95,16 @@ function configureJenkins() {
   
   waitForJenkins
 
-  pluginFolder=$(mktemp -d)
-  "${PLAYGROUND_DIR}"/scripts/jenkins/plugins/download-plugins.sh "${pluginFolder}" 
+  if [[ -z "${JENKINS_PLUGIN_FOLDER}" ]]; then
+    pluginFolder=$(mktemp -d)
+    echo "Downloading jenkins plugins to ${pluginFolder}"
+    "${PLAYGROUND_DIR}"/scripts/jenkins/plugins/download-plugins.sh "${pluginFolder}"
+  else
+    echo "Jenkins plugins folder present, skipping plugin download"
+    pluginFolder="${JENKINS_PLUGIN_FOLDER}"
+  fi 
 
-  # Install all downloaded plugin files via HTTP
+  echo "Installing Jenkins Plugins from ${pluginFolder}"
   for pluginFile in "${pluginFolder}/plugins"/*; do 
      installPlugin "${pluginFile}"
   done

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -108,7 +108,16 @@ function configureJenkins() {
   for pluginFile in "${pluginFolder}/plugins"/*; do 
      installPlugin "${pluginFile}"
   done
- 
+
+  echo "Waiting for plugin installation.."
+  PLUGIN_STATUS=($(checkPluginStatus $(cat "${PLAYGROUND_DIR}"/scripts/jenkins/plugins/plugins.txt | tr '\n' ',')))
+  while [[ ${#PLUGIN_STATUS[@]} -gt 0 ]]; do
+    PLUGIN_STATUS=($(checkPluginStatus $(cat "${PLAYGROUND_DIR}"/scripts/jenkins/plugins/plugins.txt | tr '\n' ',')))
+    echo "Processing: ${PLUGIN_STATUS[*]}"
+    sleep 5
+  done
+  echo ""
+
   safeRestart
   waitForJenkins
 

--- a/scripts/jenkins/jenkins-REST-client.sh
+++ b/scripts/jenkins/jenkins-REST-client.sh
@@ -107,6 +107,20 @@ function safeRestart() {
   fi
 }
 
+function checkPluginStatus() {
+  # shellcheck disable=SC2016
+  # we don't want to expand these variables in single quotes
+  GROOVY_SCRIPT=$(env -i PLUGIN_LIST="${1}" \
+                 envsubst '${PLUGIN_LIST}' \
+                 < scripts/jenkins/pluginCheck.groovy)
+
+  STATUS=$(curlJenkins --fail -L /dev/null \
+           -d "script=${GROOVY_SCRIPT}" --user "${JENKINS_USERNAME}:${JENKINS_PASSWORD}" \
+           "${JENKINS_URL}/scriptText")
+
+  echo -e "${STATUS#*: }" | sed 's/^.//;s/.$//'
+}
+
 function setGlobalProperty() {
   printf 'Setting Global Property %s:%s ...' "${1}" "${2}"
 

--- a/scripts/jenkins/pluginCheck.groovy
+++ b/scripts/jenkins/pluginCheck.groovy
@@ -1,0 +1,25 @@
+List plugins = []
+List available = []
+List expected = []
+
+String input = "${PLUGIN_LIST}"
+input.split(",").each { it -> expected.add(it.substring(0, it.indexOf(":"))) }
+
+Jenkins.instance.pluginManager.failedPlugins.each {
+    available.add(it.name)
+}
+
+Jenkins.instance.pluginManager.plugins.each {
+    available.add(it.shortName)
+}
+
+available.each { p ->
+    if (expected.find { (it == p) })
+        plugins.add(p)
+}
+
+def commons = plugins.intersect(expected)
+def difference = plugins.plus(expected)
+difference.removeAll(commons)
+
+return difference

--- a/scripts/jenkins/plugins/download-plugins.sh
+++ b/scripts/jenkins/plugins/download-plugins.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+# Downloads plugins declared in plugins.txt via official jenkins/docker's install-plugins.sh
+# This makes sure to get deterministic version of plugins and all dependencies
+  
+# The plugins are downloaded to $PLUGIN_FOLDER/plugins
+PLUGIN_FOLDER="$1"
+
+ABSOLUTE_BASEDIR="$(cd "$(dirname $0)" && pwd)"
+
+# shellcheck disable=SC2046 # We actually do want word splitting here so each plugin is passed as one argument
+JENKINS_UC=https://updates.jenkins.io REF="${PLUGIN_FOLDER}" \
+  "${ABSOLUTE_BASEDIR}/install-plugins.sh" $(cat ${ABSOLUTE_BASEDIR}/plugins.txt)

--- a/scripts/jenkins/plugins/install-plugins.sh
+++ b/scripts/jenkins/plugins/install-plugins.sh
@@ -1,0 +1,292 @@
+#!/bin/bash -eu
+
+# Resolve dependencies and download plugins given on the command line
+#
+# FROM jenkins
+# RUN install-plugins.sh docker-slaves github-branch-source
+#
+# Environment variables:
+# REF: directory with preinstalled plugins. Default: /usr/share/jenkins/ref/plugins
+# JENKINS_WAR: full path to the jenkins.war. Default: /usr/share/jenkins/jenkins.war
+# JENKINS_UC: url of the Update Center. Default: ""
+# JENKINS_UC_EXPERIMENTAL: url of the Experimental Update Center for experimental versions of plugins. Default: ""
+# JENKINS_INCREMENTALS_REPO_MIRROR: url of the incrementals repo mirror. Default: ""
+# JENKINS_UC_DOWNLOAD: download url of the Update Center. Default: JENKINS_UC/download
+# CURL_OPTIONS When downloading the plugins with curl. Curl options. Default: -sSfL
+# CURL_CONNECTION_TIMEOUT When downloading the plugins with curl. <seconds> Maximum time allowed for connection. Default: 20
+# CURL_RETRY When downloading the plugins with curl. Retry request if transient problems occur. Default: 3
+# CURL_RETRY_DELAY When downloading the plugins with curl. <seconds> Wait time between retries. Default: 0
+# CURL_RETRY_MAX_TIME When downloading the plugins with curl. <seconds> Retry only within this period. Default: 60
+
+set -o pipefail
+
+echo "WARN: install-plugins.sh is deprecated, please switch to jenkins-plugin-cli"
+
+JENKINS_WAR=${JENKINS_WAR:-/usr/share/jenkins/jenkins.war}
+
+. /usr/local/bin/jenkins-support
+
+REF_DIR="${REF}/plugins"
+FAILED="$REF_DIR/failed-plugins.txt"
+
+getLockFile() {
+    printf '%s' "$REF_DIR/${1}.lock"
+}
+
+getArchiveFilename() {
+    printf '%s' "$REF_DIR/${1}.jpi"
+}
+
+download() {
+    local plugin originalPlugin version lock ignoreLockFile url
+    plugin="$1"
+    version="${2:-latest}"
+    ignoreLockFile="${3:-}"
+    url="${4:-}"
+    lock="$(getLockFile "$plugin")"
+
+    if [[ $ignoreLockFile ]] || mkdir "$lock" &>/dev/null; then
+        if ! doDownload "$plugin" "$version" "$url"; then
+            # some plugin don't follow the rules about artifact ID
+            # typically: docker-plugin
+            originalPlugin="$plugin"
+            plugin="${plugin}-plugin"
+            if ! doDownload "$plugin" "$version" "$url"; then
+                echo "Failed to download plugin: $originalPlugin or $plugin" >&2
+                echo "Not downloaded: ${originalPlugin}" >> "$FAILED"
+                return 1
+            fi
+        fi
+
+        if ! checkIntegrity "$plugin"; then
+            echo "Downloaded file is not a valid ZIP: $(getArchiveFilename "$plugin")" >&2
+            echo "Download integrity: ${plugin}" >> "$FAILED"
+            return 1
+        fi
+
+        resolveDependencies "$plugin"
+    fi
+}
+
+doDownload() {
+    local plugin version url jpi
+    plugin="$1"
+    version="$2"
+    url="$3"
+    jpi="$(getArchiveFilename "$plugin")"
+
+    # If plugin already exists and is the same version do not download
+    if test -f "$jpi" && unzip -p "$jpi" META-INF/MANIFEST.MF | tr -d '\r' | grep "^Plugin-Version: ${version}$" > /dev/null; then
+        echo "Using provided plugin: $plugin"
+        return 0
+    fi
+
+    if [[ -n $url ]] ; then
+        echo "Will use url=$url"
+    elif [[ "$version" == "latest" && -n "$JENKINS_UC_LATEST" ]]; then
+        # If version-specific Update Center is available, which is the case for LTS versions,
+        # use it to resolve latest versions.
+        url="$JENKINS_UC_LATEST/latest/${plugin}.hpi"
+    elif [[ "$version" == "experimental" && -n "$JENKINS_UC_EXPERIMENTAL" ]]; then
+        # Download from the experimental update center
+        url="$JENKINS_UC_EXPERIMENTAL/latest/${plugin}.hpi"
+    elif [[ "$version" == incrementals* ]] ; then
+        # Download from Incrementals repo: https://jenkins.io/blog/2018/05/15/incremental-deployment/
+        # Example URL: https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-support/2.19-rc289.d09828a05a74/workflow-support-2.19-rc289.d09828a05a74.hpi
+        local groupId incrementalsVersion
+        # add a trailing ; so the \n gets added to the end
+        readarray -t "-d;" arrIN <<<"${version};";
+        unset 'arrIN[-1]';
+        groupId=${arrIN[1]}
+        incrementalsVersion=${arrIN[2]}
+        url="${JENKINS_INCREMENTALS_REPO_MIRROR}/$(echo "${groupId}" | tr '.' '/')/${plugin}/${incrementalsVersion}/${plugin}-${incrementalsVersion}.hpi"
+    else
+        JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
+        url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"
+    fi
+
+    echo "Downloading plugin: $plugin from $url"
+    # We actually want to allow variable value to be split into multiple options passed to curl.
+    # This is needed to allow long options and any options that take value.
+    # shellcheck disable=SC2086
+    retry_command curl ${CURL_OPTIONS:--sSfL} --connect-timeout "${CURL_CONNECTION_TIMEOUT:-20}" --retry "${CURL_RETRY:-3}" --retry-delay "${CURL_RETRY_DELAY:-0}" --retry-max-time "${CURL_RETRY_MAX_TIME:-60}" "$url" -o "$jpi"
+    return $?
+}
+
+checkIntegrity() {
+    local plugin jpi
+    plugin="$1"
+    jpi="$(getArchiveFilename "$plugin")"
+
+    unzip -t -qq "$jpi" >/dev/null
+    return $?
+}
+
+resolveDependencies() {
+    local plugin jpi dependencies
+    plugin="$1"
+    jpi="$(getArchiveFilename "$plugin")"
+
+    dependencies="$(unzip -p "$jpi" META-INF/MANIFEST.MF | tr -d '\r' | tr '\n' '|' | sed -e 's#| ##g' | tr '|' '\n' | grep "^Plugin-Dependencies: " | sed -e 's#^Plugin-Dependencies: ##')"
+
+    if [[ ! $dependencies ]]; then
+        echo " > $plugin has no dependencies"
+        return
+    fi
+
+    echo " > $plugin depends on $dependencies"
+
+    IFS=',' read -r -a array <<< "$dependencies"
+
+    for d in "${array[@]}"
+    do
+        plugin="$(cut -d':' -f1 - <<< "$d")"
+        if [[ $d == *"resolution:=optional"* ]]; then
+            echo "Skipping optional dependency $plugin"
+        else
+            local pluginInstalled
+            if pluginInstalled="$(echo -e "${bundledPlugins}\n${installedPlugins}" | grep "^${plugin}:")"; then
+                pluginInstalled="${pluginInstalled//[$'\r']}"
+                local versionInstalled; versionInstalled=$(versionFromPlugin "${pluginInstalled}")
+                local minVersion; minVersion=$(versionFromPlugin "${d}")
+                if versionLT "${versionInstalled}" "${minVersion}"; then
+                    echo "Upgrading bundled dependency $d ($minVersion > $versionInstalled)"
+                    download "$plugin" &
+                else
+                    echo "Skipping already installed dependency $d ($minVersion <= $versionInstalled)"
+                fi
+            else
+                download "$plugin" &
+            fi
+        fi
+    done
+    wait
+}
+
+bundledPlugins() {
+    if [ -f "$JENKINS_WAR" ]
+    then
+        TEMP_PLUGIN_DIR=/tmp/plugintemp.$$
+        for i in $(jar tf "$JENKINS_WAR" | grep -E '[^detached-]plugins.*\..pi' | sort)
+        do
+            rm -fr $TEMP_PLUGIN_DIR
+            mkdir -p $TEMP_PLUGIN_DIR
+            PLUGIN=$(basename "$i"|cut -f1 -d'.')
+            (cd $TEMP_PLUGIN_DIR;jar xf "$JENKINS_WAR" "$i";jar xvf "$TEMP_PLUGIN_DIR/$i" META-INF/MANIFEST.MF >/dev/null 2>&1)
+            VER=$(grep -E -i Plugin-Version "$TEMP_PLUGIN_DIR/META-INF/MANIFEST.MF"|cut -d: -f2|sed 's/ //')
+            echo "$PLUGIN:$VER"
+        done
+        rm -fr $TEMP_PLUGIN_DIR
+    else
+        echo "war not found, installing all plugins: $JENKINS_WAR"
+    fi
+}
+
+versionFromPlugin() {
+    local plugin=$1
+    if [[ $plugin =~ .*:.* ]]; then
+        echo "${plugin##*:}"
+    else
+        echo "latest"
+    fi
+
+}
+
+installedPlugins() {
+    for f in "$REF_DIR"/*.jpi; do
+        echo "$(basename "$f" | sed -e 's/\.jpi//'):$(get_plugin_version "$f")"
+    done
+}
+
+jenkinsMajorMinorVersion() {
+    if [[ -f "$JENKINS_WAR" ]]; then
+        local version major minor
+        version="$(java -jar "$JENKINS_WAR" --version)"
+        major="$(echo "$version" | cut -d '.' -f 1)"
+        minor="$(echo "$version" | cut -d '.' -f 2)"
+        echo "$major.$minor"
+    else
+        echo ""
+    fi
+}
+
+main() {
+    local plugin jenkinsVersion
+    local plugins=()
+
+    mkdir -p "$REF_DIR" || exit 1
+    rm -f "$FAILED"
+
+    # Read plugins from stdin or from the command line arguments
+    if [[ ($# -eq 0) ]]; then
+        while read -r line || [ "$line" != "" ]; do
+            # Remove leading/trailing spaces, comments, and empty lines
+            plugin=$(echo "${line}" | tr -d '\r' | sed -e 's/^[ \t]*//g' -e 's/[ \t]*$//g' -e 's/[ \t]*#.*$//g' -e '/^[ \t]*$/d')
+
+            # Avoid adding empty plugin into array
+            if [ ${#plugin} -ne 0 ]; then
+                plugins+=("${plugin}")
+            fi
+        done
+    else
+        plugins=("$@")
+    fi
+
+    # Create lockfile manually before first run to make sure any explicit version set is used.
+    echo "Creating initial locks..."
+    for plugin in "${plugins[@]}"; do
+        mkdir "$(getLockFile "${plugin%%:*}")"
+    done
+
+    echo "Analyzing war $JENKINS_WAR..."
+    bundledPlugins="$(bundledPlugins)"
+
+    echo "Registering preinstalled plugins..."
+    installedPlugins="$(installedPlugins)"
+
+    # Get the update center URL based on the jenkins version
+    jenkinsVersion="$(jenkinsMajorMinorVersion)"
+    # shellcheck disable=SC2086
+    jenkinsUcJson=$(curl ${CURL_OPTIONS:--sSfL} -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
+    if [ -n "${jenkinsUcJson}" ]; then
+        JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json/}
+        echo "Using version-specific update center: $JENKINS_UC_LATEST..."
+    else
+        JENKINS_UC_LATEST=
+    fi
+
+    echo "Downloading plugins..."
+    for plugin in "${plugins[@]}"; do
+        local reg='^([^:]+):?([^:]+)?:?([^:]+)?:?(http.+)?'
+        if [[ $plugin =~ $reg ]]; then
+            local pluginId="${BASH_REMATCH[1]}"
+            local version="${BASH_REMATCH[2]}"
+            local lock="${BASH_REMATCH[3]}"
+            local url="${BASH_REMATCH[4]}"
+            download "$pluginId" "$version" "${lock:-true}" "${url}" &
+        else
+          echo "Skipping the line '${plugin}' as it does not look like a reference to a plugin"
+        fi
+    done
+    wait
+
+    echo
+    echo "WAR bundled plugins:"
+    echo "${bundledPlugins}"
+    echo
+    echo "Installed plugins:"
+    installedPlugins
+
+    if [[ -f $FAILED ]]; then
+        echo "Some plugins failed to download!" "$(<"$FAILED")" >&2
+        exit 1
+    fi
+
+    echo "Cleaning up locks"
+    find "$REF_DIR" -regex ".*.lock" | while read -r filepath; do
+        rm -r "$filepath"
+    done
+
+}
+
+main "$@"

--- a/scripts/jenkins/plugins/install-plugins.sh
+++ b/scripts/jenkins/plugins/install-plugins.sh
@@ -20,11 +20,13 @@
 
 set -o pipefail
 
+ABSOLUTE_BASEDIR="$(cd "$(dirname $0)" && pwd)"
+
 echo "WARN: install-plugins.sh is deprecated, please switch to jenkins-plugin-cli"
 
 JENKINS_WAR=${JENKINS_WAR:-/usr/share/jenkins/jenkins.war}
 
-. /usr/local/bin/jenkins-support
+. ${ABSOLUTE_BASEDIR}/jenkins-support
 
 REF_DIR="${REF}/plugins"
 FAILED="$REF_DIR/failed-plugins.txt"

--- a/scripts/jenkins/plugins/jenkins-support
+++ b/scripts/jenkins/plugins/jenkins-support
@@ -1,0 +1,183 @@
+#!/bin/bash -eu
+
+: "${REF:="/usr/share/jenkins/ref"}"
+
+# compare if version1 < version2
+versionLT() {
+    local v1; v1=$(echo "$1" | cut -d '-' -f 1 )
+    local q1; q1=$(echo "$1" | cut -s -d '-' -f 2- )
+    local v2; v2=$(echo "$2" | cut -d '-' -f 1 )
+    local q2; q2=$(echo "$2" | cut -s -d '-' -f 2- )
+    if [ "$v1" = "$v2" ]; then
+        if [ "$q1" = "$q2" ]; then
+            return 1
+        else
+            if [ -z "$q1" ]; then
+                return 1
+            else
+                if [ -z "$q2" ]; then
+                    return 0
+                else
+                    [  "$q1" = "$(echo -e "$q1\n$q2" | sort -V | head -n1)" ]
+                fi
+            fi
+        fi
+    else
+        [  "$v1" = "$(echo -e "$v1\n$v2" | sort -V | head -n1)" ]
+    fi
+}
+
+# returns a plugin version from a plugin archive
+get_plugin_version() {
+    local archive; archive=$1
+    local version; version=$(unzip -p "$archive" META-INF/MANIFEST.MF | grep "^Plugin-Version: " | sed -e 's#^Plugin-Version: ##')
+    version=${version%%[[:space:]]}
+    echo "$version"
+}
+
+# Copy files from /usr/share/jenkins/ref into $JENKINS_HOME
+# So the initial JENKINS-HOME is set with expected content.
+# Don't override, as this is just a reference setup, and use from UI
+# can then change this, upgrade plugins, etc.
+copy_reference_file() {
+    f="${1%/}"
+    b="${f%.override}"
+    rel="${b#"$REF/"}"
+    version_marker="${rel}.version_from_image"
+    dir=$(dirname "${rel}")
+    local action;
+    local reason;
+    local container_version;
+    local image_version;
+    local marker_version;
+    local log; log=false
+    if [[ ${rel} == plugins/*.jpi ]]; then
+        container_version=$(get_plugin_version "$JENKINS_HOME/${rel}")
+        image_version=$(get_plugin_version "${f}")
+        if [[ -e $JENKINS_HOME/${version_marker} ]]; then
+            marker_version=$(cat "$JENKINS_HOME/${version_marker}")
+            if versionLT "$marker_version" "$container_version"; then
+                if ( versionLT "$container_version" "$image_version" && [[ -n $PLUGINS_FORCE_UPGRADE ]]); then
+                    action="UPGRADED"
+                    reason="Manually upgraded version ($container_version) is older than image version $image_version"
+                    log=true
+                else
+                    action="SKIPPED"
+                    reason="Installed version ($container_version) has been manually upgraded from initial version ($marker_version)"
+                    log=true
+                fi
+            else
+                if [[ "$image_version" == "$container_version" ]]; then
+                    action="SKIPPED"
+                    reason="Version from image is the same as the installed version $image_version"
+                else
+                    if versionLT "$image_version" "$container_version"; then
+                        action="SKIPPED"
+                        log=true
+                        reason="Image version ($image_version) is older than installed version ($container_version)"
+                    else
+                        action="UPGRADED"
+                        log=true
+                        reason="Image version ($image_version) is newer than installed version ($container_version)"
+                    fi
+                fi
+            fi
+        else
+            if [[ -n "$TRY_UPGRADE_IF_NO_MARKER" ]]; then
+                if [[ "$image_version" == "$container_version" ]]; then
+                    action="SKIPPED"
+                    reason="Version from image is the same as the installed version $image_version (no marker found)"
+                    # Add marker for next time
+                    echo "$image_version" > "$JENKINS_HOME/${version_marker}"
+                else
+                    if versionLT "$image_version" "$container_version"; then
+                        action="SKIPPED"
+                        log=true
+                        reason="Image version ($image_version) is older than installed version ($container_version) (no marker found)"
+                    else
+                        action="UPGRADED"
+                        log=true
+                        reason="Image version ($image_version) is newer than installed version ($container_version) (no marker found)"
+                    fi
+                fi
+            fi
+        fi
+        if [[ ! -e $JENKINS_HOME/${rel} || "$action" == "UPGRADED" || $f = *.override ]]; then
+            action=${action:-"INSTALLED"}
+            log=true
+            mkdir -p "$JENKINS_HOME/${dir}"
+            cp -pr "${f}" "$JENKINS_HOME/${rel}";
+            # pin plugins on initial copy
+            touch "$JENKINS_HOME/${rel}.pinned"
+            echo "$image_version" > "$JENKINS_HOME/${version_marker}"
+            reason=${reason:-$image_version}
+        else
+            action=${action:-"SKIPPED"}
+        fi
+    else
+        if [[ ! -e $JENKINS_HOME/${rel} || $f = *.override ]]
+        then
+            action="INSTALLED"
+            log=true
+            mkdir -p "$JENKINS_HOME/${dir}"
+            cp -pr "$(realpath "${f}")" "$JENKINS_HOME/${rel}";
+        else
+            action="SKIPPED"
+        fi
+    fi
+    if [[ -n "$VERBOSE" || "$log" == "true" ]]; then
+        if [ -z "$reason" ]; then
+            echo "$action $rel" >> "$COPY_REFERENCE_FILE_LOG"
+        else
+            echo "$action $rel : $reason" >> "$COPY_REFERENCE_FILE_LOG"
+        fi
+    fi
+}
+
+# Retries a command a configurable number of times with backoff.
+#
+# The retry count is given by ATTEMPTS (default 60), the initial backoff
+# timeout is given by TIMEOUT in seconds (default 1.)
+#
+function retry_command() {
+  local max_attempts=${ATTEMPTS-3}
+  local timeout=${TIMEOUT-1}
+  local success_timeout=${SUCCESS_TIMEOUT-1}
+  local max_success_attempt=${SUCCESS_ATTEMPTS-1}
+  local attempt=0
+  local success_attempt=0
+  local exitCode=0
+
+  while (( attempt < max_attempts ))
+  do
+    set +e
+    "$@"
+    exitCode=$?
+    set -e
+
+    if [[ $exitCode == 0 ]]
+    then
+      success_attempt=$(( success_attempt + 1 ))
+      if (( success_attempt >= max_success_attempt))
+      then
+        break
+      else
+        sleep "$success_timeout"
+        continue
+      fi
+    fi
+
+    echo "$(date -u '+%T') Failure ($exitCode) Retrying in $timeout seconds..." 1>&2
+    sleep "$timeout"
+    success_attempt=0
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout ))
+  done
+
+  if [[ $exitCode != 0 ]]
+  then
+    echo "$(date -u '+%T') Failed in the last attempt ($*)" 1>&2
+  fi
+
+  return $exitCode
+}

--- a/scripts/jenkins/plugins/plugins.txt
+++ b/scripts/jenkins/plugins/plugins.txt
@@ -4,7 +4,6 @@ pipeline-utility-steps:2.8.0
 junit:1.51
 scm-manager:1.7.5
 html5-notifier-plugin:1.5
-
 pipeline-model-definition:1.9.1
 git-client:3.9.0
 lockable-resources:2.11

--- a/scripts/jenkins/plugins/plugins.txt
+++ b/scripts/jenkins/plugins/plugins.txt
@@ -1,0 +1,6 @@
+docker-workflow:1.26
+docker-plugin:1.2.2
+pipeline-utility-steps:2.8.0
+junit:1.51
+scm-manager:1.7.5
+html5-notifier-plugin:1.5

--- a/scripts/jenkins/plugins/plugins.txt
+++ b/scripts/jenkins/plugins/plugins.txt
@@ -1,6 +1,15 @@
 docker-workflow:1.26
-docker-plugin:1.2.2
+docker-plugin:1.2.3
 pipeline-utility-steps:2.8.0
 junit:1.51
 scm-manager:1.7.5
 html5-notifier-plugin:1.5
+
+pipeline-model-definition:1.9.1
+git-client:3.9.0
+lockable-resources:2.11
+antisamy-markup-formatter:2.1
+workflow-basic-steps:2.24
+pipeline-rest-api:2.19
+pipeline-stage-view:2.19
+workflow-step-api:2.24


### PR DESCRIPTION
Right now, playground loops endlessly while applying.
Reason: Jenkins plugins installation never finishes.

How could this problem appear without us having changed anything?
The current mechanism we use to install plugins on Jenkins via HTTP (plugin-center) always installs the latest version, even if we pass a deterministic plugin version. However, is seems to only install the required plugin and not the dependencies. 

With the latest version of Docker Plugin now being 1.2.3 we can see the following error on the Jenkins UI:

```
Docker plugin (1.2.3)
    Update required: Docker Commons Plugin (1.14) to be updated to 1.16 or higher
```

This seems to lead to the Docker Plugin not being loaded and so our check for the plugin never succeeds, resulting in the endless loop.

Solution:
Install deterministic versions of plugins including their dependencies.

[Jenkins offers multiple solutions for this](https://www.jenkins.io/doc/book/installing/offline/) - a java-based plugin installation manager tool or a shell script, both contained in the official images. This PR uses the  shell plugin CLI.  It might be deprecated, but for this usecase it's much more lightweight than the "plugin installation manager tool" which requires Java, which is not installed in the playground Docker image.
We could use this in a separate stage in Dockerfile but then apply.sh would no longer work outside the Docker image, which would make development more complicated right now.
In future, when we migrated our shell scripts to a different technology, this decision might change.

## Minor fixes

Not related to the original issue the following things have been improved boy scout rule style:

* Download jenkins Plugins into playground docker image and install from there.
  This provides more deterministic results, because the install-plugins.sh loads specific versions of the plugins but the latest version of each dependency.  
  We could resolve this more fiercely by using a complete dependency tree that can be create [like this](https://gist.github.com/Lucasus/1a6b8df71425c790361c)
* Update some Jenkins plugins explicitly, that seem to exist in our base installation in a deprecated version
* e2e test:
  * In case of error also print exception message
  * Run in JRE instead of JDK image and use a deterministic groovy version `groovy:3.0.8-jre11'` instead of `groovy:jdk11'
  * Extend isolation of groovy container. Neither necessary to run as root, nor to run in host network.
  * Run only non-folder jobs. This is helpful when e2e.groovy is used on a jenkins instance that contains other jobs, not only the gitOps SCM Folders
  * Wait longer (with retries) for folder scan to complete - the existing logic lead to false negatives! Sometimes the test just succeeded without running the jobs, because the folder scan hadn't completed, yet. Then an empty list of jobs was looped.

