### PR TITLE
k3d: Upgrade to 5.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,6 +224,7 @@ def scanForAllVulns(String imageName, String fileName){
 def startK3d(clusterName) {
     sh "mkdir -p ${WORKSPACE}/.k3d/bin"
 
+    
     withEnv(["HOME=${WORKSPACE}", "PATH=${WORKSPACE}/.k3d/bin:${PATH}"]) { // Make k3d write kubeconfig to WORKSPACE
         // Install k3d binary to workspace in order to avoid concurrency issues
         sh "if ! command -v k3d >/dev/null 2>&1; then " +
@@ -231,6 +232,7 @@ def startK3d(clusterName) {
                 'TAG=v$(sed -n "s/^K3D_VERSION=//p" scripts/init-cluster.sh) ' +
                 "K3D_INSTALL_DIR=${WORKSPACE}/.k3d/bin " +
                 'bash -s -- --no-sudo; fi'
+        
         sh "yes | ./scripts/init-cluster.sh --cluster-name=${clusterName} --bind-localhost=false"
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,8 +172,10 @@ node('high-cpu') {
 
             if (clusterName) {
                 // Don't fail build if cleaning up fails
-                withEnv(["PATH=${WORKSPACE}/.k3d/bin:${PATH}"]) {
-                    sh "k3d cluster delete ${clusterName} || true"
+                withEnv(["PATH=${WORKSPACE}/.local/bin:${PATH}"]) {
+                    sh "if k3d cluster ls ${clusterName} > /dev/null; " +
+                            "then k3d cluster delete ${clusterName}; " +
+                        "fi"
                 }
             }
         }
@@ -222,17 +224,8 @@ def scanForAllVulns(String imageName, String fileName){
 }
 
 def startK3d(clusterName) {
-    sh "mkdir -p ${WORKSPACE}/.k3d/bin"
-
-    
-    withEnv(["HOME=${WORKSPACE}", "PATH=${WORKSPACE}/.k3d/bin:${PATH}"]) { // Make k3d write kubeconfig to WORKSPACE
-        // Install k3d binary to workspace in order to avoid concurrency issues
-        sh "if ! command -v k3d >/dev/null 2>&1; then " +
-                "curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh |" +
-                'TAG=v$(sed -n "s/^K3D_VERSION=//p" scripts/init-cluster.sh) ' +
-                "K3D_INSTALL_DIR=${WORKSPACE}/.k3d/bin " +
-                'bash -s -- --no-sudo; fi'
-        
+    // Install k3d to WORSKPACE and make k3d write kubeconfig to WORKSPACE
+    withEnv(["HOME=${WORKSPACE}"]) {
         sh "yes | ./scripts/init-cluster.sh --cluster-name=${clusterName} --bind-localhost=false"
     }
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can run a local k8s cluster with the GitOps playground installed with only o
 bash <(curl -s \
   https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh) \
   && sleep 2 && docker run --rm -it --pull=always -u $(id -u) \
-    -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
+    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
     --net=host \
     ghcr.io/cloudogu/gitops-playground --yes --argocd
 ```
@@ -147,7 +147,7 @@ k3d's kubeconfig.
 CLUSTER_NAME=gitops-playground
 docker pull ghcr.io/cloudogu/gitops-playground
 docker run --rm -it -u $(id -u) \
-  -v ~/.k3d/kubeconfig-${CLUSTER_NAME}.yaml:/home/.kube/config \
+  -v ~/.config/k3d/kubeconfig-${CLUSTER_NAME}.yaml:/home/.kube/config \
   --net=host \
   ghcr.io/cloudogu/gitops-playground # additional parameters go here
 ``` 
@@ -221,7 +221,7 @@ The config file is not yet a complete replacement for CLI parameters.
 
 ```bash
 docker run --rm -it --pull=always -u $(id -u) \
-    -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
+    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
     -v $(pwd)/gitops-playground.yaml:/config/gitops-playground.yaml \
     --net=host \
     ghcr.io/cloudogu/gitops-playground --yes --argocd --config-file=/config/gitops-playground.yaml

--- a/docker-registry/values.yaml
+++ b/docker-registry/values.yaml
@@ -1,8 +1,0 @@
-service:
-  # We need a hostPort in order to work around our builds running on the host's docker daemon.
-  # So here, a ClusterIP is not enough
-  port: 30000
-  nodePort: 30000
-  # Registry runs without auth, so don't expose as LB!
-  type: NodePort
-

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -84,7 +84,7 @@ Jenkins.instance.pluginManager.activePlugins.each {
   * Build and run dev Container:
     ```shell
     docker buildx build -t gitops-playground:dev --build-arg ENV=dev  --progress=plain .
-    docker run --rm -it -u $(id -u) -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
+    docker run --rm -it -u $(id -u) -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
       --net=host gitops-playground:dev <params>
      ```
   * Locally:
@@ -351,13 +351,13 @@ K3D_NODE=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{
 helm upgrade  -i my-harbor harbor/harbor -f harbor-values.yaml --version 1.12.2 --namespace harbor --set externalURL=http://$K3D_NODE:30002 --create-namespace
 ```
 
-Keep kubectl working when airgapped by setting the local IP of the container inside kubeconfig in `~/.k3d/...`
+Keep kubectl working when airgapped by setting the local IP of the container inside kubeconfig in `~/.config/k3d/...`
 ```bash
-sed -i -r 's/0.0.0.0([^0-9]+[0-9]*|\$)/${K3D_NODE}:6443/g' ~/.k3d/kubeconfig-airgapped-playground.yaml
+sed -i -r 's/0.0.0.0([^0-9]+[0-9]*|\$)/${K3D_NODE}:6443/g' ~/.config/k3d/kubeconfig-airgapped-playground.yaml
 ```
 You can switching to the airgapped context in your current shell like so:
 ```shell
-export KUBECONFIG=$HOME/.k3d/kubeconfig-airgapped-playground.yaml
+export KUBECONFIG=$HOME/.config/k3d/kubeconfig-airgapped-playground.yaml
 ```
 
 TODO also replace in `~/.kube/config` for more convenience. 
@@ -385,7 +385,7 @@ BASIC_SRC_IMAGES=$(
 BASIC_DST_IMAGES=''
 
 # Switch context to airgapped cluster here, e.g.
-export KUBECONFIG=$HOME/.k3d/kubeconfig-airgapped-playground.yaml
+export KUBECONFIG=$HOME/.config/k3d/kubeconfig-airgapped-playground.yaml
 
 while IFS= read -r image; do
   local dstImage=$K3D_NODE:30002/library/${image##*/}
@@ -415,7 +415,7 @@ Don't disconnect from the internet yet, because
 So, start the installation and once Argo CD is running, go offline.
 ```bash
 docker run -it -u $(id -u) \
-    -v ~/.k3d/kubeconfig-airgapped-playground.yaml:/home/.kube/config \
+    -v ~/.config/k3d/kubeconfig-airgapped-playground.yaml:/home/.kube/config \
     --net=host gitops-playground:dev --argocd --yes -x \
       --vault=dev --metrics \
       --grafana-image localhost:30002/library/grafana:8.2.1 \
@@ -475,7 +475,7 @@ For that, k3d provides its own ingress controller traefik.
 
 ```bash
 docker run --rm -it -u $(id -u) \
-  -v ~/.k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
+  -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
   --net=host \
   gitops-playground:dev --argocd --monitoring --vault=dev -x --yes \
   --argocd-url argocd.localhost --grafana-url grafana.localhost --vault-url vault.localhost \

--- a/docs/k3d.md
+++ b/docs/k3d.md
@@ -15,21 +15,35 @@ installing `kubectl` (see [here](https://v1-25.docs.kubernetes.io/docs/tasks/too
 
 ## Parameters
 
-* `--cluster-name` - default: `gitops-playground`
-* `--bind-localhost=false` - does not bind to localhost. That is, the URLs of the application will not be reachable via
-  localhost but via the IP address of the k3d docker container. Avoids port conflicts but is less convenient. 
-  Only exception is the registry port, it must be bound to localhost, otherwise docker will use HTTPS, leading to errors
-  on `docker push` in the example application's Jenkins Jobs.   
-  Note that if you use this option and the registry's default port 30000 is already bound on localhost (e.g. when  
-  starting more than one instance of the playground) the registry port will be bound to an arbitrary free port on 
-  localhost.In this case, the port will be printed by the `init-cluster.sh` script but can also be queried via 
-  `docker inspect`(see bellow).  
-  This port has to be passed on when creating the playground via the `--internal-registry-port` parameter. For example: 
+### --cluster-name
+`--cluster-name` - default: `gitops-playground`
+
+### --bind-localhost
+`--bind-localhost=false` - does not bind to localhost.
+That is, the URLs of the application will not be reachable via localhost but via the IP address of the k3d `server-0`
+docker container. Avoids port conflicts but is less convenient. We use this for our internal integration test in 
+[Jenkins](../Jenkinsfile), for example.
+
+There is only one port that has to be bound to localhost: the registry port. 
+For registries other than localhost or local ip addresses, docker will use HTTPS, leading to errors on `docker push` in the example application's Jenkins Jobs.
+Note that if you use this option and the registry's default port 30000 is already bound on localhost (e.g. when 
+starting more than one instance of the playground) the registry port will be bound to an arbitrary free port on 
+localhost. In this case, the port will be printed by the `init-cluster.sh` script but can also be queried via 
+`docker inspect`(see bellow).  
+This port has to be passed on when creating the playground via the `--internal-registry-port` parameter. For example: 
 
 ```shell
 --internal-registry-port=$(docker inspect \
-  --format='{{ with (index .NetworkSettings.Ports "30000/tcp") }}{{ (index . 0).HostPort }}{{ end }}' \
-  k3d-${CLUSTER_NAME}-server-0)
+--format='{{ with (index .NetworkSettings.Ports "30000/tcp") }}{{ (index . 0).HostPort }}{{ end }}' \
+k3d-${CLUSTER_NAME}-server-0)
+```
+
+In order to find out the IP address to access the services in the playground, the following docker command will do
+
+```shell
+$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' k3d-${CLUSTER_NAME}-server-0
+172.24.0.2
+# In this example you could reach Jenkins on http://172.24.0.2:9090
 ```
 
 ## Implementation details

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -237,7 +237,7 @@ function initRegistry() {
       # 30000 is needed as a static by docker via port mapping of k3d, e.g. 32769 -> 30000 on server-0 container
       # See "-p 30000" in init-cluster.sh
       # e.g 32769 is needed so the kubelet can access the image inside the server-0 container
-      kubectl create service nodeport docker-registry-internal-port --tcp=5000 --node-port ${INTERNAL_REGISTRY_PORT} -n default
+      kubectl create service nodeport docker-registry-internal-port --tcp=5000 --node-port ${INTERNAL_REGISTRY_PORT} -n default --dry-run=client -oyaml | kubectl apply -f-
     fi
   fi
 }

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -105,8 +105,11 @@ function createCluster() {
     echo "Make sure to pass --internal-registry-port=${registryPort} when applying the playground."
   fi
 
-  echo "Adding k3d cluster to ~/.kube/config"
-  k3d kubeconfig merge ${CLUSTER_NAME} --kubeconfig-switch-context > /dev/null
+  # Write ~/.config/k3d/kubeconfig-${CLUSTER_NAME}.yaml
+  # https://k3d.io/v5.6.0/usage/kubeconfig/
+  # Using this file makes applying the playground from docker more reliable and secure
+  # Otherwise a change of the current kubecontext (e.g. via kubectx) in the default kubeconfig will lead to the playground being applied to the wrong cluster
+  k3d kubeconfig write ${CLUSTER_NAME} > /dev/null
 }
 
 function printParameters() {

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -29,12 +29,18 @@ function main() {
 }
 
 function installK3d() {
-    echo "Installing install k3d ${K3D_VERSION}"
+    echo "Installing install k3d ${K3D_VERSION} to \$HOME/.local/bin"
     echo 'Using this script: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh'
     # shellcheck disable=SC2016
-    echo 'You can later uninstall it via: sudo rm $(which k3d)'
-    if confirm "Do you want to continue"  ' [y/N]'; then
-      curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v${K3D_VERSION} bash
+    echo 'If $HOME/.local/bin is not on your PATH, you can add it for this session: export PATH="$HOME/.local/bin:$PATH"'
+    # shellcheck disable=SC2016
+    echo 'You can uninstall k3d later via: rm $HOME/.local/bin/k3d'
+    if confirm "Do you want to continue?" ' [y/N]'; then
+      # Allow this script to execute k3d without having /.local/bin on the path
+      export PATH="$HOME/.local/bin:$PATH"
+      mkdir -p .local/bin
+      curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | \
+        TAG=v${K3D_VERSION} K3D_INSTALL_DIR=${HOME}/.local/bin bash -s -- --no-sudo
     else
       echo "Not installed."
       # Return error here to avoid possible subsequent commands to be executed

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -16,6 +16,7 @@ function main() {
   
   # Install k3d if necessary
   if ! command -v k3d >/dev/null 2>&1; then
+    echo The GitOps playground uses k3d, which is not found on the PATH. 
     installK3d
   else
     ACTUAL_K3D_VERSION="$(k3d --version | grep k3d | sed 's/k3d version v\(.*\)/\1/')"
@@ -28,7 +29,17 @@ function main() {
 }
 
 function installK3d() {
-  curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v${K3D_VERSION} bash
+    echo "Installing install k3d ${K3D_VERSION}"
+    echo 'Using this script: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh'
+    # shellcheck disable=SC2016
+    echo 'You can later uninstall it via: sudo rm $(which k3d)'
+    if confirm "Do you want to continue"  ' [y/N]'; then
+      curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v${K3D_VERSION} bash
+    else
+      echo "Not installed."
+      # Return error here to avoid possible subsequent commands to be executed
+      exit 1
+    fi
 }
 
 function createCluster() {

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -45,9 +45,9 @@ function createCluster() {
     fi
   fi
 
-  HOST_PORT_RANGE='8010-32767'
+  HOST_PORT_RANGE='8010-65535'
   K3D_ARGS=(
-    # Allow services to bind to ports < 30000
+    # Allow services to bind to ports < 30000 > 32xxx
     "--k3s-arg=--kube-apiserver-arg=service-node-port-range=${HOST_PORT_RANGE}@server:0"
     # Used by Jenkins Agents pods
     '-v /var/run/docker.sock:/var/run/docker.sock@server:0'


### PR DESCRIPTION
Most breaking changes are abstracted by init-cluster.sh
Except: k3d now writes kubeconfig to different folder.
  * Used to be: ` ~/.k3d`
  * Now is: ` ~/.config/k3d/`
  * This made it necessary to adapt the TLDR command in our README
  * We could move the file in init-cluster to avoid breaking change but then we would use a non-default folder. See 217a172.

I used the chance to change the logic of the init-cluster.sh to install k3d without needing root permissions to `.local/bin`.
I think not needing root/sudo makes a nicer UX and also allows use to reuse this logic in Jenkinsfile.
The only downside I see is that `.local/bin` might not be in the users `PATH`. See 7740fe1.

You can try the latest like so:

```bash
COMMIT=7740fe1
bash <(curl -s \
  https://raw.githubusercontent.com/cloudogu/gitops-playground/$COMMIT/scripts/init-cluster.sh) \
  && sleep 2 && docker run --rm -it --pull=always -u $(id -u) \
    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
    --net=host \
    ghcr.io/cloudogu/gitops-playground:$COMMIT --yes --argocd
```