### PR TITLE
Push branch "test" as image tag "test" + Get rid of CVE-2022-1471

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,7 +169,8 @@ COPY src /app/src
 USER 0
 # Avoid criticla CVE in ivy, which is not fixed in groovy 3 right now. We don't use trivy anyway, so delete it.
 RUN rm /opt/groovy/lib/ivy-2.5.0.jar
-
+# Avoid criticla CVE in SnakeYAML, which is not fixed in groovy 3 right now. Our app brings its own dependency for snakeyaml
+RUN rm /opt/groovy/lib/snakeyaml-1.30.jar
 
 
 # Pick final image according to build-arg

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,7 @@ FROM alpine as prod
 COPY --from=native-image /app/apply-ng app/apply-ng
 
 
-FROM eclipse-temurin:${JDK_VERSION}-jdk-alpine as dev
+FROM eclipse-temurin:${JDK_VERSION}-jre-alpine as dev
 
 COPY scripts/apply-ng.sh /app/scripts/
 COPY --from=maven-build /app/gitops-playground.jar /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,18 +159,13 @@ FROM alpine as prod
 COPY --from=native-image /app/apply-ng app/apply-ng
 
 
-FROM groovy:${GROOVY_VERSION}-jdk${JDK_VERSION}-alpine as dev
+FROM eclipse-temurin:${JDK_VERSION}-jdk-alpine as dev
+
 COPY scripts/apply-ng.sh /app/scripts/
-# Copy gitops-playground.jar where groovy can find it (see apply-ng.sh)
-# HOME might be /home, but for the JVM /etc/passwd counts, where the user groovy has /home/groovy as home
-COPY --from=maven-build /app/gitops-playground.jar /home/groovy/.groovy/lib/
+COPY --from=maven-build /app/gitops-playground.jar /app/
 COPY src /app/src
 # Allow initialization in final FROM ${ENV} stage
 USER 0
-# Avoid criticla CVE in ivy, which is not fixed in groovy 3 right now. We don't use trivy anyway, so delete it.
-RUN rm /opt/groovy/lib/ivy-2.5.0.jar
-# Avoid criticla CVE in SnakeYAML, which is not fixed in groovy 3 right now. Our app brings its own dependency for snakeyaml
-RUN rm /opt/groovy/lib/snakeyaml-1.30.jar
 
 
 # Pick final image according to build-arg

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ ARG ENV=prod
 
 # Keep in sync with the versions in pom.xml
 ARG JDK_VERSION='17'
