### PR TITLE
Fix using --insecure and --argocd

### DIFF
--- a/argocd/argocd/argocd/values.ftl.yaml
+++ b/argocd/argocd/argocd/values.ftl.yaml
@@ -50,18 +50,23 @@ argo-cd:
       argocd:
         name: argocd
         url: ${scmm.baseUrl}/repo/${namePrefix}argocd/argocd
+        <#if isInsecure>insecure: "true"</#if>
       example-apps:
         name: example-apps
         url: ${scmm.baseUrl}/repo/${namePrefix}argocd/example-apps
+        <#if isInsecure>insecure: "true"</#if>
       cluster-resources:
         name: cluster-resources
         url: ${scmm.baseUrl}/repo/${namePrefix}argocd/cluster-resources
+        <#if isInsecure>insecure: "true"</#if>
       nginx-helm-jenkins:
         name: nginx-helm-jenkins
         url: ${scmm.baseUrl}/repo/${namePrefix}argocd/nginx-helm-jenkins
+        <#if isInsecure>insecure: "true"</#if>
       nginx-helm-umbrella:
         name: nginx-helm-umbrella
         url: ${scmm.baseUrl}/repo/${namePrefix}argocd/nginx-helm-umbrella
+        <#if isInsecure>insecure: "true"</#if>
       bitnami:
         name: bitnami
         type: helm

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -261,7 +261,7 @@ class ArgoCD extends Feature {
         k8sClient.createSecret('generic', repoTemplateSecretName, 'argocd',
                 new Tuple2('url', scmmUrlForArgoCD),
                 new Tuple2('username', "${namePrefix}gitops"),
-                new Tuple2('password', password)
+                new Tuple2('password', config.scmm['password'])
         )
         k8sClient.label('secret', repoTemplateSecretName,'argocd',
                 new Tuple2(' argocd.argoproj.io/secret-type', 'repo-creds'))
@@ -365,6 +365,7 @@ class ArgoCD extends Feature {
                     namePrefixForEnvVars: config.application['namePrefixForEnvVars'] as String,
                     images: config.images,
                     isRemote: config.application['remote'],
+                    isInsecure: config.application['insecure'],
                     secrets: [
                             active: config.features['secrets']['active']
                     ],


### PR DESCRIPTION
We were not respecting the --insecure flag in Argo CD. As a result, Argo CD would not talk to SCM-Manager and would fail with the following error:

rpc error: code = Unknown desc = Get "https://something/scm/repo/argocd/argocd/info/refs?service=git-upload-pack": x509: certificate signed by unknown authority