### PR TITLE
Upgrade Jenkins and fix vuln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,8 @@ COPY --from=maven-build /app/gitops-playground.jar /home/groovy/.groovy/lib/
 COPY src /app/src
 # Allow initialization in final FROM ${ENV} stage
 USER 0
+# Avoid criticla CVE in ivy, which is not fixed in groovy 3 right now. We don't use trivy anyway, so delete it.
+RUN rm /opt/groovy/lib/ivy-2.5.0.jar
 
 
 

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -13,7 +13,7 @@ fi
 # In addition:
 # - Upgrade bash image in values.yaml and gid-grepper
 # - Also upgrade plugins. See docs/developers.md
-JENKINS_HELM_CHART_VERSION=4.2.9
+JENKINS_HELM_CHART_VERSION=4.2.12
 
 SET_USERNAME="admin"
 SET_PASSWORD="admin"
@@ -100,7 +100,7 @@ function configureJenkins() {
   if [[ -z "${JENKINS_PLUGIN_FOLDER}" ]]; then
     pluginFolder=$(mktemp -d)
     echo "Downloading jenkins plugins to ${pluginFolder}"
-    "${PLAYGROUND_DIR}"/scripts/jenkins/plugins/download-plugins.sh "${pluginFolder}"
+    #"${PLAYGROUND_DIR}"/scripts/jenkins/plugins/download-plugins.sh "${pluginFolder}"
   else
     echo "Jenkins plugins folder present, skipping plugin download"
     pluginFolder="${JENKINS_PLUGIN_FOLDER}"


### PR DESCRIPTION
* Jenkins Chart 4.2.9 is no longer working (even with default values) because of plugin dependency `Plugin workflow-aggregator ... depends on configuration-as-code:1559.v38a_b_2e3b_6b_b_7, but there is an older version defined on the top level`
* Avoid  CVE-2022-37865 in ivy for dev image

Cherry picks from #98 