### PR TITLE
Remove workaround for curl 8.2.0 

### DIFF
--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -95,7 +95,7 @@ grafana:
   env:
     GF_SMTP_ENABLED: true
     GF_SMTP_FROM_ADDRESS: grafana-alerts@cloudogu.com
-    GF_SMTP_HOST: mailhog.monitoring.svc.cluster.local:1025
+    GF_SMTP_HOST: mailhog.${namePrefix}monitoring.svc.cluster.local:1025
 
   resources:
     limits:


### PR DESCRIPTION
A bug in curl (https://github.com/curl/curl/issues/11486) broke the
jenkins plugin installation. We introduced a workaround in https://github.com/cloudogu/gitops-playground/commit/16300dea3434313840533257838728e3b8aeddae.

A fix for curl is released and we can remove the workaround now.