### PR TITLE
Add option to destruct the playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,11 @@ See [Secrets management tools](#secrets-managment-tools) for details.
 ### Remove playground
 
 For k3d, you can just `k3d cluster delete gitops-playground`. This will delete the whole cluster.
-Right now, there is no way to remove the playground from a cluster completely. We are planning to implement this, though.
+
+To remove the playground without deleting the cluster, use the option `--destroy`.
+You need pass the same parameters when deploying the playground to ensure that the destroy script 
+can authenticate with all tools.
+Note that this option has limitations. It does not remove CRDs, namespaces, locally deployed SCM-Manager, Jenkins and registry, plugins for SCM-Manager and Jenkins 
 
 ## Stack
 

--- a/docs/architecture-decision-records.md
+++ b/docs/architecture-decision-records.md
@@ -3,6 +3,39 @@ Architecture Decision Records
 
 Bases on [this template](https://adr.github.io/madr/examples.html).
 
+## Using Retrofit as API client for SCM-Manager
+
+### Context and Problem Statement
+
+We want to use the SCM-Manager REST-API to delete users and repositories
+for cleaning up the playground.
+In the future, we want to use the same client to create resources when moving away from bash.
+
+There is no official API client for SCM-Manager anymore.
+There is a OpenAPI document for the API.
+
+### Considered Options
+
+* Using a [client generator](https://github.com/OpenAPITools/openapi-generator/tree/master)
+* Using hand rolled API client based on an HTTP client
+* Using Retrofit
+
+### Decision Outcome
+
+The client generator for groovy does not support basic authentication needed for interfacing with SCM-Manager.
+The java generator needs various dependencies that we would need to introduce into the project.
+Both have mediocre support for specifying a base url at runtime.
+
+Hand rolling an API based on HTTP requires a lot of effort not only initially, but for every resource added to the client.
+
+Retrofit offers a declarative approach to define API clients.
+Furthermore, it has first-class support for specifying a base url.
+Retrofit uses reflection to generate the client. 
+As a result, we need to configure GraalVM appropriately.
+
+We decided to use Retrofit due to its small footprint and because we already integrated OkHttp.
+Additionally, creating an API endpoint in Retrofit requires little effort.
+
 ## Using Templating Mechanism for Generating Repositories 
 
 ### Context and Problem Statement

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,18 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>4.11.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>retrofit</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <version>4.11.0</version>
       <scope>test</scope>

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.Logger
 import com.cloudogu.gitops.Application
 import com.cloudogu.gitops.config.ApplicationConfigurator
 import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.destroy.Destroyer
 import groovy.util.logging.Slf4j
 import io.micronaut.context.ApplicationContext
 import org.slf4j.LoggerFactory
@@ -115,6 +116,9 @@ class GitopsPlaygroundCli  implements Runnable {
     private boolean pipeYes
     @Option(names = ['--name-prefix'], description = 'Set name-prefix for repos, jobs, namespaces')
     private String namePrefix
+    @Option(names = ['--destroy'], description = 'Unroll playground')
+    private boolean destroy
+
 
     // args group operator
     @Option(names = ['--fluxv2'], description = 'Install Flux V2')
@@ -127,8 +131,14 @@ class GitopsPlaygroundCli  implements Runnable {
     @Override
     void run() {
         def context = ApplicationContext.run().registerSingleton(new Configuration(getConfig()))
-        Application app = context.getBean(Application)
-        app.start()
+
+        if (destroy) {
+            Destroyer destroyer = context.getBean(Destroyer)
+            destroyer.destroy()
+        } else {
+            Application app = context.getBean(Application)
+            app.start()
+        }
     }
 
     void setLogging() {

--- a/src/main/groovy/com/cloudogu/gitops/cli/JenkinsCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/JenkinsCli.groovy
@@ -1,7 +1,7 @@
 package com.cloudogu.gitops.cli
 
 import com.cloudogu.gitops.dependencyinjection.JenkinsFactory
-import com.cloudogu.gitops.jenkins.Configuration
+import com.cloudogu.gitops.jenkins.JenkinsConfiguration
 import com.cloudogu.gitops.jenkins.UserManager
 import groovy.util.logging.Slf4j
 import io.micronaut.context.ApplicationContext
@@ -39,7 +39,7 @@ class JenkinsCli {
 
     private ApplicationContext createApplicationContext(OptionsMixin options) {
         ApplicationContext.run()
-                .registerSingleton(new JenkinsFactory(new Configuration(options.jenkinsUrl, options.jenkinsUsername, options.jenkinsPassword)))
+                .registerSingleton(new JenkinsFactory(new JenkinsConfiguration(options.jenkinsUrl, options.jenkinsUsername, options.jenkinsPassword)))
     }
 
     static class OptionsMixin {

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -201,7 +201,14 @@ class ApplicationConfigurator {
             log.debug("Setting external jenkins config")
             newConfig.jenkins["internal"] = false
             newConfig.jenkins["urlForScmm"] = newConfig.jenkins["url"] 
+        } else if (newConfig.application["runningInsideK8s"]) {
+            log.debug("Setting jenkins url to k8s service, since installation is running inside k8s")
+            newConfig.jenkins["url"] = networkingUtils.createUrl("jenkins.default.svc.cluster.local", "80")
+        } else {
+            log.debug("Setting internal jenkins configs")
+            def port = fileSystemUtils.getLineFromFile(fileSystemUtils.getRootDir() + "/jenkins/values.yaml", "nodePort:").findAll(/\d+/)*.toString().get(0)
+            String cba = newConfig.application["clusterBindAddress"]
+            newConfig.jenkins["url"] = networkingUtils.createUrl(cba, port)
         }
-        // TODO missing external config (see setScmmConfig())
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/config/Configuration.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Configuration.groovy
@@ -13,4 +13,12 @@ class Configuration {
     Map getConfig() {
         return this.config
     }
+
+    String getNamePrefix() {
+        return this.config.application['namePrefix']
+    }
+
+    String getNamePrefixForEnvVars() {
+        return this.config.application['namePrefixForEnvVars']
+    }
 }

--- a/src/main/groovy/com/cloudogu/gitops/dependencyinjection/HttpClientFactory.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/dependencyinjection/HttpClientFactory.groovy
@@ -5,14 +5,35 @@ import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 import okhttp3.JavaNetCookieJar
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.jetbrains.annotations.NotNull
+import org.slf4j.LoggerFactory
 
 @Factory
 class HttpClientFactory {
     @Singleton
-    OkHttpClient okHttpClient() {
+    OkHttpClient okHttpClient(HttpLoggingInterceptor httpLoggingInterceptor) {
         return new OkHttpClient.Builder()
                 .cookieJar(new JavaNetCookieJar(new CookieManager()))
+                .addInterceptor(httpLoggingInterceptor)
                 .addInterceptor(new RetryInterceptor())
                 .build()
+    }
+
+    @Singleton
+    HttpLoggingInterceptor createLoggingInterceptor() {
+        def logger = LoggerFactory.getLogger("com.cloudogu.gitops.HttpClient")
+
+        def ret = new HttpLoggingInterceptor(new HttpLoggingInterceptor.Logger() {
+            @Override
+            void log(@NotNull String msg) {
+                logger.trace(msg)
+            }
+        })
+
+        ret.setLevel(HttpLoggingInterceptor.Level.HEADERS)
+        ret.redactHeader("Authorization")
+
+        return ret
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/dependencyinjection/HttpClientFactory.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/dependencyinjection/HttpClientFactory.groovy
@@ -2,6 +2,7 @@ package com.cloudogu.gitops.dependencyinjection
 
 import com.cloudogu.gitops.okhttp.RetryInterceptor
 import io.micronaut.context.annotation.Factory
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import okhttp3.JavaNetCookieJar
 import okhttp3.OkHttpClient
@@ -12,6 +13,7 @@ import org.slf4j.LoggerFactory
 @Factory
 class HttpClientFactory {
     @Singleton
+    @Named("jenkins")
     OkHttpClient okHttpClient(HttpLoggingInterceptor httpLoggingInterceptor) {
         return new OkHttpClient.Builder()
                 .cookieJar(new JavaNetCookieJar(new CookieManager()))

--- a/src/main/groovy/com/cloudogu/gitops/dependencyinjection/JenkinsFactory.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/dependencyinjection/JenkinsFactory.groovy
@@ -1,21 +1,22 @@
 package com.cloudogu.gitops.dependencyinjection
 
 import com.cloudogu.gitops.jenkins.ApiClient
-import com.cloudogu.gitops.jenkins.Configuration
+import com.cloudogu.gitops.jenkins.JenkinsConfiguration
 import io.micronaut.context.annotation.Factory
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import okhttp3.OkHttpClient
 
 @Factory
 class JenkinsFactory {
-    private Configuration config
+    private JenkinsConfiguration config
 
-    JenkinsFactory(Configuration config) {
+    JenkinsFactory(JenkinsConfiguration config) {
         this.config = config
     }
 
     @Singleton
-    ApiClient jenkinsApiClient(OkHttpClient client) {
+    ApiClient jenkinsApiClient(@Named("jenkins") OkHttpClient client) {
         return new ApiClient(
                 config.url,
                 config.username,

--- a/src/main/groovy/com/cloudogu/gitops/dependencyinjection/RetrofitFactory.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/dependencyinjection/RetrofitFactory.groovy
@@ -1,0 +1,42 @@
+package com.cloudogu.gitops.dependencyinjection
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.scmm.api.AuthorizationInterceptor
+import com.cloudogu.gitops.scmm.api.RepositoryApi
+import com.cloudogu.gitops.scmm.api.UsersApi
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+
+@Factory
+class RetrofitFactory {
+    @Singleton
+    UsersApi usersApi(Retrofit retrofit) {
+        return retrofit.create(UsersApi)
+    }
+
+    @Singleton
+    RepositoryApi repositoryApi(Retrofit retrofit) {
+        return retrofit.create(RepositoryApi)
+    }
+
+    @Singleton
+    Retrofit retrofit(Configuration configuration, @Named("scmm") OkHttpClient okHttpClient) {
+        return new Retrofit.Builder()
+                .baseUrl(configuration.config.scmm['url'] as String + '/api/')
+                .client(okHttpClient)
+                .build()
+    }
+
+    @Singleton
+    @Named("scmm")
+    OkHttpClient okHttpClient(HttpLoggingInterceptor loggingInterceptor, Configuration configuration) {
+        return new OkHttpClient.Builder()
+                .addInterceptor(new AuthorizationInterceptor(configuration.config.scmm['username'] as String, configuration.config.scmm['password'] as String))
+                .addInterceptor(loggingInterceptor)
+                .build()
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/destroy/ArgoCDDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/ArgoCDDestructionHandler.groovy
@@ -1,0 +1,100 @@
+package com.cloudogu.gitops.destroy
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.scmm.ScmmRepo
+import com.cloudogu.gitops.scmm.ScmmRepoProvider
+import com.cloudogu.gitops.utils.FileSystemUtils
+import com.cloudogu.gitops.utils.HelmClient
+import com.cloudogu.gitops.utils.K8sClient
+import jakarta.inject.Singleton
+
+import java.nio.file.Path
+
+@Singleton
+class ArgoCDDestructionHandler implements DestructionHandler {
+    private K8sClient k8sClient
+    private ScmmRepoProvider repoProvider
+    private HelmClient helmClient
+    private Configuration configuration
+    private FileSystemUtils fileSystemUtils
+
+    ArgoCDDestructionHandler(
+            Configuration configuration,
+            K8sClient k8sClient,
+            ScmmRepoProvider repoProvider,
+            HelmClient helmClient,
+            FileSystemUtils fileSystemUtils
+    ) {
+        this.k8sClient = k8sClient
+        this.repoProvider = repoProvider
+        this.helmClient = helmClient
+        this.configuration = configuration
+        this.fileSystemUtils = fileSystemUtils
+    }
+
+    @Override
+    void destroy() {
+
+        def repo = repoProvider.getRepo("argocd/argocd")
+        repo.cloneRepo()
+
+        for (def app in k8sClient.getCustomResource("app")) {
+            if (app.name == 'bootstrap' || app.name == 'argocd' || app.name == 'projects') {
+                // we don't want bootstrap to kill everything
+                // argocd and projects are needed for argocd to function and run finalizers
+                continue
+            }
+
+            k8sClient.patch(
+                    "app",
+                    app.name,
+                    app.namespace,
+                    'merge',
+                    [
+                            metadata: [
+                                    finalizers: [
+                                            "resources-finalizer.argocd.argoproj.io"
+                                    ]
+                            ]
+                    ]
+            )
+        }
+
+        List<Tuple2<String, String>> appsToBeDeleted = [
+                new Tuple2<String, String>("argocd", "bootstrap"), // first to prevent recreation
+                new Tuple2<String, String>("argocd", "cluster-resources"),
+                new Tuple2<String, String>("argocd", "example-apps"),
+        ]
+
+        for (def app in appsToBeDeleted) {
+            k8sClient.delete("app", app.v1, app.v2)
+        }
+
+        installArgoCDViaHelm(repo)
+        helmClient.uninstall('argocd')
+        for (def project in k8sClient.getCustomResource('appprojects')) {
+            k8sClient.delete("appproject", project.namespace, project.name)
+        }
+
+        k8sClient.delete("app", 'argocd', "projects")
+        k8sClient.delete("app", 'argocd', "argocd")
+
+        k8sClient.delete('secret', 'default', 'gitops-scmm')
+        k8sClient.delete('secret', 'default', 'jenkins-credentials')
+        k8sClient.delete('secret', 'default', 'argocd-repo-creds-scmm')
+    }
+
+    void installArgoCDViaHelm(ScmmRepo repo) {
+        // this is a hack to be able to uninstall using helm
+        def namePrefix = configuration.config.application['namePrefix']
+
+        // Install umbrella chart from folder
+        String umbrellaChartPath = Path.of(repo.getAbsoluteLocalRepoTmpDir(), 'argocd/')
+        // Even if the Chart.lock already contains the repo, we need to add it before resolving it
+        // See https://github.com/helm/helm/issues/8036#issuecomment-872502901
+        List helmDependencies = fileSystemUtils.readYaml(Path.of(umbrellaChartPath, 'Chart.yaml'))['dependencies']
+        helmClient.addRepo('argo', helmDependencies[0]['repository'] as String)
+        helmClient.dependencyBuild(umbrellaChartPath)
+        helmClient.upgrade('argocd', umbrellaChartPath, [namespace: "${namePrefix}argocd"])
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/destroy/ArgoCDDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/ArgoCDDestructionHandler.groovy
@@ -88,7 +88,7 @@ class ArgoCDDestructionHandler implements DestructionHandler {
 
     void installArgoCDViaHelm(ScmmRepo repo) {
         // this is a hack to be able to uninstall using helm
-        def namePrefix = configuration.config.application['namePrefix']
+        def namePrefix = configuration.getNamePrefix()
 
         // Install umbrella chart from folder
         String umbrellaChartPath = Path.of(repo.getAbsoluteLocalRepoTmpDir(), 'argocd/')

--- a/src/main/groovy/com/cloudogu/gitops/destroy/ArgoCDDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/ArgoCDDestructionHandler.groovy
@@ -6,11 +6,13 @@ import com.cloudogu.gitops.scmm.ScmmRepoProvider
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.cloudogu.gitops.utils.HelmClient
 import com.cloudogu.gitops.utils.K8sClient
+import io.micronaut.core.annotation.Order
 import jakarta.inject.Singleton
 
 import java.nio.file.Path
 
 @Singleton
+@Order(100)
 class ArgoCDDestructionHandler implements DestructionHandler {
     private K8sClient k8sClient
     private ScmmRepoProvider repoProvider
@@ -71,7 +73,7 @@ class ArgoCDDestructionHandler implements DestructionHandler {
         }
 
         installArgoCDViaHelm(repo)
-        helmClient.uninstall('argocd')
+        helmClient.uninstall('argocd', 'argocd')
         for (def project in k8sClient.getCustomResource('appprojects')) {
             k8sClient.delete("appproject", project.namespace, project.name)
         }

--- a/src/main/groovy/com/cloudogu/gitops/destroy/Destroyer.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/Destroyer.groovy
@@ -18,9 +18,7 @@ class Destroyer implements DestructionHandler {
         log.info("Start destroying")
         for (def handler in destructionHandlers) {
             log.info("Running handler $handler.class.simpleName")
-            if (handler instanceof JenkinsDestructionHandler) {
-                handler.destroy()
-            }
+            handler.destroy()
         }
         log.info("Finished destroying")
     }

--- a/src/main/groovy/com/cloudogu/gitops/destroy/Destroyer.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/Destroyer.groovy
@@ -18,7 +18,9 @@ class Destroyer implements DestructionHandler {
         log.info("Start destroying")
         for (def handler in destructionHandlers) {
             log.info("Running handler $handler.class.simpleName")
-            handler.destroy()
+            if (handler instanceof JenkinsDestructionHandler) {
+                handler.destroy()
+            }
         }
         log.info("Finished destroying")
     }

--- a/src/main/groovy/com/cloudogu/gitops/destroy/Destroyer.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/Destroyer.groovy
@@ -1,0 +1,25 @@
+package com.cloudogu.gitops.destroy
+
+import groovy.util.logging.Slf4j
+import jakarta.inject.Singleton
+
+@Singleton
+@Slf4j
+class Destroyer implements DestructionHandler {
+
+    private final List<DestructionHandler> destructionHandlers
+
+    Destroyer(List<DestructionHandler> destructionHandlers) {
+        this.destructionHandlers = destructionHandlers
+    }
+
+    @Override
+    void destroy() {
+        log.info("Start destroying")
+        for (def handler in destructionHandlers) {
+            log.info("Running handler $handler.class.simpleName")
+            handler.destroy()
+        }
+        log.info("Finished destroying")
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/destroy/DestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/DestructionHandler.groovy
@@ -1,0 +1,5 @@
+package com.cloudogu.gitops.destroy
+
+interface DestructionHandler {
+    void destroy()
+}

--- a/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
@@ -1,0 +1,30 @@
+package com.cloudogu.gitops.destroy
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.jenkins.GlobalPropertyManager
+import com.cloudogu.gitops.jenkins.JobManager
+import io.micronaut.core.annotation.Order
+import jakarta.inject.Singleton
+
+@Singleton
+@Order(300)
+class JenkinsDestructionHandler implements DestructionHandler {
+    private JobManager jobManager
+    private GlobalPropertyManager globalPropertyManager
+    private Configuration configuration
+
+    JenkinsDestructionHandler(JobManager jobManager, Configuration configuration, GlobalPropertyManager globalPropertyManager) {
+        this.jobManager = jobManager
+        this.configuration = configuration
+        this.globalPropertyManager = globalPropertyManager
+    }
+
+    @Override
+    void destroy() {
+        jobManager.deleteJob("${configuration.getNamePrefix()}example-apps")
+        globalPropertyManager.deleteGlobalProperty("SCMM_URL")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_URL")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PATH")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}K8S_VERSION")
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/destroy/ScmmDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/ScmmDestructionHandler.groovy
@@ -1,0 +1,64 @@
+package com.cloudogu.gitops.destroy
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.scmm.api.RepositoryApi
+import com.cloudogu.gitops.scmm.api.UsersApi
+import io.micronaut.core.annotation.Order
+import jakarta.inject.Singleton
+
+@Singleton
+@Order(200)
+class ScmmDestructionHandler implements DestructionHandler {
+    private UsersApi usersApi
+    private RepositoryApi repositoryApi
+    private Configuration configuration
+
+    ScmmDestructionHandler(
+            Configuration configuration,
+            UsersApi usersApi,
+            RepositoryApi repositoryApi
+    ) {
+        this.usersApi = usersApi
+        this.configuration = configuration
+        this.repositoryApi = repositoryApi
+    }
+
+    @Override
+    void destroy() {
+        deleteUser("gitops")
+        deleteRepository("argocd", "argocd")
+        deleteRepository("argocd", "cluster-resources")
+        deleteRepository("argocd", "example-apps")
+        deleteRepository("argocd", "nginx-helm-jenkins")
+        deleteRepository("argocd", "petclinic-plain")
+        deleteRepository("argocd", "petclinic-helm")
+        deleteRepository("exercises", "broken-application")
+        deleteRepository("exercises", "nginx-validation")
+        deleteRepository("exercises", "petclinic-helm")
+        deleteRepository("3rd-party-dependencies", "ces-build-lib", false)
+        deleteRepository("3rd-party-dependencies", "gitops-build-lib", false)
+        deleteRepository("3rd-party-dependencies", "spring-boot-helm-chart", false)
+        deleteRepository("3rd-party-dependencies", "spring-boot-helm-chart-with-dependency", false)
+    }
+
+    private void deleteRepository(String namespace, String repository, boolean prefixNamespace = true) {
+        def namePrefix = prefixNamespace ? getNamePrefix() : ''
+        def response = repositoryApi.delete("${namePrefix}$namespace", repository).execute()
+
+        if (response.code() != 204) {
+            throw new RuntimeException("Could not delete user $namespace/$repository (${response.code()} ${response.message()}): ${response.errorBody().string()}")
+        }
+    }
+
+    private void deleteUser(String name) {
+        def response = usersApi.delete("${getNamePrefix()}$name").execute()
+
+        if (response.code() != 204) {
+            throw new RuntimeException("Could not delete user $name (${response.code()} ${response.message()}): ${response.errorBody().string()}")
+        }
+    }
+
+    private String getNamePrefix() {
+        return configuration.config.application['namePrefix']
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/destroy/ScmmDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/ScmmDestructionHandler.groovy
@@ -59,6 +59,6 @@ class ScmmDestructionHandler implements DestructionHandler {
     }
 
     private String getNamePrefix() {
-        return configuration.config.application['namePrefix']
+        return configuration.getNamePrefix()
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/jenkins/GlobalPropertyManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/jenkins/GlobalPropertyManager.groovy
@@ -1,0 +1,36 @@
+package com.cloudogu.gitops.jenkins
+
+import jakarta.inject.Singleton
+import org.intellij.lang.annotations.Language
+
+@Singleton
+class GlobalPropertyManager {
+    private ApiClient apiClient
+
+    GlobalPropertyManager(ApiClient apiClient) {
+        this.apiClient = apiClient
+    }
+
+    void deleteGlobalProperty(String key) {
+        @Language("groovy")
+        def script = """
+            def instance = Jenkins.getInstance()
+            def globalNodeProperties = instance.getGlobalNodeProperties()
+            def envVarsNodePropertyList = globalNodeProperties.getAll(hudson.slaves.EnvironmentVariablesNodeProperty.class)
+            
+            if (envVarsNodePropertyList == null || envVarsNodePropertyList.size() == 0) {
+                print("Nothing to do")
+                return
+            }
+            
+            envVars = envVarsNodePropertyList.get(0).getEnvVars()            
+            envVars.remove("$key")
+            print("Done")
+        """
+
+        def result = apiClient.runScript(script)
+        if (result != 'Nothing to do' && result != 'Done') {
+            throw new RuntimeException("Could not delete global property: $result")
+        }
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/jenkins/JenkinsConfiguration.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/jenkins/JenkinsConfiguration.groovy
@@ -1,11 +1,11 @@
 package com.cloudogu.gitops.jenkins
 
-class Configuration {
+class JenkinsConfiguration {
     private final String url
     private final String username
     private final String password
 
-    Configuration(String url, String username, String password) {
+    JenkinsConfiguration(String url, String username, String password) {
         this.url = url
         this.username = username
         this.password = password

--- a/src/main/groovy/com/cloudogu/gitops/jenkins/JenkinsConfigurationAdapter.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/jenkins/JenkinsConfigurationAdapter.groovy
@@ -1,0 +1,15 @@
+package com.cloudogu.gitops.jenkins
+
+import com.cloudogu.gitops.config.Configuration
+import jakarta.inject.Singleton
+
+@Singleton
+class JenkinsConfigurationAdapter extends JenkinsConfiguration {
+    JenkinsConfigurationAdapter(Configuration configuration) {
+        super(
+                configuration.config.jenkins['url'] as String,
+                configuration.config.jenkins['username'] as String,
+                configuration.config.jenkins['password'] as String,
+        )
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/jenkins/JobManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/jenkins/JobManager.groovy
@@ -17,7 +17,7 @@ class JobManager {
         }
 
         @Language("groovy")
-        String script = "print(Jenkins.instance.getItem('$name').delete())"
+        String script = "print(Jenkins.instance.getItem('$name')?.delete())"
         def result = apiClient.runScript(script)
 
         if (result != 'null') {

--- a/src/main/groovy/com/cloudogu/gitops/jenkins/JobManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/jenkins/JobManager.groovy
@@ -1,0 +1,27 @@
+package com.cloudogu.gitops.jenkins
+
+import jakarta.inject.Singleton
+import org.intellij.lang.annotations.Language
+
+@Singleton
+class JobManager {
+    private ApiClient apiClient
+
+    JobManager(ApiClient apiClient) {
+        this.apiClient = apiClient
+    }
+
+    void deleteJob(String name) {
+        if (name.contains("'")) {
+            throw new RuntimeException('Job name cannot contain quotes.')
+        }
+
+        @Language("groovy")
+        String script = "print(Jenkins.instance.getItem('$name').delete())"
+        def result = apiClient.runScript(script)
+
+        if (result != 'null') {
+            throw new RuntimeException("Could not delete job $name")
+        }
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/scmm/api/AuthorizationInterceptor.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/scmm/api/AuthorizationInterceptor.groovy
@@ -1,0 +1,26 @@
+package com.cloudogu.gitops.scmm.api
+
+
+import okhttp3.Credentials
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.jetbrains.annotations.NotNull
+
+class AuthorizationInterceptor implements Interceptor {
+    private String username
+    private String password
+
+    AuthorizationInterceptor(String username, String password) {
+        this.username = username
+        this.password = password
+    }
+
+    @Override
+    Response intercept(@NotNull Chain chain) throws IOException {
+        def newRequest = chain.request().newBuilder()
+                .header("Authorization", Credentials.basic(username, password))
+                .build()
+
+        return chain.proceed(newRequest)
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/scmm/api/RepositoryApi.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/scmm/api/RepositoryApi.groovy
@@ -1,0 +1,11 @@
+package com.cloudogu.gitops.scmm.api
+
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.DELETE
+import retrofit2.http.Path
+
+interface RepositoryApi {
+    @DELETE("v2/repositories/{namespace}/{name}")
+    Call<ResponseBody> delete(@Path("namespace") String namespace, @Path("name") String name)
+}

--- a/src/main/groovy/com/cloudogu/gitops/scmm/api/UsersApi.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/scmm/api/UsersApi.groovy
@@ -1,0 +1,11 @@
+package com.cloudogu.gitops.scmm.api
+
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.DELETE
+import retrofit2.http.Path
+
+interface UsersApi {
+    @DELETE("v2/users/{id}")
+    Call<ResponseBody> delete(@Path("id") String id)
+}

--- a/src/main/groovy/com/cloudogu/gitops/utils/HelmClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/HelmClient.groovy
@@ -30,4 +30,10 @@ class HelmClient {
                 "${args.namespace? "--namespace ${args.namespace} " : ''}"
         commandExecutor.execute(command).stdOut
     }
+
+    String uninstall(String release) {
+        String[] command = ["helm", "uninstall", release]
+
+        commandExecutor.execute(command).stdOut
+    }
 }

--- a/src/main/groovy/com/cloudogu/gitops/utils/HelmClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/HelmClient.groovy
@@ -31,8 +31,8 @@ class HelmClient {
         commandExecutor.execute(command).stdOut
     }
 
-    String uninstall(String release) {
-        String[] command = ["helm", "uninstall", release]
+    String uninstall(String release, String namespace) {
+        String[] command = ["helm", "uninstall", release, '--namespace', namespace]
 
         commandExecutor.execute(command).stdOut
     }

--- a/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
@@ -1,6 +1,7 @@
 package com.cloudogu.gitops.utils
 
 import com.cloudogu.gitops.config.Configuration
+import groovy.transform.Immutable
 import groovy.util.logging.Slf4j
 import jakarta.inject.Provider
 import jakarta.inject.Singleton
@@ -8,7 +9,6 @@ import jakarta.inject.Singleton
 @Slf4j
 @Singleton
 class K8sClient {
-
     private CommandExecutor commandExecutor
     private FileSystemUtils fileSystemUtils
     private Provider<Configuration> configurationProvider
@@ -79,20 +79,21 @@ class K8sClient {
                         keyValues.collect { "${it.v1}=${it.v2}"}.join(' ')
         commandExecutor.execute(command)
     }
-    
-    void patch(String resource, String name, String namespace  = '', Map yaml) {
+
+    void patch(String resource, String name, String namespace  = '', String type = '', Map yaml) {
         // We're using a patch file here, instead of a patch JSON (--patch), because of quoting issues
         // ERROR c.c.gitops.utils.CommandExecutor - Stderr: error: unable to parse "'{\"stringData\":": yaml: found unexpected end of stream
         File patchYaml = File.createTempFile('gitops-playground-patch-yaml', '')
         fileSystemUtils.writeYaml(yaml, patchYaml)
-        
+
         //  kubectl patch secret argocd-secret -p '{"stringData": { "admin.password": "'"${bcryptArgoCDPassword}"'"}}' || true
         String command =
                 "kubectl patch ${resource} ${name}${namespace ? " -n ${getNamePrefix()}${namespace}" : ''}" +
+                        (type ? " --type=$type" : '')+
                         " --patch-file=${patchYaml.absolutePath}"
         commandExecutor.execute(command)
     }
-    
+
     void delete(String resource, String namespace  = '', Tuple2... selectors) {
         if (!selectors) {
             throw new RuntimeException("Missing selectors")
@@ -102,13 +103,46 @@ class K8sClient {
                 "kubectl delete ${resource}${namespace ? " -n ${getNamePrefix()}${namespace}" : ''}" +
                         ' --ignore-not-found=true ' + // Make idempotent
                         selectors.collect { "--selector=${it.v1}=${it.v2}"}.join(' ')
-        
+
         commandExecutor.execute(command)
+    }
+
+    void delete(String resource, String namespace, String name) {
+        String command =
+                "kubectl delete ${resource}${namespace ? " -n ${getNamePrefix()}${namespace}" : ''}" +
+                        " $name" +
+                        ' --ignore-not-found=true ' // Make idempotent
+
+        commandExecutor.execute(command)
+    }
+
+    List<CustomResource> getCustomResource(String resource) {
+        String[] command = ["kubectl", "get", resource, "-A", "-o", "jsonpath={range .items[*]}{.metadata.namespace}{','}{.metadata.name}{'\\n'}{end}"]
+        def result = commandExecutor.execute(command)
+
+        if (!result.stdOut) {
+            return []
+        }
+
+        result.stdOut.split("\n").collect {
+            def parts = it.split(",")
+
+            def prefix = getNamePrefix()
+            assert(parts[0].startsWith(prefix))
+
+            return new CustomResource(parts[0].substring(prefix.length()), parts[1])
+        }
     }
 
     private String getNamePrefix() {
         def config = configurationProvider.get().config
 
         return config.application['namePrefix'] as String
+    }
+
+    @Immutable
+    static class CustomResource {
+        String namespace
+        String name
     }
 }

--- a/src/main/resources/proxy-config.json
+++ b/src/main/resources/proxy-config.json
@@ -2,5 +2,7 @@
   ["java.util.function.Consumer"],
   ["java.util.function.Function"],
   ["java.util.function.Predicate"],
-  ["java.util.function.Supplier"]
+  ["java.util.function.Supplier"],
+  ["com.cloudogu.gitops.scmm.api.UsersApi"],
+  ["com.cloudogu.gitops.scmm.api.RepositoryApi"]
 ]

--- a/src/test/groovy/com/cloudogu/gitops/destroy/DestroyerDependencyInjectionTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/destroy/DestroyerDependencyInjectionTest.groovy
@@ -1,0 +1,24 @@
+package com.cloudogu.gitops.destroy
+
+import com.cloudogu.gitops.config.Configuration
+import io.micronaut.context.ApplicationContext
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+
+class DestroyerDependencyInjectionTest {
+    @Test
+    void 'can create bean'() {
+        def destroyer = ApplicationContext.run()
+                .registerSingleton(new Configuration([
+                        scmm: [
+                                url: 'http://localhost:9091/scm',
+                                username: 'admin',
+                                password: 'admin',
+                        ]
+                ]))
+                .getBean(Destroyer)
+
+        Assertions.assertThat(destroyer.destructionHandlers).hasSize(2)
+    }
+}

--- a/src/test/groovy/com/cloudogu/gitops/destroy/DestroyerDependencyInjectionTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/destroy/DestroyerDependencyInjectionTest.groovy
@@ -5,7 +5,6 @@ import io.micronaut.context.ApplicationContext
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 
-
 class DestroyerDependencyInjectionTest {
     @Test
     void 'can create bean'() {
@@ -15,10 +14,15 @@ class DestroyerDependencyInjectionTest {
                                 url: 'http://localhost:9091/scm',
                                 username: 'admin',
                                 password: 'admin',
+                        ],
+                        jenkins: [
+                                url: 'http://localhost:9090',
+                                username: 'admin',
+                                password: 'admin',
                         ]
                 ]))
                 .getBean(Destroyer)
 
-        Assertions.assertThat(destroyer.destructionHandlers).hasSize(2)
+        Assertions.assertThat(destroyer.destructionHandlers).hasSize(3)
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/destroy/ScmmDestructionHandlerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/destroy/ScmmDestructionHandlerTest.groovy
@@ -1,0 +1,52 @@
+package com.cloudogu.gitops.destroy
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.scmm.api.RepositoryApi
+import com.cloudogu.gitops.scmm.api.UsersApi
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Retrofit
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class ScmmDestructionHandlerTest {
+
+    private Retrofit retrofit
+    private MockWebServer mockWebServer
+
+    @BeforeEach
+    void setUp() {
+        mockWebServer = new MockWebServer()
+        retrofit = new Retrofit.Builder()
+                .baseUrl(mockWebServer.url(""))
+                .build()
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    void 'destroys all'() {
+        def destructionHandler = new ScmmDestructionHandler(new Configuration([application: [namePrefix: 'foo-']]), retrofit.create(UsersApi), retrofit.create(RepositoryApi))
+
+        for (def i = 0; i < 1 /* user */ + 13 /* repositories */; i++) {
+            mockWebServer.enqueue(new MockResponse().setResponseCode(204))
+        }
+        destructionHandler.destroy()
+
+        def request = mockWebServer.takeRequest()
+        assertThat(request.requestUrl.encodedPath()).isEqualTo("/v2/users/foo-gitops")
+        assertThat(request.method).isEqualTo("DELETE")
+
+        for (def i = 0; i < 13; ++i) {
+            request = mockWebServer.takeRequest()
+            assertThat(request.method).isEqualTo("DELETE")
+            assertThat(request.requestUrl.encodedPath()).matches(~/^\/v2\/repositories\/.*\/.*$/)
+        }
+    }
+}

--- a/src/test/groovy/com/cloudogu/gitops/jenkins/JobManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/jenkins/JobManagerTest.groovy
@@ -1,0 +1,30 @@
+package com.cloudogu.gitops.jenkins
+
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.shouldFail
+import static org.mockito.ArgumentMatchers.anyString
+import static org.mockito.Mockito.*
+
+class JobManagerTest {
+    @Test
+    void 'throws when job contains invalid characters'() {
+        def client = mock(ApiClient)
+        def jobManager = new JobManager(client)
+
+        shouldFail(RuntimeException) {
+            jobManager.deleteJob("foo'foo")
+        }
+    }
+
+    @Test
+    void 'deletes job'() {
+        def client = mock(ApiClient)
+        def jobManager = new JobManager(client)
+
+        when(client.runScript(anyString())).thenReturn("null")
+        jobManager.deleteJob("foo")
+
+        verify(client).runScript("print(Jenkins.instance.getItem('foo')?.delete())")
+    }
+}

--- a/src/test/groovy/com/cloudogu/gitops/utils/CommandExecutorForTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/CommandExecutorForTest.groovy
@@ -21,4 +21,9 @@ class CommandExecutorForTest extends CommandExecutor {
     protected Process doExecute(String command) {
         return mock(Process)
     }
+
+    @Override
+    protected Process doExecute(String[] command) {
+        return mock(Process)
+    }
 }

--- a/src/test/groovy/com/cloudogu/gitops/utils/CommandExecutorForTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/CommandExecutorForTest.groovy
@@ -3,11 +3,18 @@ import static org.mockito.Mockito.mock
 
 class CommandExecutorForTest extends CommandExecutor {
     List<String> actualCommands = []
+
+    Queue<Output> outputs = new LinkedList<Output>()
+
+    void enqueueOutput(Output output) {
+        outputs.add(output)
+    }
     
     @Override
     protected Output getOutput(Process proc, String command, boolean failOnError) {
         actualCommands += command
-        return new Output('', '', 0)
+
+        return outputs.poll() ?: new Output('', '', 0)
     }
 
     @Override

--- a/src/test/groovy/com/cloudogu/gitops/utils/HelmClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/HelmClientTest.groovy
@@ -1,0 +1,30 @@
+package com.cloudogu.gitops.utils
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class HelmClientTest {
+    @Test
+    void 'assembles parameters for upgrade'() {
+        def commandExecutor = new CommandExecutorForTest()
+        new HelmClient(commandExecutor).upgrade("the-release", "path/to/chart", [
+                version: 'the-version',
+                namespace: 'the-namespace',
+                values: 'values.yaml',
+        ])
+        new HelmClient(commandExecutor).upgrade("the-release", "path/to/chart", [:])
+        new HelmClient(commandExecutor).upgrade("the-release", "path/to/chart", [namespace: 'the-namespace'])
+
+        Assertions.assertThat(commandExecutor.actualCommands[0]).isEqualTo('helm upgrade -i the-release path/to/chart --version the-version --values values.yaml --namespace the-namespace ')
+        Assertions.assertThat(commandExecutor.actualCommands[1]).isEqualTo('helm upgrade -i the-release path/to/chart ')
+        Assertions.assertThat(commandExecutor.actualCommands[2]).isEqualTo('helm upgrade -i the-release path/to/chart --namespace the-namespace ')
+    }
+
+    @Test
+    void 'assembles parameters for uninstall'() {
+        def commandExecutor = new CommandExecutorForTest()
+        new HelmClient(commandExecutor).uninstall("the-release")
+
+        Assertions.assertThat(commandExecutor.actualCommands[0]).isEqualTo('helm uninstall the-release')
+    }
+}

--- a/src/test/groovy/com/cloudogu/gitops/utils/HelmClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/HelmClientTest.groovy
@@ -23,8 +23,8 @@ class HelmClientTest {
     @Test
     void 'assembles parameters for uninstall'() {
         def commandExecutor = new CommandExecutorForTest()
-        new HelmClient(commandExecutor).uninstall("the-release")
+        new HelmClient(commandExecutor).uninstall("the-release", 'the-namespace')
 
-        Assertions.assertThat(commandExecutor.actualCommands[0]).isEqualTo('helm uninstall the-release')
+        Assertions.assertThat(commandExecutor.actualCommands[0]).isEqualTo('helm uninstall the-release --namespace the-namespace')
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
@@ -111,6 +111,13 @@ class K8sClientTest {
     }
 
     @Test
+    void 'Patches with type merge'() {
+        k8sClient.patch('secret', 'my-secret', '', 'merge', [a: 'b'])
+
+        assertThat(commandExecutor.actualCommands[0]).startsWith("kubectl patch secret my-secret --type=merge --patch-file=")
+    }
+
+    @Test
     void 'Deletes'() {
         k8sClient.delete('secret', 'my-ns',
                 new Tuple2('key1', 'value1'), new Tuple2('key2', 'value2'))
@@ -133,6 +140,14 @@ class K8sClientTest {
         shouldFail(RuntimeException) {
             k8sClient.delete('secret')
         }
+    }
+
+    @Test
+    void 'Gets custom resources with name prefix'() {
+        commandExecutor.enqueueOutput(new CommandExecutor.Output('', "foo-namespace,name\nfoo-namespace2,name2", 0))
+        def result = k8sClient.getCustomResource('foo')
+
+        assertThat(result).isEqualTo([new K8sClient.CustomResource('namespace', 'name'), new K8sClient.CustomResource('namespace2', 'name2')])
     }
     
 


### PR DESCRIPTION
We want to be able to quickly demo the application and destruct it afterwards without destroying the cluster.
Furthermore, we want to be able to unroll changes to the SCM-Manager and Jenkins that might be outside of our cluster (e.g. in a Cloudogu EcoSystem).

We add a command line parameter `--destroy` that can be used in conjunction with the other configuration parameters. 
The script will then unroll changes based on the given configuration (e.g. `--name-prefix`).