### PR TITLE
Fix specifying protocol for ingress urls

### DIFF
--- a/applications/cluster-resources/mailhog-helm-values.ftl.yaml
+++ b/applications/cluster-resources/mailhog-helm-values.ftl.yaml
@@ -17,11 +17,11 @@ resources:
     memory: 10Mi
     cpu: 20m
 
-<#if mail.url?has_content>
+<#if mail.url??>
 ingress:
   enabled: true
   hosts:
-    - host: ${mail.url}
+    - host: ${mail.url.host}
       paths:
         - path: "/"
           pathType: Prefix

--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -71,10 +71,10 @@ grafana:
   service:
     type: NodePort
     nodePort: "9095"
-<#if monitoring.grafana.url?has_content>
+<#if monitoring.grafana.url??>
   ingress:
     enabled: true
-    hosts: [${monitoring.grafana.url}]
+    hosts: [${monitoring.grafana.url.host}]
 </#if>
   containerSecurityContext:
     allowPrivilegeEscalation: false

--- a/argocd/argocd/argocd/values.ftl.yaml
+++ b/argocd/argocd/argocd/values.ftl.yaml
@@ -2,10 +2,10 @@
 argo-cd:
 
   server:
-<#if argocd.url?has_content>
+<#if argocd.host?has_content>
     ingress:
       enabled: true
-      hosts: [${argocd.url}]
+      hosts: [${argocd.host}]
 </#if>
 
     service:

