### PR TITLE
Retry HTTP request when socket times out

### DIFF
--- a/src/test/groovy/com/cloudogu/gitops/okhttp/RetryInterceptorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/okhttp/RetryInterceptorTest.groovy
@@ -4,6 +4,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -46,6 +47,21 @@ class RetryInterceptorTest {
     }
 
     @Test
+    void 'retries on timeout'() {
+        def timeoutResponse = new MockResponse()
+        timeoutResponse.socketPolicy(SocketPolicy.NO_RESPONSE)
+        webServer.enqueue(timeoutResponse)
+        webServer.enqueue(new MockResponse().setResponseCode(200).setBody("Successful Result"))
+
+        def client = createClient()
+
+        def response = client.newCall(new Request.Builder().url(webServer.url("")).build()).execute()
+
+        assertThat(response.body().string()).isEqualTo("Successful Result")
+        assertThat(webServer.requestCount).isEqualTo(2)
+    }
+
+    @Test
     void 'fails after third retry'() {
         webServer.enqueue(new MockResponse().setResponseCode(500))
         webServer.enqueue(new MockResponse().setResponseCode(500))
@@ -65,6 +81,7 @@ class RetryInterceptorTest {
     private OkHttpClient createClient() {
         new OkHttpClient.Builder()
                 .addInterceptor(new RetryInterceptor(retries: 3, waitPeriodInMs: 0))
+                .readTimeout(50, TimeUnit.MILLISECONDS)
                 .build()
     }
 }


### PR DESCRIPTION
We observed socket timeouts during jenkins restarts, especially when the host has high load. As a countermeasure, we retry these cases.