### PR TITLE
Jenkins: Run on dedicated build agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ properties([
     ])
 ])
 
-node('docker') {
+node('high-cpu') {
 
     git = new Git(this)
     // Avoid 'No such property: clusterName' error in 'Stop k3d' stage in builds that have failed in an early stage


### PR DESCRIPTION
As we're increasingly running into timeouts when sharing the agents with other jobs that also require a lot of CPU, we're now running dedicated machines per Job.

This also resolves any potential concurrency issues in `Jenkinsfile` that we spent a fortune to avoid :smile: 