### PR TITLE
Jenkinsfile: Send additional mail to devs if main fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,10 @@ node('high-cpu') {
         }
 
         mailIfStatusChanged(git.commitAuthorEmail)
+        
+        if (env.BRANCH_NAME == 'main' && env.GOP_DEVELOPERS) {
+            mailIfStatusChanged(env.GOP_DEVELOPERS)
+        }
     }
 }
 


### PR DESCRIPTION
The merge commit of a PR at github has a git user with an email address at `users.noreply.github.com`.

This leads to Jenkins mails on failed commits being not delivered. So: send an additional mail to a list of devs defined in Jenkins. A failed main branch deserves urgent attention.