### PR TITLE
Allow running apply.sh without container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ terraform/account.json
 /.mvn/wrapper/maven-wrapper.jar
 # Is created on "helm dep update ." but not needed in repo
 /argocd/argocd/argocd/charts/
+
+gitops-playground.jar
+jenkins-plugins

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -83,26 +83,21 @@ Jenkins.instance.pluginManager.plugins.collect().sort().each {
       --net=host gitops-playground:dev <params>
      ```
   * Locally:
-    * [Provide dependencies](#providing-dependencies)
-    * Just run `scripts/apply.sh <params>`
-
-### Providing dependencies
-
-It seems like `groovy --classpath gitops-playground-cli-*.jar` [does not load jars]( https://stackoverflow.com/questions/10585808/groovy-script-classpath),
-Workaround:
-
-* Run
-  ```shell
-  mvn package -DskipTests
-  ```
-* Copy `target/gitops-playground-cli-*.jar` to `~/.groovy/lib`
-* Make sure to use the exact same groovy version as in pom.xml
-  To avoid
-  ```
-  Caused by: groovy.lang.GroovyRuntimeException: Conflicting module versions. Module [groovy-datetime is loaded in version 3.0.8 and you are trying to load version 3.0.13
-  ```
-  Solution might be to remove groovy from `gitops-playground-cli-*.jar`
-
+    * Provide `gitops-playground.jar` for `apply-ng.sh`:
+      ```bash
+      ./mvnw package -DskipTests
+      ln -s target/gitops-playground-cli-0.1.jar gitops-playground.jar 
+       ```
+    * Just run `scripts/apply.sh <params>`.  
+      Hint: You can speed up the process by installing the Jenkins plugins from your filesystem, instead of from the internet.  
+      To do so, download the plugins into a folder, then set this folder vie env var:  
+      `JENKINS_PLUGIN_FOLDER=$(pwd) scripts/apply.sh <params>`.  
+      A working combination of plugins be extracted from the image:  
+      ```bash
+      id=$(docker create ghcr.io/cloudogu/gitops-playground)
+      docker cp $id:/gitops/jenkins-plugins .
+      docker rm -v $id
+      ```
 
 ## Development image
 
@@ -120,10 +115,7 @@ It can be built like so:
 docker buildx build -t gitops-playground:dev --build-arg ENV=dev  --progress=plain  .  
 ```
 Hint: uses buildkit for much faster builds, skipping the static image stuff not needed for dev.
-
-TODO: Copy a script `apply-ng` into the dev image that calls `groovy GitopsPlaygroundCliMain?! args`.
-Then, we can use the dev image to try out if the playground image works without having to wait for the static image to
-be built.
+With Docker version >= 23 you can also use `docker build`, because buildkit is the new default builder.
 
 ## Implicit + explicit dependencies
 

--- a/scripts/apply-ng.sh
+++ b/scripts/apply-ng.sh
@@ -19,7 +19,7 @@ function groovy() {
   # Set params like startGroovy does (which is called by the "groovy" script)
   # See https://github.com/apache/groovy/blob/master/src/bin/startGroovy
   java \
-    -classpath /app/gitops-playground.jar \
+    -classpath "$PLAYGROUND_DIR"/gitops-playground.jar \
     org.codehaus.groovy.tools.GroovyStarter \
           --main groovy.ui.GroovyMain \
            "$@" 

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -96,7 +96,7 @@ function configureJenkins() {
   if [[ -z "${JENKINS_PLUGIN_FOLDER}" ]]; then
     pluginFolder=$(mktemp -d)
     echo "Downloading jenkins plugins to ${pluginFolder}"
-    #"${PLAYGROUND_DIR}"/scripts/jenkins/plugins/download-plugins.sh "${pluginFolder}"
+    "${PLAYGROUND_DIR}"/scripts/jenkins/plugins/download-plugins.sh "${pluginFolder}"
   else
     echo "Jenkins plugins folder present, skipping plugin download"
     pluginFolder="${JENKINS_PLUGIN_FOLDER}"


### PR DESCRIPTION
Running apply.sh without container used to work unofficially, for development.

It stopped in 4d95f75e, when we (probably unintentionally) commented a line in init-jenkins.sh.
Later, in a9c1a160, we got rid of the need for a local groovy installation, which also influences the apply.sh, when run locally.

This commit updates the developers.md and fixes some small issues to allow local apply.sh execution for the sake of faster development speed.

Important: After this PR, the `dev` image should still work.