### PR TITLE
pin plugin workflow-durable-task-step to fix corrupted dependencies

### DIFF
--- a/scripts/jenkins/plugins/plugins.txt
+++ b/scripts/jenkins/plugins/plugins.txt
@@ -1,3 +1,4 @@
+workflow-durable-task-step:2.40
 workflow-cps-global-lib:2.21
 credentials:2.6.1
 docker-workflow:1.26


### PR DESCRIPTION
- The install plugins script tries to download the latest plugin dependencies. In this case the latest dependency plugin "workflow-durable-task-step" is not compatible with the used jenkins version anymore

Signed-off-by: pmarkiewka <philipp.markiewka@cloudogu.com>