### PR TITLE
Fix path to SCM-Manager in prometheus scrape config

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
@@ -108,7 +108,7 @@ class PrometheusStack extends Feature {
         String host = 'scmm-scm-manager.default.svc.cluster.local'
         String path = '/scm/api/v2/metrics/prometheus'
         if (!config.scmm['internal']) {
-            URI uri = new URI((config.scmm['url'] as String) + path)
+            URI uri = new URI((config.scmm['url'] as String) + '/api/v2/metrics/prometheus')
             protocol = uri.scheme
             host = uri.authority
             path = uri.path

--- a/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
@@ -87,13 +87,13 @@ class PrometheusStackTest {
     @Test
     void 'uses remote scmm url if requested'() {
         config.scmm["internal"] = false
-        config.scmm["url"] = 'https://localhost:9091/prefix'
+        config.scmm["url"] = 'https://localhost:9091/scm'
         createStack().install()
 
 
         def additionalScrapeConfigs = parseActualStackYaml()['prometheus']['prometheusSpec']['additionalScrapeConfigs'] as List
         assertThat(((additionalScrapeConfigs[0]['static_configs'] as List)[0]['targets'] as List)[0]).isEqualTo('localhost:9091')
-        assertThat(additionalScrapeConfigs[0]['metrics_path']).isEqualTo('/prefix/scm/api/v2/metrics/prometheus')
+        assertThat(additionalScrapeConfigs[0]['metrics_path']).isEqualTo('/scm/api/v2/metrics/prometheus')
         assertThat(additionalScrapeConfigs[0]['scheme']).isEqualTo('https')
 
         // scrape config for jenkins is unchanged


### PR DESCRIPTION
We missed that we set the path including the /scm prefix. Therefore, we must not prepend the path to the prometheus endpoint with /scm.

This is different to Jenkins. Jenkins runs without a path prefix.