### PR TITLE
Simplify TLDR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN mkdir ${RESULT_LIB} && \
     tar -xvzf musl.tar.gz -C ${RESULT_LIB} --strip-components 1 && \
     cp /usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.a ${RESULT_LIB}/lib/
 ENV CC=/musl/bin/gcc
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.13.tar.gz && \
     mkdir zlib && tar -xvzf zlib.tar.gz -C zlib --strip-components 1 && \
     cd zlib && ./configure --static --prefix=/musl && \
     make && make install && \

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ For questions or suggestions you are welcome to join us at our myCloudogu [commu
 You can run a local k8s cluster with the GitOps playground installed with only one command (on Linux)
 
 ```shell
-docker pull ghcr.io/cloudogu/gitops-playground && \ 
 bash <(curl -s \
   https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh) \
-  && sleep 2 && docker run --rm -it -u $(id -u) -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
+  && sleep 2 && docker run --rm -it --pull=always -u $(id -u) \ 
+    -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
     --net=host \
     ghcr.io/cloudogu/gitops-playground --yes
 ```


### PR DESCRIPTION
TIL `docker run --pull=always`

Build broke, because `https://zlib.net/zlib-1.2.12.tar.gz` no longer exists. So had to fix this, even though this mere documentation change did not have anything to do with it 🙄