### PR TITLE
Bugfix/e2e job discovery

### DIFF
--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -145,6 +145,9 @@ class JenkinsHandler {
         if (folderJob.getJobs().size() == 0) {
             println "WARNING: Job ${job.name} is a folder but does not include jobs."
         } else {
+            println "Found repositories. Waiting a little more so that all repositories have been discovered"
+            Thread.sleep(10000)
+            folderJob = server.getFolderJob(job).get()
             println "There are ${folderJob.getJobs().size()} jobs. These are:"
             folderJob.getJobs().each { Map.Entry<String, Job> repoJob -> println "${repoJob.getKey()}" }
         }

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -95,9 +95,9 @@ class JenkinsHandler {
             // since there is no support for namespace scan; we call built on root folder and wait to discover branches.
             potentialNamespaceJob.value.build(true)
             
-            FolderJob namespaceJob = waitForFolderJob(jenkins, potentialNamespaceJob.value)
+            waitForFolderJob(jenkins, potentialNamespaceJob.value)
 
-            namespaceJob.each { Map.Entry<String, Job> repoJob ->
+            jenkins.getFolderJob(potentialNamespaceJob.value).get().getJobs().each { Map.Entry<String, Job> repoJob ->
                 println("Key: ${repoJob.getKey()} - Value: ${repoJob.getValue()}")
                 jenkins.getFolderJob(repoJob.value).get().getJobs().each { Map.Entry<String, Job> branchJob ->
                     println("Key: ${branchJob.getKey()} - Value: ${branchJob.getValue()}")
@@ -126,7 +126,7 @@ class JenkinsHandler {
 
     }
 
-    FolderJob waitForFolderJob(JenkinsServer server, Job job) {
+    void waitForFolderJob(JenkinsServer server, Job job) {
         // Scanning namespace takes several seconds to complete. Example:
         // [Wed Sep 08 13:52:35 CEST 2021] Finished organization scan. Scan took 13 sec
         int count = 0;
@@ -146,9 +146,8 @@ class JenkinsHandler {
             println "WARNING: Job ${job.name} is a folder but does not include jobs."
         } else {
             println "There are ${folderJob.getJobs().size()} jobs. These are:"
-            folderJob.getJobs().each { Map.Entry<String, Job> repoJob -> println "Key: ${repoJob.getKey()} - Value: ${repoJob.getValue()}" }
+            folderJob.getJobs().each { Map.Entry<String, Job> repoJob -> println "Key: ${repoJob.getKey()} - Value: ${repoJob.getValue().details()}" }
         }
-        return folderJob
     }
 }
 

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -146,7 +146,7 @@ class JenkinsHandler {
             println "WARNING: Job ${job.name} is a folder but does not include jobs."
         } else {
             println "Found repositories. Waiting a little more so that all repositories have been discovered"
-            Thread.sleep(10000)
+            Thread.sleep(30000)
             folderJob = server.getFolderJob(job).get()
             println "There are ${folderJob.getJobs().size()} jobs. These are:"
             folderJob.getJobs().each { Map.Entry<String, Job> repoJob -> println "${repoJob.getKey()}" }

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -94,13 +94,13 @@ class JenkinsHandler {
             
             // since there is no support for namespace scan; we call built on root folder and wait to discover branches.
             potentialNamespaceJob.value.build(true)
-            
-            waitForFolderJob(jenkins, potentialNamespaceJob.value)
 
-            jenkins.getFolderJob(potentialNamespaceJob.value).get().getJobs().each { Map.Entry<String, Job> repoJob ->
-                println("Key: ${repoJob.getKey()} - Value: ${repoJob.getValue().details()}")
+            var namespaceJob = waitForFolderJob(jenkins, potentialNamespaceJob.value)
+
+            namespaceJob.getJobs().each { Map.Entry<String, Job> repoJob ->
+                println("Checking the repo ${repoJob.getKey()}")
                 jenkins.getFolderJob(repoJob.value).get().getJobs().each { Map.Entry<String, Job> branchJob ->
-                    println("Key: ${branchJob.getKey()} - Value: ${branchJob.getValue().details()}")
+                    println("Checking the branch ${branchJob.getKey()}")
                     jobs.add(branchJob.value.details())
                 }
             }
@@ -126,7 +126,7 @@ class JenkinsHandler {
 
     }
 
-    void waitForFolderJob(JenkinsServer server, Job job) {
+    FolderJob waitForFolderJob(JenkinsServer server, Job job) {
         // Scanning namespace takes several seconds to complete. Example:
         // [Wed Sep 08 13:52:35 CEST 2021] Finished organization scan. Scan took 13 sec
         int count = 0;
@@ -148,6 +148,7 @@ class JenkinsHandler {
             println "There are ${folderJob.getJobs().size()} jobs. These are:"
             folderJob.getJobs().each { Map.Entry<String, Job> repoJob -> println "Key: ${repoJob.getKey()} - Value: ${repoJob.getValue().details()}" }
         }
+        return folderJob
     }
 }
 

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -146,7 +146,7 @@ class JenkinsHandler {
             println "WARNING: Job ${job.name} is a folder but does not include jobs."
         } else {
             println "There are ${folderJob.getJobs().size()} jobs. These are:"
-            folderJob.getJobs().each { Map.Entry<String, Job> repoJob -> println "Key: ${repoJob.getKey()} - Value: ${repoJob.getValue().details()}" }
+            folderJob.getJobs().each { Map.Entry<String, Job> repoJob -> println "${repoJob.getKey()}" }
         }
         return folderJob
     }

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -98,9 +98,9 @@ class JenkinsHandler {
             waitForFolderJob(jenkins, potentialNamespaceJob.value)
 
             jenkins.getFolderJob(potentialNamespaceJob.value).get().getJobs().each { Map.Entry<String, Job> repoJob ->
-                println("Key: ${repoJob.getKey()} - Value: ${repoJob.getValue()}")
+                println("Key: ${repoJob.getKey()} - Value: ${repoJob.getValue().details()}")
                 jenkins.getFolderJob(repoJob.value).get().getJobs().each { Map.Entry<String, Job> branchJob ->
-                    println("Key: ${branchJob.getKey()} - Value: ${branchJob.getValue()}")
+                    println("Key: ${branchJob.getKey()} - Value: ${branchJob.getValue().details()}")
                     jobs.add(branchJob.value.details())
                 }
             }

--- a/scripts/e2e.groovy
+++ b/scripts/e2e.groovy
@@ -95,7 +95,7 @@ class JenkinsHandler {
             // since there is no support for namespace scan; we call built on root folder and wait to discover branches.
             potentialNamespaceJob.value.build(true)
 
-            var namespaceJob = waitForFolderJob(jenkins, potentialNamespaceJob.value)
+            var namespaceJob = waitForNamespaceJob(jenkins, potentialNamespaceJob.value)
 
             namespaceJob.getJobs().each { Map.Entry<String, Job> repoJob ->
                 println("Checking the repo ${repoJob.getKey()}")
@@ -126,7 +126,7 @@ class JenkinsHandler {
 
     }
 
-    FolderJob waitForFolderJob(JenkinsServer server, Job job) {
+    FolderJob waitForNamespaceJob(JenkinsServer server, Job job) {
         // Scanning namespace takes several seconds to complete. Example:
         // [Wed Sep 08 13:52:35 CEST 2021] Finished organization scan. Scan took 13 sec
         int count = 0;


### PR DESCRIPTION
This fixes the problem, where scanning Jenkins for builds might return only a partial build list. This could lead to only test some of our applications in the integration test step and not all of them. So we implemented a mechanism to (if at least one build was found) wait a little so that all builds in all folders were registered.

Additionally, we changed some naming in code to have a better readability and understanding which variable corresponds to which Jenkins job layer.