-# Those are set by the micronaut BOM, see pom.xml
-ARG GROOVY_VERSION='3.0.13'
+# Set by the micronaut BOM, see pom.xml
 ARG GRAAL_VERSION='22.3.0'
 
 FROM alpine:3.17.1 as alpine

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,6 +139,13 @@ node('docker') {
                                 images[0].push('latest')
                                 currentBuild.description = createImageName('latest')
                                 currentBuild.description += "\n${imageNames[0]}"
+                            } else if (env.BRANCH_NAME == 'test') {
+                                images[1].push()
+                                images[1].push('test-dev')
+                                images[0].push()
+                                images[0].push('test')
+                                currentBuild.description = createImageName('test')
+                                currentBuild.description += "\n${imageNames[0]}"
                             } else if (params.forcePushImage) {
                                 images[1].push()
                                 images[0].push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,15 @@ node('docker') {
                 }
 
                 stage('Build cli') {
-                    // Read version from Dockerfile (DRY)
-                    String jdkVersion = sh (returnStdout: true, script: 'grep -r \'ARG JDK_VERSION\' Dockerfile | sed "s/.*JDK_VERSION=\'\\(.*\\)\'.*/\\1/" ').trim()
-                    String groovyVersion = sh (returnStdout: true, script: 'grep -r \'ARG GROOVY_VERSION\' Dockerfile | sed "s/.*GROOVY_VERSION=\'\\(.*\\)\'.*/\\1/" ').trim()
+                    // Read Java version from Dockerfile (DRY)
+                    String jdkVersion = sh (returnStdout: true, script: 
+                            'grep -r \'ARG JDK_VERSION\' Dockerfile | sed "s/.*JDK_VERSION=\'\\(.*\\)\'.*/\\1/" ').trim()
+                    // Groovy version is defined by micronaut version. Get it from there.
+                    String groovyVersion = sh (returnStdout: true, script:
+                            'MICRONAUT_VERSION=$(cat pom.xml | sed -n \'/<parent>/,/<\\/parent>/p\' | ' +
+                                    'sed -n \'s/.*<version>\\(.*\\)<\\/version>.*/\\1/p\'); ' +
+                            'curl -s https://repo1.maven.org/maven2/io/micronaut/micronaut-bom/${MICRONAUT_VERSION}/micronaut-bom-${MICRONAUT_VERSION}.pom | ' +
+                                    'sed -n \'s/.*<groovy.version>\\(.*\\)<\\/groovy.version>.*/\\1/p\'').trim()
                     groovyImage = "groovy:${groovyVersion}-jdk${jdkVersion}"
                     // Re-use groovy image here, even though we only need JDK
                     mvn = new MavenWrapperInDocker(this, groovyImage)
@@ -48,7 +54,6 @@ node('docker') {
                     mvn 'clean install -DskipTests'
                 }
 
-                // This interferes with the e2etests regarding the dependency download of grapes. It might be that the MavenWrapperInDocker somehow interferes with the FileSystem so that grapes is no longer to write to fs.
                 stage('Test cli') {
                     mvn 'test -Dmaven.test.failure.ignore=true'
                     // Archive test results. Makes build unstable on failed tests.

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,10 @@
     <groupId>io.micronaut</groupId>
     <artifactId>micronaut-parent</artifactId>
     <!-- When updating, also update groovy and graal version in dockerfile -->
-    <!-- See e.g. here for versions: https://search.maven.org/artifact/io.micronaut/micronaut-bom/3.7.2/pom -->
-    <version>3.7.2</version>
+    <!-- See e.g. here for versions: https://central.sonatype.com/artifact/io.micronaut/micronaut-bom/3.8.7
+       graal.version and groovy.version -->
+    <!-- ON NEXT GROOVY UPDATE: check if we can get rid of explicit jackson-dataformat-yaml without critical CVE -->
+    <version>3.8.7</version>
   </parent>
 
   <properties>
@@ -57,6 +59,13 @@
       <version>${groovy.version}</version>
     </dependency>
 
+    <!-- Avoid CVE-2022-1471 in transitive dependency of groovy-yaml. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.15.0-rc2</version>
+    </dependency>
+    
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,8 @@
   <parent>
     <groupId>io.micronaut</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <!-- When updating, also update groovy and graal version in dockerfile -->
-    <!-- See e.g. here for versions: https://central.sonatype.com/artifact/io.micronaut/micronaut-bom/3.8.7
-       graal.version and groovy.version -->
+    <!-- When updating, also update and graal version in dockerfile -->
+    <!-- See "graal.version" here https://central.sonatype.com/artifact/io.micronaut/micronaut-bom/3.8.7 -->
     <!-- ON NEXT GROOVY UPDATE: check if we can get rid of explicit jackson-dataformat-yaml without critical CVE -->
     <version>3.8.7</version>
   </parent>

--- a/scripts/apply-ng.sh
+++ b/scripts/apply-ng.sh
@@ -15,24 +15,13 @@ function main() {
 
 function groovy() {
   # We don't need the groovy "binary" (script) to start, because the gitops-playground.jar already contains groovy-all.
-
-  # Write starter-conf file (required by groovy)
-  GROOVY_CONF=$(mktemp)
   
   # Set params like startGroovy does (which is called by the "groovy" script)
   # See https://github.com/apache/groovy/blob/master/src/bin/startGroovy
   java \
-    --add-modules=ALL-SYSTEM \
-    -Dgroovy.jaxb=jaxb \
     -classpath /app/gitops-playground.jar \
-    -Dscript.name="$0" \
-    -Dprogram.name="$(basename "$0")" \
-    -Dgroovy.starter.conf="$GROOVY_CONF" \
-    -Dgroovy.home=$PLAYGROUND_DIR \
     org.codehaus.groovy.tools.GroovyStarter \
           --main groovy.ui.GroovyMain \
-          --conf "$GROOVY_CONF" \
-          --classpath . \
            "$@" 
 }
 

--- a/scripts/apply-ng.sh
+++ b/scripts/apply-ng.sh
@@ -16,21 +16,8 @@ function main() {
 function groovy() {
   # We don't need the groovy "binary" (script) to start, because the gitops-playground.jar already contains groovy-all.
 
-  # Write starter-conf (required by groovy)
-  # See https://github.com/apache/groovy/blob/master/src/conf/groovy-starter.conf
-  # No write permission on $PLAYGROUND_DIR, so use /tmp
-  GROOVY_CONF=/tmp/groovy-starter.conf
-  
-cat << EOF > $GROOVY_CONF
-    # load required libraries
-    load !{groovy.home}/lib/*.jar
-
-    # load user specific libraries
-    load !{user.home}/.groovy/lib/*.jar
-
-    # tools.jar for ant tasks
-    load \${tools.jar}
-EOF
+  # Write starter-conf file (required by groovy)
+  GROOVY_CONF=$(mktemp)
   
   # Set params like startGroovy does (which is called by the "groovy" script)
   # See https://github.com/apache/groovy/blob/master/src/bin/startGroovy

--- a/scripts/apply-ng.sh
+++ b/scripts/apply-ng.sh
@@ -2,14 +2,51 @@
 set -o errexit -o nounset -o pipefail
 
 # Entry point for the new generation of our apply script, written in groovy  
+function main() {
+    
+  if [[ -f "$PLAYGROUND_DIR/apply-ng" ]]; then
+      "$PLAYGROUND_DIR"/apply-ng "$@"
+  else 
+      echo "apply-ng binary not found, calling groovy scripts"
+      groovy --classpath "$PLAYGROUND_DIR"/src/main/groovy \
+        "$PLAYGROUND_DIR"/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMain.groovy "$@" 
+  fi
+}
 
-if [[ -f "$PLAYGROUND_DIR/apply-ng" ]]; then
-    "$PLAYGROUND_DIR"/apply-ng "$@"
-else 
-    echo "apply-ng binary not found, calling groovy scripts"
-    # Classpath seems not to load jars, so for this to work, 
-    # we need to make sure to put gitops-playground-cli-*.jar into ~/.groovy/lib
-    # https://stackoverflow.com/questions/10585808/groovy-script-classpath 
-    groovy --classpath "$PLAYGROUND_DIR"/src/main/groovy \
-      "$PLAYGROUND_DIR"/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMain.groovy "$@" 
-fi
+function groovy() {
+  # We don't need the groovy "binary" (script) to start, because the gitops-playground.jar already contains groovy-all.
+
+  # Write starter-conf (required by groovy)
+  # See https://github.com/apache/groovy/blob/master/src/conf/groovy-starter.conf
+  # No write permission on $PLAYGROUND_DIR, so use /tmp
+  GROOVY_CONF=/tmp/groovy-starter.conf
+  
+cat << EOF > $GROOVY_CONF
+    # load required libraries
+    load !{groovy.home}/lib/*.jar
+
+    # load user specific libraries
+    load !{user.home}/.groovy/lib/*.jar
+
+    # tools.jar for ant tasks
+    load \${tools.jar}
+EOF
+  
+  # Set params like startGroovy does (which is called by the "groovy" script)
+  # See https://github.com/apache/groovy/blob/master/src/bin/startGroovy
+  java \
+    --add-modules=ALL-SYSTEM \
+    -Dgroovy.jaxb=jaxb \
+    -classpath /app/gitops-playground.jar \
+    -Dscript.name="$0" \
+    -Dprogram.name="$(basename "$0")" \
+    -Dgroovy.starter.conf="$GROOVY_CONF" \
+    -Dgroovy.home=$PLAYGROUND_DIR \
+    org.codehaus.groovy.tools.GroovyStarter \
+          --main groovy.ui.GroovyMain \
+          --conf "$GROOVY_CONF" \
+          --classpath . \
+           "$@" 
+}
+
+main "$@"


### PR DESCRIPTION
The moving tag `test`  allows us to have a constant image tag that can be used to review features in customer environments before merging them to main.