### PR TITLE
Upgrade SCMM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ properties([
     ])
 ])
 
-node('docker') {
+node('high-cpu') {
 
     git = new Git(this)
     // Avoid 'No such property: clusterName' error in 'Stop k3d' stage in builds that have failed in an early stage

--- a/scripts/scm-manager/init-scmm.sh
+++ b/scripts/scm-manager/init-scmm.sh
@@ -2,7 +2,7 @@
 set -o errexit -o nounset -o pipefail
 
 SCMM_PROTOCOL=http
-SCMM_HELM_CHART_VERSION=2.40.0
+SCMM_HELM_CHART_VERSION=2.44.2
 
 function deployLocalScmmManager() {
   local REMOTE_CLUSTER=${1}


### PR DESCRIPTION
Avoids errors caused by accidental breaking change in scmm-review-plugin with gitops-build-lib.

The problem was fixed in 2.27.1, which requires SCM-Manager 2.44.0.