### PR TITLE
Improved retrying for invalid jenkins crumbs

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/dependencyinjection/RetrofitFactory.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/dependencyinjection/RetrofitFactory.groovy
@@ -1,6 +1,7 @@
 package com.cloudogu.gitops.dependencyinjection
 
 import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.okhttp.RetryInterceptor
 import com.cloudogu.gitops.scmm.api.AuthorizationInterceptor
 import com.cloudogu.gitops.scmm.api.RepositoryApi
 import com.cloudogu.gitops.scmm.api.UsersApi
@@ -38,6 +39,7 @@ class RetrofitFactory {
         def builder = new OkHttpClient.Builder()
                 .addInterceptor(new AuthorizationInterceptor(configuration.config.scmm['username'] as String, configuration.config.scmm['password'] as String))
                 .addInterceptor(loggingInterceptor)
+                .addInterceptor(new RetryInterceptor())
 
         if (configuration.config.application['insecure']) {
             def context = insecureSslContext.get()

--- a/src/main/groovy/com/cloudogu/gitops/jenkins/ApiClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/jenkins/ApiClient.groovy
@@ -80,6 +80,7 @@ class ApiClient {
     }
 
     // We pass a closure, so that we actually refetch a new crumb for a failed request
+    // The Jenkins ApiClient has it's own retry logic on top of RetryInterceptor, because of crumb lifetime and restarts
     private Response sendRequestWithRetries(Closure<Request> request) {
         def retry = 0
         Response response = null

--- a/src/main/groovy/com/cloudogu/gitops/jenkins/JobManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/jenkins/JobManager.groovy
@@ -14,7 +14,7 @@ class JobManager {
     }
 
     void createCredential(String jobName, String id, String username, String password, String description) {
-        def response = apiClient.sendRequest(
+        def response = apiClient.sendRequestWithCrumb(
                 "job/$jobName/credentials/store/folder/domain/_/createCredentials",
                 new FormBody.Builder()
                         .add("json", JsonOutput.toJson([

--- a/src/main/groovy/com/cloudogu/gitops/okhttp/RetryInterceptor.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/okhttp/RetryInterceptor.groovy
@@ -55,9 +55,6 @@ class RetryInterceptor implements Interceptor {
             502, // Bad Gateway
             503, // Service Unavailable
             504, // Gateway Timeout
-            // additional codes that could be temporary in e.g. Jenkins
-            401, // Unauthorized
-            403, // Forbidden
         ]
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/jenkins/ApiClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/jenkins/ApiClientTest.groovy
@@ -148,7 +148,7 @@ class ApiClientTest {
     }
 
     @Test
-    void 'retries max 3 times on invalid crumb'() {
+    void 'retries on invalid crumb are limited'() {
         webServer.setDispatcher { request ->
             switch (request.path) {
                 case "/jenkins/crumbIssuer/api/json":

--- a/src/test/groovy/com/cloudogu/gitops/okhttp/RetryInterceptorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/okhttp/RetryInterceptorTest.groovy
@@ -34,19 +34,6 @@ class RetryInterceptorTest {
     }
 
     @Test
-    void 'retries on 401 and 403'() {
-        webServer.enqueue(new MockResponse().setResponseCode(401))
-        webServer.enqueue(new MockResponse().setResponseCode(403))
-        webServer.enqueue(new MockResponse().setResponseCode(200).setBody("Successful Result"))
-
-        def client = createClient()
-
-        def response = client.newCall(new Request.Builder().url(webServer.url("")).build()).execute()
-
-        assertThat(response.body().string()).isEqualTo("Successful Result")
-    }
-
-    @Test
     void 'retries on timeout'() {
         def timeoutResponse = new MockResponse()
         timeoutResponse.socketPolicy(SocketPolicy.NO_RESPONSE)


### PR DESCRIPTION
We were running into an issue where jenkins was restarted after we fetched a crumb but before we used that crumb.

1. Fetch crumb
2. Restart Jenkins
3. Use crumb e.g. in /scriptText

Due to the restart, the crumb is invalid (either due to the crumb itself or the associated session).
The previous handling would then retry the /scriptText request without refreshing the crumb.

We changed the behaviour in the following responsibilities:

1. RetryInterceptor is responsible for retrying HTTP level issues (e.g. status codes or timeouts)
2. ApiClient is responsible for application (aka Jenkins) level issues (i.e. HTTP status code 401 or 403 during restarts or invalid crumbs)

As a result, we don't leak special cases for Jenkins into the RetryInterceptor anymore and it can be used for SCMM APIs as well.