### PR TITLE
Petclinic: Switch from buildpacks to Dockerfile

### DIFF
--- a/applications/argocd/petclinic/Dockerfile.ftl
+++ b/applications/argocd/petclinic/Dockerfile.ftl
@@ -1,0 +1,13 @@
+FROM ${baseImage}
+
+# Set permissions to group 0 for openshift compatibility
+# See https://docs.openshift.com/container-platform/4.15/openshift_images/create-images.html#use-uid_create-images
+RUN mkdir /app && chown 1000:0 /app \
+ && chmod -R g=u /app
+
+COPY target/*.jar /app/petclinic.jar
+
+EXPOSE 8080
+USER 1000
+
+ENTRYPOINT [ "java", "-server","-jar", "/app/petclinic.jar" ]

--- a/applications/argocd/petclinic/helm/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/helm/Jenkinsfile.ftl
@@ -53,14 +53,10 @@ node {
             String imageTag = createImageTag()
             String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
             imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
-            mvn "spring-boot:build-image -DskipTests -Dcheckstyle.skip -Dspring-boot.build-image.imageName=${imageName} " +
-                    // Pin builder image for reproducible builds. Update here to get newer JDK minor versions.
-                    "-Dspring-boot.build-image.builder=paketobuildpacks/builder:0.3.229-base "
+            image = docker.build(imageName, '.')
 
             if (isBuildSuccessful()) {
-                def docker = cesBuildLib.Docker.new(this)
                 docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
-                    def image = docker.image(imageName)
                     image.push()
                 }
             } else {

--- a/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
@@ -32,13 +32,12 @@ node {
         }
 
         stage('Build') {
-            // Build and tests skipped for faster demo and exercise purposes
-            //mvn 'clean package -DskipTests -Dcheckstyle.skip'
-            //archiveArtifacts artifacts: '**/target/*.jar'
+            mvn 'clean package -DskipTests -Dcheckstyle.skip'
+            archiveArtifacts artifacts: '**/target/*.jar'
         }
 
         stage('Test') {
-            // Build and tests skipped for faster demo and exercise purposes
+            // Tests skipped for faster demo and exercise purposes
             //mvn 'test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip'
         }
 
@@ -47,14 +46,10 @@ node {
             String imageTag = createImageTag()
             String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
             imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
-            mvn "spring-boot:build-image -DskipTests -Dcheckstyle.skip -Dspring-boot.build-image.imageName=${imageName} " +
-                    // Pin builder image for reproducible builds. Update here to get newer JDK minor versions.
-                    "-Dspring-boot.build-image.builder=paketobuildpacks/builder:0.3.229-base "
+            image = docker.build(imageName, '.')
 
             if (isBuildSuccessful()) {
-                def docker = cesBuildLib.Docker.new(this)
                 docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
-                    def image = docker.image(imageName)
                     image.push()
                 }
             } else {

--- a/applications/argocd/petclinic/plain-k8s/k8s/staging/deployment.yaml
+++ b/applications/argocd/petclinic/plain-k8s/k8s/staging/deployment.yaml
@@ -34,6 +34,9 @@ spec:
           volumeMounts:
             - name: messages
               mountPath: /tmp/messages
+            - name: tmp
+              # Make /tmp writable with readOnlyRootFilesystem
+              mountPath: /tmp
           resources:
             limits:
               cpu: 1
@@ -41,7 +44,25 @@ spec:
             requests:
               cpu: 300m
               memory: 650Mi
+          securityContext: # Implement some least privilege good practices
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            # These two seem to cause problems with OpenShift, so we disable them for now
+            #runAsUser: 65312
+            #seccompProfile:
+            #  type: RuntimeDefault
+            # With k8s 1.30 apparmor is added 
+            # Won't work on k3d, though, because apparmor is not enabled
+            # apparmorProfile: "runtime/default"
+      enableServiceLinks: false
+      automountServiceAccountToken: false # When not communicating with API Server
       volumes:
         - name: messages
           configMap:
             name: messages
+        - name: tmp
+          emptyDir: {}

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -187,6 +187,9 @@
         "nginx": {
           "type": "string"
         },
+        "petclinic": {
+          "type": "string"
+        },
         "yamllint": {
           "type": "string"
         }

--- a/exercises/petclinic-helm/Jenkinsfile.ftl
+++ b/exercises/petclinic-helm/Jenkinsfile.ftl
@@ -47,14 +47,10 @@ node {
             String imageTag = createImageTag()
             String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
             imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
-            mvn "spring-boot:build-image -DskipTests -Dcheckstyle.skip -Dspring-boot.build-image.imageName=${imageName}" +
-                                // Pin builder image for reproducible builds. Update here to get newer JDK minor versions.
-                                "-Dspring-boot.build-image.builder=paketobuildpacks/builder:0.3.229-base "
+            image = docker.build(imageName, '.')
 
             if (isBuildSuccessful()) {
-                def docker = cesBuildLib.Docker.new(this)
                 docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
-                    def image = docker.image(imageName)
                     image.push()
                 }
             } else {

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -107,6 +107,8 @@ class GitopsPlaygroundCli  implements Runnable {
     private String vaultImage
     @Option(names = ['--nginx-image'], description = 'Sets image for nginx used in various applications')
     private String nginxImage
+    @Option(names = ['--petclinic-image'], description = 'Sets image for petclinic used in various applications')
+    private String petClinicImage
     @Option(names = ['--base-url'], description = 'the external base url (TLD) for all tools, e.g. https://example.com or http://localhost:8080. The individual -url params for argocd, grafana, vault and mailhog take precedence.')
     private String baseUrl
 
@@ -360,6 +362,7 @@ class GitopsPlaygroundCli  implements Runnable {
                         helmKubeval: helmKubevalImage,
                         yamllint   : yamllintImage,
                         nginx      : nginxImage,
+                        petclinic  : petClinicImage,
                 ],
                 features    : [
                         argocd : [

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -98,6 +98,7 @@ class ApplicationConfigurator {
                     helmKubeval: HELM_IMAGE,
                     yamllint   : "cytopia/yamllint:1.25-0.7",
                     nginx      : null,
+                    petclinic   : 'eclipse-temurin:11-jre-alpine'
             ],
             repositories : [
                     springBootHelmChart: [

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -61,6 +61,7 @@ class Schema {
          String helmKubeval = ""
          String yamllint = ""
          String nginx = ""
+         String petclinic = ""
     }
 
      static class FeaturesSchema {

--- a/src/main/groovy/com/cloudogu/gitops/utils/TemplatingEngine.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/TemplatingEngine.groovy
@@ -10,19 +10,32 @@ class TemplatingEngine {
         this.engine = engine ?: new Configuration(new Version("2.3.32"))
     }
 
-    File replaceTemplate(File file, Map parameters) {
-        if (!file.name.contains(".ftl")) {
+    /**
+     * Executes template with parameters and replaces the .ftl in the file name.
+     */
+    File replaceTemplate(File templateFile, Map parameters) {
+        def targetFile = new File(templateFile.toString().replace(".ftl", ""))
+
+        template(templateFile, targetFile, parameters)
+
+        templateFile.delete()
+
+        return targetFile
+    }
+
+    /**
+     * Executes template and writes to targetFile, keeping the template file.
+     */
+    File template(File templateFile, File targetFile, Map parameters) {
+        if (!templateFile.name.contains(".ftl")) {
             throw new RuntimeException("File must contain .ftl to be a template")
         }
 
-        engine.setDirectoryForTemplateLoading(file.parentFile)
+        engine.setDirectoryForTemplateLoading(templateFile.parentFile)
 
-        def targetFile = new File(file.toString().replace(".ftl", ""))
-        def templ = engine.getTemplate(file.name)
-        templ.process(parameters, targetFile.newWriter())
-
-        file.delete()
-
+        def template = engine.getTemplate(templateFile.name)
+        template.process(parameters, targetFile.newWriter())
+        
         return targetFile
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -16,7 +16,8 @@ class ConfigToConfigFileConverterTest {
                         helm       : 'helm-value',
                         kubeval    : 'kubeval-value',
                         helmKubeval: 'helmKubeval-value',
-                        yamllint   : 'yamllint-value'
+                        yamllint   : 'yamllint-value',
+                        petclinic : 'petclinic-value'
                 ],
                 features   : [
                         argocd    : [
@@ -53,6 +54,7 @@ images:
   helmKubeval: "helmKubeval-value"
   yamllint: "yamllint-value"
   nginx: ""
+  petclinic: "petclinic-value"
 features:
   argocd:
     url: ""

--- a/src/test/groovy/com/cloudogu/gitops/utils/TemplatingEngineTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/TemplatingEngineTest.groovy
@@ -1,15 +1,23 @@
 package com.cloudogu.gitops.utils
 
+
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assertions.assertThat 
 
 class TemplatingEngineTest {
 
+    File tmpDir
+
+    @BeforeEach
+    void before() {
+        tmpDir = File.createTempDir('gitops-playground-tests-templatingengine')
+        tmpDir.deleteOnExit()
+    }
+
     @Test
     void 'replaces two templates in different folders'() {
-        def tmpDir = File.createTempDir('gitops-playground-tests-templatingengine')
-        tmpDir.deleteOnExit()
         def fooTemplate = new File(tmpDir.absolutePath, "foo.ftl.txt")
         fooTemplate.text = """
             this is the template
@@ -23,7 +31,7 @@ class TemplatingEngineTest {
 
         def tmpDir2 = File.createTempDir('gitops-playground-tests-templatingengine')
         tmpDir2.deleteOnExit()
-        def barTemplate = new File(tmpDir.absolutePath, "bar.ftl.txt")
+        def barTemplate = new File(tmpDir2.absolutePath, "bar.ftl.txt")
         barTemplate.text = "Hello \${name}"
 
         def engine = new TemplatingEngine()
@@ -31,6 +39,22 @@ class TemplatingEngineTest {
                 name: "Playground",
         ])
 
-        assertThat(new File(tmpDir.absolutePath, "bar.txt").text).isEqualTo("Hello Playground")
+        assertThat(new File(tmpDir2.absolutePath, "bar.txt").text).isEqualTo("Hello Playground")
+        assertThat(barTemplate).doesNotExist()
+    }
+
+    @Test
+    void 'keeps template file'() {
+        def barTemplate = new File(tmpDir.absolutePath, "bar.ftl.txt")
+        def barTarget = new File(tmpDir.absolutePath, "bar.txt")
+        barTemplate.text = "Hello \${name}"
+        
+        def engine = new TemplatingEngine()
+        engine.template(barTemplate, barTarget, [
+                name: "Playground",
+        ])
+
+        assertThat(barTarget.text).isEqualTo("Hello Playground")
+        assertThat(barTemplate).exists()
     }
 }


### PR DESCRIPTION
Why? Air-gapped mode.
Buildpacks load multiple dependencies from different sources, some of them directly from GitHub. This just seems not to work in air-gapped envs.

Our Dockerfile has only one dependency: the base image. This can now be replaced using a param or config option.

The drawback: buildpacks provide a rather easy way of getting deterministic builds, which we will lose for now.

While one it: Implement k8s appOps best practices for security context in petclinic-plain. This should make sure we can also run on OpenShift.