### PR TITLE
Fix starting grafana when using Azure Gatekeeper

### DIFF
--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -71,7 +71,11 @@ grafana:
   service:
     type: NodePort
     nodePort: "9095"
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
   sidecar:
+    securityContext:
+      allowPrivilegeEscalation: false
     dashboards:
       #this needs to be added so that the label will become 'label: grafana_dashboards: "1"'
       labelValue: 1


### PR DESCRIPTION
There are policies within azure that deny containers that run as a non-default user when `allowPrivilegeEscalation` was not set. https://store.policy.core.windows.net/kubernetes/container-no-privilege-escalation/v3/template.yaml