--- a/src/main/groovy/com/cloudogu/gitops/features/Mailhog.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Mailhog.groovy
@@ -45,7 +45,7 @@ class Mailhog extends Feature {
         String bcryptMailhogPassword = BCrypt.hashpw(password, BCrypt.gensalt(4))
         def tmpHelmValues = new TemplatingEngine().replaceTemplate(fileSystemUtils.copyToTempDir(HELM_VALUES_PATH).toFile(), [
                 mail: [
-                        url: config.features['mail']['url']
+                        url: config.features['mail']['url'] ? new URL(config.features['mail']['url'] as String) : null
                 ],
                 isRemote: config.application['remote'],
                 username: username,

--- a/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
@@ -51,7 +51,7 @@ class PrometheusStack extends Feature {
                 namePrefix: namePrefix,
                 monitoring: [
                         grafana: [
-                                url: config.features['monitoring']['grafanaUrl']
+                                url: config.features['monitoring']['grafanaUrl'] ? new URL(config.features['monitoring']['grafanaUrl'] as String) : null,
                         ]
                 ],
                 scmm: getScmmConfiguration(),

--- a/src/main/groovy/com/cloudogu/gitops/features/Vault.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Vault.groovy
@@ -3,16 +3,11 @@ package com.cloudogu.gitops.features
 import com.cloudogu.gitops.Feature
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.features.deployment.DeploymentStrategy
-import com.cloudogu.gitops.utils.DockerImageParser
-import com.cloudogu.gitops.utils.FileSystemUtils
-import com.cloudogu.gitops.utils.K8sClient
-import com.cloudogu.gitops.utils.MapUtils
-import com.cloudogu.gitops.utils.TemplatingEngine
+import com.cloudogu.gitops.utils.*
 import groovy.util.logging.Slf4j
 import io.micronaut.core.annotation.Order
 import jakarta.inject.Singleton
 
-import java.nio.file.Files
 import java.nio.file.Path
 
 @Slf4j
@@ -83,12 +78,13 @@ class Vault extends Feature {
         }
 
         if (config.features['secrets']['vault']['url']) {
+            def url = new URL(config.features['secrets']['vault']['url'] as String)
             MapUtils.deepMerge([
                    server: [
                            ingress: [
                                    enabled: true,
                                    hosts: [
-                                           [host: config.features['secrets']['vault']['url']],
+                                           [host: url.host],
                                    ],
                            ]
                    ]

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -300,7 +300,6 @@ class ArgoCD extends Feature {
                     isRemote            : config.application['remote'],
                     isInsecure          : config.application['insecure'],
                     argocd              : [
-                            url: config.features['argocd']['url'] ? new URL(config.features['argocd']['url'] as String) : null,
                             host: config.features['argocd']['url'] ? new URL(config.features['argocd']['url'] as String).host : "",
                     ],
                     monitoring          : [

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -300,17 +300,18 @@ class ArgoCD extends Feature {
                     isRemote            : config.application['remote'],
                     isInsecure          : config.application['insecure'],
                     argocd              : [
-                            url: config.features['argocd']['url'],
+                            url: config.features['argocd']['url'] ? new URL(config.features['argocd']['url'] as String) : null,
+                            host: config.features['argocd']['url'] ? new URL(config.features['argocd']['url'] as String).host : "",
                     ],
                     monitoring          : [
                             grafana: [
-                                    url: config.features['monitoring']['grafanaUrl']
+                                    url: config.features['monitoring']['grafanaUrl'] ? new URL(config.features['monitoring']['grafanaUrl'] as String) : null,
                             ]
                     ],
                     secrets             : [
                             active: config.features['secrets']['active'],
                             vault : [
-                                    url: config.features['secrets']['vault']['url'],
+                                    url: config.features['secrets']['vault']['url'] ? new URL(config.features['secrets']['vault']['url'] as String) : null,
                             ],
                     ],
                     scmm                : [

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -300,6 +300,9 @@ class ArgoCD extends Feature {
                     isRemote            : config.application['remote'],
                     isInsecure          : config.application['insecure'],
                     argocd              : [
+                            // We extract the host directly here (instead of passing in the URL object), because 
+                            // Freemarker reports "argocd.url.host" as null or missing, even thoug it's there. 
+                            // See discussion on #149
                             host: config.features['argocd']['url'] ? new URL(config.features['argocd']['url'] as String).host : "",
                     ],
                     monitoring          : [

--- a/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
@@ -72,7 +72,7 @@ class MailhogTest {
 
     @Test
     void 'uses ingress if enabled'() {
-        config.features['mail']['url'] = 'mailhog.local'
+        config.features['mail']['url'] = 'http://mailhog.local'
         createMailhog().install()
 
         def ingressYaml = parseActualYaml()['ingress']

--- a/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
@@ -87,7 +87,7 @@ class PrometheusStackTest {
 
     @Test
     void 'uses ingress if enabled'() {
-        config['features']['monitoring']['grafanaUrl'] = 'grafana.local'
+        config['features']['monitoring']['grafanaUrl'] = 'http://grafana.local'
         createStack().install()
 
 

--- a/src/test/groovy/com/cloudogu/gitops/features/VaultTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/VaultTest.groovy
@@ -79,7 +79,7 @@ class VaultTest {
 
     @Test
     void 'uses ingress if enabled'() {
-        config['features']['secrets']['vault']['url'] = 'vault.local'
+        config['features']['secrets']['vault']['url'] = 'http://vault.local'
         createVault().install()
 
 

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -158,7 +158,7 @@ class ArgoCDTest {
         assertThat(valuesYaml['argo-cd']['server']['service']['type']).isEqualTo('LoadBalancer')
         assertThat(valuesYaml['argo-cd']['notifications']['argocdUrl']).isEqualTo( 'https://argo.cd')
         assertThat(valuesYaml['argo-cd']['server']['ingress']['enabled']).isEqualTo(true)
-        assertThat((valuesYaml['argo-cd']['server']['ingress']['hosts'] as List)[0]).isEqualTo('https://argo.cd')
+        assertThat((valuesYaml['argo-cd']['server']['ingress']['hosts'] as List)[0]).isEqualTo('argo.cd')
     }
 
     @Test


### PR DESCRIPTION
In #147 we implemented ingresses for all applications. The parameter --argocd-url was already used beforehand for urls in notifications.
In #147 we mistakenly assumed that the url would only include the hostname without protocol or paths.
Here, we fix this by parsing the URL and extracting the host for the ingress configuration.