### PR TITLE
init-cluster.sh: Restore default for bind-localhost

### DIFF
--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -177,7 +177,7 @@ get_longopt_value(){
 
 readParameters() {
   CLUSTER_NAME=gitops-playground
-  BIND_LOCALHOST=false
+  BIND_LOCALHOST=true
   BIND_INGRESS_PORT=""
   # Use default port for playground registry, because no parameter is required when applying
   BIND_REGISTRY_PORT="30000"


### PR DESCRIPTION
This was changed accidentally in #159 / 60c96aba because at this point we planned to switch to ingresses by default. We later found out that subdomains of ingress don't work everywhere (e.g. not on debian).

So at this point it's easiest to keep downward compatibility. Also the docs and --help params state that bind-localhost is true by default.