### PR TITLE
Use a mailhog image without CVEs

### DIFF
--- a/applications/cluster-resources/mailhog-helm-values.ftl.yaml
+++ b/applications/cluster-resources/mailhog-helm-values.ftl.yaml
@@ -1,3 +1,11 @@
+<#if image?has_content>
+image:
+  repository: ${image?split(":")[0]}
+  <#if image?contains(":")>
+  tag: ${image?split(":")[1]}
+  </#if>
+</#if>
+
 service:
   type: <#if isRemote>LoadBalancer<#else>NodePort</#if>
   port:

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -101,7 +101,8 @@ class ApplicationConfigurator {
                             helm  : [
                                     chart  : 'mailhog',
                                     repoURL: 'https://codecentric.github.io/helm-charts',
-                                    version: '5.0.1'
+                                    version: '5.0.1',
+                                    image: 'ghcr.io/cloudogu/mailhog:v1.0.1'
                             ]
                     ],
                     monitoring: [

--- a/src/main/groovy/com/cloudogu/gitops/features/Mailhog.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Mailhog.groovy
@@ -47,6 +47,7 @@ class Mailhog extends Feature {
                 mail: [
                         url: config.features['mail']['url'] ? new URL(config.features['mail']['url'] as String) : null
                 ],
+                image: config['features']['mail']['helm']['image'] as String,
                 isRemote: config.application['remote'],
                 username: username,
                 passwordCrypt: bcryptMailhogPassword,

--- a/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
@@ -38,7 +38,8 @@ class MailhogTest {
                             helm  : [
                                     chart  : 'mailhog',
                                     repoURL: 'https://codecentric.github.io/helm-charts',
-                                    version: '5.0.1'
+                                    version: '5.0.1',
+                                    image: ''
                             ]
                     ]
             ],
@@ -116,6 +117,36 @@ class MailhogTest {
         config.features['argocd']['active'] = true
 
         createMailhog().install()
+    }
+    
+    @Test
+    void 'Allows overriding the image'() {
+        config['features']['mail']['helm']['image'] = 'abc'
+
+        createMailhog().install()
+        assertThat(parseActualYaml()['image']['repository']).isEqualTo('abc')
+    }
+    
+    @Test
+    void 'Allows overriding the image with tag'() {
+        config['features']['mail']['helm']['image'] = 'abc:42'
+        
+        createMailhog().install()
+        assertThat(parseActualYaml()['image']['repository']).isEqualTo('abc')
+        assertThat(parseActualYaml()['image']['tag']).isEqualTo(42)
+    }
+    
+    @Test
+    void 'Image is optional'() {
+        config['features']['mail']['helm']['image'] = ''
+
+        createMailhog().install()
+        assertThat(parseActualYaml()['image']).isNull()
+        
+        config['features']['mail']['helm']['image'] = null
+
+        createMailhog().install()
+        assertThat(parseActualYaml()['image']).isNull()
     }
 
     protected void assertMailhogInstalledImperativelyViaHelm() {


### PR DESCRIPTION
Supersedes #142, as there were breaking changes that made it easier to re-implement.

In the meantime the playground was extended, providing the option to template our mailog values.yaml.
This PR uses this option, preparing for parameterization of the image version.
