### PR TITLE
Introduce option for two registries

### DIFF
--- a/applications/argocd/petclinic/helm/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/helm/Jenkinsfile.ftl
@@ -4,11 +4,20 @@ String getApplication() { "spring-petclinic-helm" }
 String getScmManagerCredentials() { 'scmm-user' }
 String getConfigRepositoryPRBaseUrl() { env.SCMM_URL }
 String getConfigRepositoryPRRepo() { '${namePrefix}argocd/example-apps' }
-// The docker daemon cant use the k8s service name, because it is not running inside the cluster
+<#if registry.twoRegistries>
+String getDockerRegistryPullBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PULL_URL }
+String getDockerRegistryPullPath() { env.${namePrefixForEnvVars}REGISTRY_PULL_PATH }
+String getDockerRegistryPullCredentials() { 'registry-pull-user' }
+String getDockerRegistryPushBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PUSH_URL }
+String getDockerRegistryPushPath() { env.${namePrefixForEnvVars}REGISTRY_PUSH_PATH }
+String getDockerRegistryPushCredentials() { 'registry-push-user' }
+<#else>
 String getDockerRegistryBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_URL }
 String getDockerRegistryPath() { env.${namePrefixForEnvVars}REGISTRY_PATH }
-<#noparse>
 String getDockerRegistryCredentials() { 'registry-user' }
+</#if>
+
+<#noparse>
 String getCesBuildLibRepo() { "${env.SCMM_URL}/repo/3rd-party-dependencies/ces-build-lib/" }
 String getCesBuildLibVersion() { '1.64.1' }
 String getGitOpsBuildLibRepo() { "${env.SCMM_URL}/repo/3rd-party-dependencies/gitops-build-lib" }
@@ -51,12 +60,34 @@ node {
         String imageName = ""
         stage('Docker') {
             String imageTag = createImageTag()
+</#noparse>
+<#if registry.twoRegistries>
+<#noparse>
+            String pathPrefix = !dockerRegistryPushPath?.trim() ? "" : "${dockerRegistryPushPath}/"
+            imageName = "${dockerRegistryPushBaseUrl}/${pathPrefix}${application}:${imageTag}"
+            docker.withRegistry("http://${dockerRegistryPullBaseUrl}", dockerRegistryPullCredentials) {
+                image = docker.build(imageName, '.')
+            }
+</#noparse>
+<#else>
+<#noparse>
             String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
             imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
             image = docker.build(imageName, '.')
+</#noparse>
+</#if>
 
             if (isBuildSuccessful()) {
+<#if registry.twoRegistries>
+<#noparse>
+                docker.withRegistry("http://${dockerRegistryPushBaseUrl}", dockerRegistryPushCredentials) {
+</#noparse>
+<#else>
+<#noparse>
                 docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
+</#noparse>
+</#if>
+<#noparse>
                     image.push()
                 }
             } else {

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -211,9 +211,6 @@
         "pullPassword": {
           "type": "string"
         },
-        "pullPath": {
-          "type": "string"
-        },
         "pullUrl": {
           "type": "string"
         },

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -195,6 +195,51 @@
         }
       },
       "additionalProperties": false
+    },
+    "registry": {
+      "type": "object",
+      "properties": {
+        "internalPort": {
+          "type": "integer"
+        },
+        "password": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "pullPassword": {
+          "type": "string"
+        },
+        "pullPath": {
+          "type": "string"
+        },
+        "pullUrl": {
+          "type": "string"
+        },
+        "pullUsername": {
+          "type": "string"
+        },
+        "pushPassword": {
+          "type": "string"
+        },
+        "pushPath": {
+          "type": "string"
+        },
+        "pushUrl": {
+          "type": "string"
+        },
+        "pushUsername": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -10,22 +10,22 @@ It provides workarounds or solutions for the given issues.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-  - [Testing](#testing)
-    - [Usage](#usage)
-    - [Options](#options)
-  - [Jenkins plugin installation issues](#jenkins-plugin-installation-issues)
-    - [Solution](#solution)
-  - [Local development](#local-development)
-    - [Provide `gitops-playground.jar` for scripts](#provide-gitops-playgroundjar-for-scripts)
-  - [Development image](#development-image)
-  - [Implicit + explicit dependencies](#implicit--explicit-dependencies)
-  - [GraalVM](#graalvm)
-    - [Graal package](#graal-package)
-    - [Dockerfile](#dockerfile)
-    - [Create Graal native image config](#create-graal-native-image-config)
-    - [JGit](#jgit)
-    - [FAQ](#faq)
-      - [SAM conversion problem](#sam-conversion-problem)
+- [Testing](#testing)
+  - [Usage](#usage)
+  - [Options](#options)
+- [Jenkins plugin installation issues](#jenkins-plugin-installation-issues)
+  - [Solution](#solution)
+- [Local development](#local-development)
+  - [Provide `gitops-playground.jar` for scripts](#provide-gitops-playgroundjar-for-scripts)
+- [Development image](#development-image)
+- [Implicit + explicit dependencies](#implicit--explicit-dependencies)
+- [GraalVM](#graalvm)
+  - [Graal package](#graal-package)
+  - [Dockerfile](#dockerfile)
+  - [Create Graal native image config](#create-graal-native-image-config)
+  - [JGit](#jgit)
+  - [FAQ](#faq)
+    - [SAM conversion problem](#sam-conversion-problem)
 - [External registry for development](#external-registry-for-development)
 - [Emulate an airgapped environment](#emulate-an-airgapped-environment)
   - [Setup cluster](#setup-cluster)
@@ -101,7 +101,7 @@ Jenkins.instance.pluginManager.activePlugins.sort().each {
 ## Local development
 
 * Run locally
-  * Run from IDE (allows for easy debugging), works e.g. with IntelliJ IDEA 
+  * Run from IDE (allows for easy debugging), works e.g. with IntelliJ IDEA
     Note: If you encounter `error=2, No such file or directory`,
     it might be necessary to explicitly set your `PATH` in Run Configuration's Environment Section.
   * From shell:  
@@ -207,15 +207,15 @@ xdg-open "http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAd
 
 ## Implicit + explicit dependencies
 
-The GitOps Playground comprises a lot of software components. The versions of some of them are pinned within this 
+The GitOps Playground comprises a lot of software components. The versions of some of them are pinned within this
 repository so need to be upgraded regularly.
 
 * Kubernetes [in Terraform](../terraform/vars.tf) and locally [k3d](../scripts/init-cluster.sh),
 * [k3d](../scripts/init-cluster.sh)
 * [Groovy libs](../pom.xml) + [Maven](../.mvn/wrapper/maven-wrapper.properties)
 * Installed components
-  * Jenkins 
-    * Helm Chart 
+  * Jenkins
+    * Helm Chart
     * Plugins
     * Pod `tmp-docker-gid-grepper`
     * `dockerClientVersion`
@@ -246,12 +246,12 @@ repository so need to be upgraded regularly.
 The playground started up as a collection of ever-growing shell scripts. Once we realized that the playground is here to stay, we started looking into alternatives to keep our code base in a maintainable state.
 
 Our requirements:
-* a scriptable language, so we could easily explore new features at customers (see [Dev image](#development-image)), 
+* a scriptable language, so we could easily explore new features at customers (see [Dev image](#development-image)),
 * the possibility of generating a native binary, in order to get a more lightweight (in terms of vulnerabilities) resulting image.
 
-As the team at the time had a strong Java background and was already profound in groovy, e.g. from `Jenkinsfiles`, we decided to use groovy. 
+As the team at the time had a strong Java background and was already profound in groovy, e.g. from `Jenkinsfiles`, we decided to use groovy.
 We added Micronaut, because it promised good support for CLI, groovy and GraalVM for creating a static image.
-It turned out that Micronaut did not support GraalVM native images for groovy. In order to get this to work some more 
+It turned out that Micronaut did not support GraalVM native images for groovy. In order to get this to work some more
 hacking was necessary. See [`graal` package](../src/main/groovy/com/cloudogu/gitops/graal) and also the `native-image` stage in [`Dockerfile`](../Dockerfile).
 
 ### Graal package
@@ -274,7 +274,7 @@ Some things are a bit special for the playground:
 ### Create Graal native image config
 
 The `RUN java -agentlib:native-image-agent` instructions in `Dockerfile` execute the `playground.jar` with the agent attached.
-These runs create static image config files for some dynamic reflection things. 
+These runs create static image config files for some dynamic reflection things.
 These files are later picked up by the `native-image`.
 This is done to reduce the chance of `ClassNotFoundException`s, `MethodNotFoundException`s, etc. at runtime.
 
@@ -283,7 +283,7 @@ In the future we could further improve this by running unit test with the graal 
 However, this leads to some mysterious error `Class initialization of com.oracle.truffle.js.scriptengine.GraalJSEngineFactory failed.` 🤷‍♂️
 Also, a lot of failing test with `FileNotFoundException` (due to `user.dir`?).
 If more Exceptions should turn up in the future we might follow up on this.
-Then, we might want to add an env var that actually calls JGit (instead of the mock) in order to execute JGit code with 
+Then, we might want to add an env var that actually calls JGit (instead of the mock) in order to execute JGit code with
 the agent attached.
 ```shell
 ./mvnw test "-DargLine=-agentlib:native-image-agent=config-output-dir=conf" --fail-never
@@ -293,7 +293,7 @@ At the moment this does not seem to be necessary, though.
 ### JGit
 
 JGit seems to cause [a lot](https://bugs.eclipse.org/bugs/show_bug.cgi?id=546175) [of](https://github.com/quarkusio/quarkus/issues/21372) [trouble](https://github.com/miguelaferreira/issue-micronaut-graalvm-jgit) with GraalVM.  
-Unfortunately for the playground, JGit is a good choice: The only(?) actively developed native Java library for git. 
+Unfortunately for the playground, JGit is a good choice: The only(?) actively developed native Java library for git.
 In the long run, we want to get rid of the shell-outs and the `git` binary in the playground image in order to reduce
 attack surface and complexity. So we need JGit.
 
@@ -305,9 +305,9 @@ That's why we picked some classes into the Graal package (see this [package](../
 Those are picked up by `native-image` binary in `Dockerfile`.
 In addition, we had to add some more parameters (`initialize-at-run-time` and `-H:IncludeResourceBundles`) to `native-image`.
 
-For the moment this works and hopefully some day JGit will have support for GraalVM built-in. 
-Until then, there is a chance, that each upgrade of JGit causes new issues. If so, check if the code of the Quarkus 
-extension provides solutions. 🤞 Good luck 🍀. 
+For the moment this works and hopefully some day JGit will have support for GraalVM built-in.
+Until then, there is a chance, that each upgrade of JGit causes new issues. If so, check if the code of the Quarkus
+extension provides solutions. 🤞 Good luck 🍀.
 
 ### FAQ
 
@@ -323,6 +323,21 @@ to class 'java.util.function.Predicate'
 Implicit closure-to-SAM conversions will not always happen.
 You can configure an explicit list in [resources/proxy-config.json](../src/main/resources/proxy-config.json) and [resources/reflect-config.json](../src/main/resources/reflect-config.json).
 
+
+# Testing URL separator hyphens
+```bash
+docker run --rm -t  -u $(id -u) \
+    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
+    -v $(pwd)/gitops-playground.yaml:/config/gitops-playground.yaml \
+    --net=host \
+   gitops-playground:dev --yes --argocd --base-url=http://localhost  --ingress-nginx --mail --monitoring --vault=dev --url-separator-hyphen
+
+# Create localhost entries with hyphens
+echo 127.0.0.1 $(kubectl get ingress -A  -o jsonpath='{.items[*].spec.rules[*].host}') | sudo tee -a /etc/hosts
+
+# Produce clickable links:
+kubectl get --all-namespaces ingress -o json 2> /dev/null | jq -r '.items[] | .spec.rules[] | .host as $host | .http.paths[] | ( "http://" + $host + .path )' | sort | grep -v ^/
+```
 
 # External registry for development
 
@@ -368,7 +383,7 @@ notary:
 
 Then install it like so:
 ```bash
-helm upgrade -i my-harbor harbor/harbor -f harbor-values.yaml --version 1.12.2 --namespace harbor --create-namespace
+helm upgrade -i my-harbor harbor/harbor -f harbor-values.yaml --version 1.14.2 --namespace harbor --create-namespace
 ```
 Once it's up and running either create your own private project or just set the existing `library` to private:
 ```bash
@@ -390,7 +405,7 @@ docker tag bitnami/nginx:1.25.1 localhost:30002/library/nginx:1.25.1
 docker push localhost:30002/library/nginx:1.25.1
 ```
 
-To make the registry credentials know to kubernetes, apply the following to *each* namespace where they are needed: 
+To make the registry credentials know to kubernetes, apply the following to *each* namespace where they are needed:
 
 ```bash
 kubectl create secret docker-registry regcred \
@@ -403,18 +418,110 @@ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred
 This will work for all pods that don't use their own ServiceAccount.
 That is, for most helm charts, you'll need to set an individual value.
 
+# Testing two registries
+
+## Very simple test
+* Start playground once,
+* then again with these parameters:  
+  `--registry-pull-url=localhost:30000 --registry-push-url=localhost:30000`
+* The petclinic pipelines should still run
+
+## Proper test
+
+* Start cluster:
+```shell
+# Stop other cluster, if necessary
+# k3d cluster stop gitops-playground
+scripts/init-cluster.sh --bind-ingress-port=80 --cluster-name=two-regs
+```
+* Setup harbor as stated [above](#external-registry-for-development), but with Port `30000`.  
+  Wait for harbor to startup: ` kubectl get pod -n harbor`  
+  Don't care about harbor `jobservice`
+* Create registries and base image:
+
+```bash
+operations=("Pull" "Push")
+
+for operation in "${operations[@]}"; do
+
+    # Convert the operation to lowercase for the project name and email
+    lower_operation=$(echo "$operation" | tr '[:upper:]' '[:lower:]')
+    
+    echo creating project $lower_operation
+    projectId=$(curl -is --fail 'http://localhost:30000/api/v2.0/projects' -X POST -u admin:Harbor12345    -H 'Content-Type: application/json' --data-raw "{\"project_name\":\"$lower_operation\",\"metadata\":{\"public\":\"false\"},\"storage_limit\":-1,\"registry_id\":null}" | grep -i 'Location:' | awk '{print $2}' | awk -F '/' '{print $NF}' | tr -d '[:space:]')
+
+    echo creating user $operation with PW ${operation}12345
+    curl -s  --fail 'http://localhost:30000/api/v2.0/users' -X POST -u admin:Harbor12345 -H 'Content-Type: application/json' --data-raw "{\"username\":\"$operation\",\"email\":\"$operation@example.com\",\"realname\":\"$operation example\",\"password\":\"${operation}12345\",\"comment\":null}"
+    
+	echo "Adding member $operation to project $lower_operation; ID=${projectId}"
+
+    curl  --fail "http://localhost:30000/api/v2.0/projects/${projectId}/members" -X POST -u admin:Harbor12345    -H 'Content-Type: application/json' --data-raw "{\"role_id\":4,\"member_user\":{\"username\":\"$operation\"}}"
+done
+
+skopeo copy docker://eclipse-temurin:11-jre-alpine --dest-creds Pull:Pull12345 --dest-tls-verify=false  docker://localhost:30000/pull/eclipse-temurin:11-jre-alpine
+```
+
+* Deploy playground:
+
+```bash
+docker run --rm -t  -u $(id -u)  \
+    -v ~/.config/k3d/kubeconfig-two-regs.yaml:/home/.kube/config \
+    -v $(pwd)/gitops-playground.yaml:/config/gitops-playground.yaml \
+    --net=host \
+  gitops-playground:dev -x --yes --argocd  --ingress-nginx --base-url=http://localhost  \
+  --registry-push-url=localhost:30000 \
+  --registry-push-path=push \
+  --registry-push-username=Push \
+  --registry-push-password=Push12345 \
+  --registry-pull-url=localhost:30000 \
+  --registry-pull-username=Pull \
+  --registry-pull-password=Pull12345 \
+  --petclinic-image=localhost:30000/pull/eclipse-temurin:11-jre-alpine 
+# Or with config file --config-file=/config/gitops-playground.yaml 
+```
+
+To make the registry credentials know to kubernetes, apply the following:
+
+```bash
+namespaces=("example-apps-production" "example-apps-staging")
+
+for namespace in "${namespaces[@]}"; do
+  kubectl create secret docker-registry regcred \
+  -n $namespace \
+  --docker-server=localhost:30000 \
+  --docker-username=Push \
+  --docker-password=Push12345
+  kubectl patch serviceaccount default -n $namespace -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+done
+```
+
+The same using a config file looks like so:
+
+```yaml
+registry: 
+  pullUrl: localhost:30000
+  pullUsername: Pull
+  pullPassword: Pull12345
+  pushUrl: localhost:30000
+  pushUsername: Push
+  pushPassword: Push12345
+  pushPath: push
+images: 
+  petclinic: localhost:30000/pull/eclipse-temurin:11-jre-alpine
+```
+
 # Emulate an airgapped environment
 
 Let's set up our local playground to emulate an airgapped env, as some of our customers have.
 
 Note that with approach bellow, the whole k3d cluster is airgapped with one exception: the Jenkins agents can work around this.
-To be able to run the `docker` plugin in Jenkins (in a k3d cluster that only provides containerd) we mount the host's 
-docker socket into the agents. 
+To be able to run the `docker` plugin in Jenkins (in a k3d cluster that only provides containerd) we mount the host's
+docker socket into the agents.
 From there it can start containers which are not airgapped.
 So this approach is not suitable to test if the builds use any public images.
 One solution could be to apply the `iptables` rule mentioned bellow to `docker0` (not tested).
 
-The approach discussed here is suitable to check if the cluster tries to load anything from the internet, 
+The approach discussed here is suitable to check if the cluster tries to load anything from the internet,
 like images or helm charts.
 
 ## Setup cluster
@@ -440,12 +547,12 @@ You can switch to the airgapped context in your current shell like so:
 export KUBECONFIG=$HOME/.config/k3d/kubeconfig-airgapped-playground.yaml
 ```
 
-TODO also replace in `~/.kube/config` for more convenience. 
+TODO also replace in `~/.kube/config` for more convenience.
 In there, we need to be more careful, because there are other contexts. This makes it more difficult.
 
 ## Provide images needed by playground
 
-First, let's import necessary images into harbor using `skopeo`. 
+First, let's import necessary images into harbor using `skopeo`.
 With `skopeo`, this process is much easier than with `docker` because we don't need to pull the images first.
 You can get a list of images from a running playground that is not airgapped.
 
@@ -483,7 +590,7 @@ Note that even though the images are named `$K3D_NODE:30002/library/...`, these 
 
 ## Install the playground
 
-Don't disconnect from the internet yet, because 
+Don't disconnect from the internet yet, because
 
 * k3d needs some images itself, e.g. the `local-path-provisioner` (see Troubleshooting) which are only pulled on demand.
   In this case when the first PVC gets provisioned.
@@ -609,7 +716,7 @@ nft insert rule ip filter INPUT tcp dport 80 accept
 
 Locally:
 ````shell
-mvnp -DskipTests
+mvn package -DskipTests
 java -classpath target/gitops-playground-cli-0.1.jar org.codehaus.groovy.tools.GroovyStarter --main groovy.ui.GroovyMain \
   --classpath src/main/groovy src/main/groovy/com/cloudogu/gitops/cli/GenerateJsonSchema.groovy \
    | jq > docs/configuration.schema.json

--- a/exercises/petclinic-helm/Jenkinsfile.ftl
+++ b/exercises/petclinic-helm/Jenkinsfile.ftl
@@ -4,11 +4,19 @@ String getApplication() { "exercise-spring-petclinic-helm" }
 String getScmManagerCredentials() { 'scmm-user' }
 String getConfigRepositoryPRBaseUrl() { env.SCMM_URL }
 String getConfigRepositoryPRRepo() { '${namePrefix}argocd/example-apps' }
-// The docker daemon cant use the k8s service name, because it is not running inside the cluster
+<#if registry.twoRegistries>
+String getDockerRegistryPullBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PULL_URL }
+String getDockerRegistryPullPath() { env.${namePrefixForEnvVars}REGISTRY_PULL_PATH }
+String getDockerRegistryPullCredentials() { 'registry-pull-user' }
+String getDockerRegistryPushBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PUSH_URL }
+String getDockerRegistryPushPath() { env.${namePrefixForEnvVars}REGISTRY_PUSH_PATH }
+String getDockerRegistryPushCredentials() { 'registry-push-user' }
+<#else>
 String getDockerRegistryBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_URL }
 String getDockerRegistryPath() { env.${namePrefixForEnvVars}REGISTRY_PATH }
-<#noparse>
 String getDockerRegistryCredentials() { 'registry-user' }
+</#if>
+<#noparse>
 String getCesBuildLibRepo() { "${env.SCMM_URL}/repo/3rd-party-dependencies/ces-build-lib/" }
 String getCesBuildLibVersion() { '1.64.1' }
 String getHelmChartRepository() { "${env.SCMM_URL}/repo/3rd-party-dependencies/spring-boot-helm-chart-with-dependency" }
@@ -45,12 +53,35 @@ node {
         String imageName = ""
         stage('Docker') {
             String imageTag = createImageTag()
+</#noparse>
+<#if registry.twoRegistries>
+<#noparse>
+            String pathPrefix = !dockerRegistryPushPath?.trim() ? "" : "${dockerRegistryPushPath}/"
+            imageName = "${dockerRegistryPushBaseUrl}/${pathPrefix}${application}:${imageTag}"
+            docker.withRegistry("http://${dockerRegistryPullBaseUrl}", dockerRegistryPullCredentials) {
+                image = docker.build(imageName, '.')
+            }
+</#noparse>
+<#else>
+<#noparse>
             String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
             imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
             image = docker.build(imageName, '.')
+</#noparse>
+</#if>
 
-            if (isBuildSuccessful()) {
+
+                if (isBuildSuccessful()) {
+<#if registry.twoRegistries>
+<#noparse>
+                            docker.withRegistry("http://${dockerRegistryPushBaseUrl}", dockerRegistryPushCredentials) {
+</#noparse>
+<#else>
+<#noparse>
                 docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
+</#noparse>
+</#if>
+<#noparse>
                     image.push()
                 }
             } else {

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -35,6 +35,8 @@ import static groovy.json.JsonOutput.toJson
 @Slf4j
 class GitopsPlaygroundCli  implements Runnable {
     // args group registry
+    @Option(names = ['--internal-registry-port'], description = 'Port of registry registry. Ignored when a registry*url params are set')
+    private Integer internalRegistryPort
     @Option(names = ['--registry-url'], description = 'The url of your external registry')
     private String registryUrl
     @Option(names = ['--registry-path'], description = 'Optional when --registry-url is set')
@@ -43,8 +45,22 @@ class GitopsPlaygroundCli  implements Runnable {
     private String registryUsername
     @Option(names = ['--registry-password'], description = 'Optional when --registry-url is set')
     private String registryPassword
-    @Option(names = ['--internal-registry-port'], description = 'Port of registry registry. Ignored when registry-url is set')
-    private Integer internalRegistryPort
+    @Option(names = ['--registry-pull-url'], description = 'The url of your external pull-registry. Make sure to always use this with --registry-push-url')
+    private String registryPullUrl
+    @Option(names = ['--registry-pull-path'], description = 'Optional when --registry-pull-url is set')
+    private String registryPullPath
+    @Option(names = ['--registry-pull-username'], description = 'Optional when --registry-pull-url is set')
+    private String registryPullUsername
+    @Option(names = ['--registry-pull-password'], description = 'Optional when --registry-pull-url is set')
+    private String registryPullPassword
+    @Option(names = ['--registry-push-url'], description = 'The url of your external pull-registry. Make sure to always use this with --registry-pull-url')
+    private String registryPushUrl
+    @Option(names = ['--registry-push-path'], description = 'Optional when --registry-push-url is set')
+    private String registryPushPath
+    @Option(names = ['--registry-push-username'], description = 'Optional when --registry-push-url is set')
+    private String registryPushUsername
+    @Option(names = ['--registry-push-password'], description = 'Optional when --registry-push-url is set')
+    private String registryPushPassword
 
     // args group jenkins
     @Option(names = ['--jenkins-url'], description = 'The url of your external jenkins')
@@ -326,11 +342,19 @@ class GitopsPlaygroundCli  implements Runnable {
 
         return [
                 registry   : [
+                        internalPort: internalRegistryPort,
                         url         : registryUrl,
                         path        : registryPath,
                         username    : registryUsername,
                         password    : registryPassword,
-                        internalPort: internalRegistryPort
+                        pullUrl         : registryPullUrl,
+                        pullPath        : registryPullPath,
+                        pullUsername    : registryPullUsername,
+                        pullPassword    : registryPullPassword,
+                        pushUrl         : registryPushUrl,
+                        pushPath        : registryPushPath,
+                        pushUsername    : registryPushUsername,
+                        pushPassword    : registryPushPassword,
                 ],
                 jenkins    : [
                         url     : jenkinsUrl,

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -30,11 +30,24 @@ class ApplicationConfigurator {
     private final Map DEFAULT_VALUES = makeDeeplyImmutable([
             registry   : [
                     internal: true, // Set dynamically
+                    twoRegistries: false, // Set dynamically
+                    internalPort: DEFAULT_REGISTRY_PORT,
+                    // Single registry
                     url         : '',
                     path        : '',
                     username    : '',
                     password    : '',
-                    internalPort: DEFAULT_REGISTRY_PORT,
+                    // Alternative: Use different registries, e.g. in air-gapped envs 
+                    // "Pull" registry for 3rd party images
+                    pullUrl         : '',
+                    pullPath        : '',
+                    pullUsername    : '',
+                    pullPassword    : '',
+                    // "Push" registry for writing application specific images
+                    pushUrl         : '',
+                    pushPath        : '',
+                    pushUsername    : '',
+                    pushPassword    : '',
                     helm  : [
                             chart  : 'docker-registry',
                             repoURL: 'https://charts.helm.sh/stable',
@@ -262,17 +275,8 @@ class ApplicationConfigurator {
             newConfig.application['namePrefixForEnvVars'] ="${(newConfig.application['namePrefix'] as String).toUpperCase().replace('-', '_')}"
         }
 
-        if (newConfig.registry['url']) {
-            newConfig.registry['internal'] = false
-        } else {
-            /* Internal Docker registry must be on localhost. Otherwise docker will use HTTPS, leading to errors on 
-               docker push in the example application's Jenkins Jobs.
-               Both setting up HTTPS or allowing insecure registry via daemon.json makes the playground difficult to use.
-               So, always use localhost.
-               Allow overriding the port, in case multiple playground instance run on a single host in different 
-               k3d clusters. */
-            newConfig.registry['url'] = "localhost:${newConfig.registry['internalPort']}"
-        }
+        addRegistryConfig(newConfig)
+        
         if (newConfig['features']['secrets']['vault']['mode'])
             newConfig['features']['secrets']['active'] = true
         if (newConfig['features']['mail']['smtpAddress'] || newConfig['features']['mail']['mailhog'])
@@ -290,6 +294,31 @@ class ApplicationConfigurator {
         config = makeDeeplyImmutable(newConfig)
 
         return config
+    }
+
+    private void addRegistryConfig(Map newConfig) {
+        if (newConfig.registry['pullUrl'] && newConfig.registry['pushUrl']) {
+            newConfig.registry['twoRegistries'] = true
+        } else if (newConfig.registry['pullUrl'] && !newConfig.registry['pushUrl'] ||
+                newConfig.registry['pushUrl'] && !newConfig.registry['pullUrl']) {
+            throw new RuntimeException("Always set pull AND push URL. pullUrl=${newConfig.registry['pullUrl']}, pushUrl=${newConfig.registry['pushUrl']}")
+        }
+
+        if (newConfig.registry['url'] && newConfig.registry['twoRegistries']) {
+            log.warn("Set both registry.url and registry.pullUrl/registry.pushUrl! Implicitly ignoring registry.url")
+        }
+
+        if (newConfig.registry['url'] || newConfig.registry['twoRegistries']) {
+            newConfig.registry['internal'] = false
+        } else {
+            /* Internal Docker registry must be on localhost. Otherwise docker will use HTTPS, leading to errors on 
+               docker push in the example application's Jenkins Jobs.
+               Both setting up HTTPS or allowing insecure registry via daemon.json makes the playground difficult to use.
+               So, always use localhost.
+               Allow overriding the port, in case multiple playground instance run on a single host in different 
+               k3d clusters. */
+            newConfig.registry['url'] = "localhost:${newConfig.registry['internalPort']}"
+        }
     }
 
     Map setConfig(File configFile, boolean skipInternalConfig = false) {

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -40,7 +40,6 @@ class ApplicationConfigurator {
                     // Alternative: Use different registries, e.g. in air-gapped envs 
                     // "Pull" registry for 3rd party images
                     pullUrl         : '',
-                    pullPath        : '',
                     pullUsername    : '',
                     pullPassword    : '',
                     // "Push" registry for writing application specific images

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -14,7 +14,7 @@ package com.cloudogu.gitops.config.schema
  * @see com.cloudogu.gitops.config.ApplicationConfigurator
  */
 class Schema {
-//     RegistrySchema registry // used in bash
+     RegistrySchema registry
 //     JenkinsSchema jenkins // used in bash
 //     ScmmSchema scmm // used in bash
 //     ApplicationSchema application // used in bash
@@ -22,11 +22,22 @@ class Schema {
      FeaturesSchema features
 
      static class RegistrySchema {
+         int internalPort
          String url = ""
          String path = ""
          String username = ""
          String password = ""
-         int internalPort
+         // Alternative: Use different registries, e.g. in air-gapped envs 
+         // "Pull" registry for 3rd party images
+         String pullUrl = ""
+         String pullPath = ""
+         String pullUsername = ""
+         String pullPassword = ""
+         // "Push" registry for writing application specific images
+         String pushUrl = ""
+         String pushPath = ""
+         String pushUsername = ""
+         String pushPassword = ""
     }
 
      static class JenkinsSchema {

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -1,6 +1,5 @@
 //file:noinspection unused
-package com.cloudogu.gitops.config.schema
-
+package com.cloudogu.gitops.config.schema 
 /**
  * The schema for the configuration file.
  * It is used to validate the passed yaml file.
@@ -28,9 +27,8 @@ class Schema {
          String username = ""
          String password = ""
          // Alternative: Use different registries, e.g. in air-gapped envs 
-         // "Pull" registry for 3rd party images
+         // "Pull" registry for 3rd party images, e.g. base images
          String pullUrl = ""
-         String pullPath = ""
          String pullUsername = ""
          String pullPassword = ""
          // "Push" registry for writing application specific images

--- a/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
@@ -25,6 +25,10 @@ class JenkinsDestructionHandler implements DestructionHandler {
         globalPropertyManager.deleteGlobalProperty("SCMM_URL")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_URL")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PATH")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PULL_URL")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PULL_PATH")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PUSH_URL")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PUSH_PATH")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}K8S_VERSION")
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -69,8 +69,15 @@ class Jenkins extends Feature {
         ])
 
         globalPropertyManager.setGlobalProperty('SCMM_URL', config.scmm['url'] as String)
-        globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_URL", config.registry['url'] as String)
-        globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PATH", config.registry['path'] as String)
+        if (config.registry['twoRegistries']) {
+            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PULL_URL", config.registry['pullUrl'] as String)
+            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PULL_PATH", config.registry['pullPath'] as String)
+            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PUSH_URL", config.registry['pushUrl'] as String)
+            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PUSH_PATH", config.registry['pushPath'] as String)
+        } else {
+            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_URL", config.registry['url'] as String)
+            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PATH", config.registry['path'] as String)
+        }
 
         globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}K8S_VERSION", ApplicationConfigurator.K8S_VERSION)
 
@@ -91,12 +98,27 @@ class Jenkins extends Feature {
                     "${config.scmm['password']}",
                     'credentials for accessing scm-manager')
 
-            jobManger.createCredential(
-                    "${config.application['namePrefix']}example-apps",
-                    "registry-user",
-                    "${config.registry['username']}",
-                    "${config.registry['password']}",
-                    'credentials for accessing the docker-registry')
+            if (config.registry['twoRegistries']) {
+                jobManger.createCredential(
+                        "${config.application['namePrefix']}example-apps",
+                        "registry-pull-user",
+                        "${config.registry['pullUsername']}",
+                        "${config.registry['pullPassword']}",
+                        'credentials for accessing the docker-registry that contains 3rd party or base images')
+                jobManger.createCredential(
+                        "${config.application['namePrefix']}example-apps",
+                        "registry-push-user",
+                        "${config.registry['pushUsername']}",
+                        "${config.registry['pushPassword']}",
+                        'credentials for accessing the docker-registry that contains images built on jenkins')
+            } else {
+                jobManger.createCredential(
+                        "${config.application['namePrefix']}example-apps",
+                        "registry-user",
+                        "${config.registry['username']}",
+                        "${config.registry['password']}",
+                        'credentials for accessing the docker-registry')
+            }
         }
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -334,6 +334,9 @@ class ArgoCD extends Feature {
                             emailToUser  : config.features['argocd']['emailToUser'],
                             emailToAdmin : config.features['argocd']['emailToAdmin']
                     ],
+                    registry : [
+                            twoRegistries: config.registry['twoRegistries']
+                    ],
                     monitoring          : [
                             grafana: [
                                     url: config.features['monitoring']['grafanaUrl'] ? new URL(config.features['monitoring']['grafanaUrl'] as String) : null,

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -11,6 +11,21 @@ class ConfigToConfigFileConverterTest {
         def converter = new ConfigToConfigFileConverter()
 
         def config = converter.convert([
+                registry   : [
+                        internalPort: 123,
+                        url         : 'url',
+                        path        : 'path',
+                        username    : 'username',
+                        password    : 'password',
+                        pullUrl         : 'pullUrl',
+                        pullPath        : 'pullPath',
+                        pullUsername    : 'pullUsername',
+                        pullPassword    : 'pullPassword',
+                        pushUrl         : 'pushUrl',
+                        pushPath        : 'pushPath',
+                        pushUsername    : 'pushUsername',
+                        pushPassword    : 'pushPassword',
+                ],
                 images     : [
                         kubectl    : 'kubectl-value',
                         helm       : 'helm-value',
@@ -47,6 +62,20 @@ class ConfigToConfigFileConverterTest {
         ])
 
         assertThat(config).isEqualTo("""---
+registry:
+  internalPort: 123
+  url: "url"
+  path: "path"
+  username: "username"
+  password: "password"
+  pullUrl: "pullUrl"
+  pullPath: "pullPath"
+  pullUsername: "pullUsername"
+  pullPassword: "pullPassword"
+  pushUrl: "pushUrl"
+  pushPath: "pushPath"
+  pushUsername: "pushUsername"
+  pushPassword: "pushPassword"
 images:
   kubectl: "kubectl-value"
   helm: "helm-value"

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -18,7 +18,6 @@ class ConfigToConfigFileConverterTest {
                         username    : 'username',
                         password    : 'password',
                         pullUrl         : 'pullUrl',
-                        pullPath        : 'pullPath',
                         pullUsername    : 'pullUsername',
                         pullPassword    : 'pullPassword',
                         pushUrl         : 'pushUrl',
@@ -69,7 +68,6 @@ registry:
   username: "username"
   password: "password"
   pullUrl: "pullUrl"
-  pullPath: "pullPath"
   pullUsername: "pullUsername"
   pullPassword: "pullPassword"
   pushUrl: "pushUrl"

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -44,7 +44,16 @@ class JenkinsTest {
                     url     : 'reg-url',
                     path    : 'reg-path',
                     username: 'reg-usr',
-                    password: 'reg-pw'
+                    password: 'reg-pw',
+                    twoRegistries: false,
+                    pullUrl: 'reg-pull-url',
+                    pullPath: 'reg-pull-path',
+                    pullUsername    : 'reg-pull-usr',
+                    pullPassword    : 'reg-pull-pw',
+                    pushUrl: 'reg-push-url',
+                    pushPath: 'reg-push-path',
+                    pushUsername    : 'reg-push-usr',
+                    pushPassword    : 'reg-push-pw',
             ],
             scmm       : [
                     url     : 'http://scmm',
@@ -94,10 +103,15 @@ class JenkinsTest {
         assertThat(env['INSTALL_ARGOCD']).isEqualTo('true')
 
         verify(globalPropertyManager).setGlobalProperty('SCMM_URL', 'http://scmm')
+        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_K8S_VERSION', ApplicationConfigurator.K8S_VERSION)
+        
         verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_URL', 'reg-url')
         verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PATH', 'reg-path')
-        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_K8S_VERSION', ApplicationConfigurator.K8S_VERSION)
-
+        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PULL_URL'), anyString())
+        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PULL_PATH'), anyString())
+        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PUSH_URL'), anyString())
+        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PUSH_PATH'), anyString())
+        
         verify(userManager).createUser('metrics-usr', 'metrics-pw')
         verify(userManager).grantPermission('metrics-usr', UserManager.Permissions.METRICS_VIEW)
 
@@ -105,10 +119,40 @@ class JenkinsTest {
 
         verify(jobManger).createCredential('my-prefix-example-apps', 'scmm-user', 
                 'my-prefix-gitops', 'scmm-pw', 'credentials for accessing scm-manager')
+        
         verify(jobManger).createCredential('my-prefix-example-apps', 'registry-user', 
                 'reg-usr', 'reg-pw', 'credentials for accessing the docker-registry')
+        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-pull-user'),
+                anyString(), anyString(), anyString())
+        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-push-user'),
+                anyString(), anyString(), anyString())
     }
 
+
+    @Test
+    void 'Handles two registries'() {
+        config.registry['twoRegistries'] = true
+        
+        createJenkins().install()
+        
+        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PULL_URL', 'reg-pull-url')
+        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PULL_PATH', 'reg-pull-path')
+        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PUSH_URL', 'reg-push-url')
+        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PUSH_PATH', 'reg-push-path')
+
+        verify(jobManger).createCredential('my-prefix-example-apps', 'registry-pull-user',
+                'reg-pull-usr', 'reg-pull-pw', 
+                'credentials for accessing the docker-registry that contains 3rd party or base images')
+        verify(jobManger).createCredential('my-prefix-example-apps', 'registry-push-user',
+                'reg-push-usr', 'reg-push-pw', 
+                'credentials for accessing the docker-registry that contains images built on jenkins')
+
+        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_URL'), anyString())
+        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PATH'), anyString())
+        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-user'), 
+                anyString(), anyString(), anyString())
+    }
+    
     @Test
     void 'Does not create create job credentials when argo cd is deactivated'() {
         when(userManager.isUsingCasSecurityRealm()).thenReturn(true)

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -52,6 +52,9 @@ class ArgoCDTest {
                     password: ''
             ],
             images      : buildImages + [ petclinic  : 'petclinic-value' ],
+            registry: [
+                    twoRegistries: false,
+            ],
             repositories: [
                     springBootHelmChart: [
                             url: 'https://github.com/cloudogu/spring-boot-helm-chart.git',
@@ -503,6 +506,15 @@ class ArgoCDTest {
         assertArgoCdYamlPrefixes(ArgoCD.SCMM_URL_INTERNAL, '')
         assertJenkinsEnvironmentVariablesPrefixes('')
     }
+    
+    @Test
+    void 'Creates Jenkinsfiles for two registries'() {
+        config.registry['twoRegistries'] = true
+        createArgoCD().install()
+
+        assertJenkinsEnvironmentVariablesPrefixes('')
+        assertJenkinsfileRegistryCredentials()
+    }
 
     @Test
     void 'Pushes repos with name-prefix'() {
@@ -645,10 +657,28 @@ class ArgoCDTest {
     }
 
     private void assertJenkinsEnvironmentVariablesPrefixes(String prefix) {
+        List singleRegistryEnvVars = ["env.${prefix}REGISTRY_URL", "env.${prefix}REGISTRY_URL"]
+        List twoRegistriesEnvVars = ["env.${prefix}REGISTRY_PULL_URL", "env.${prefix}REGISTRY_PULL_PATH",
+                                   "env.${prefix}REGISTRY_PUSH_URL", "env.${prefix}REGISTRY_PUSH_PATH" ]
+        
         assertThat(new File(nginxHelmJenkinsRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains("env.${prefix}K8S_VERSION")
+        
         for (def petclinicRepo : petClinicRepos) {
-            assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains("env.${prefix}REGISTRY_URL")
-            assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains("env.${prefix}REGISTRY_PATH")
+            if (config.registry['twoRegistries']) {
+                twoRegistriesEnvVars.each { expectedEnvVar ->
+                    assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(expectedEnvVar)
+                }
+                singleRegistryEnvVars.each { expectedEnvVar ->
+                    assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).doesNotContain(expectedEnvVar)
+                }
+            } else {
+                singleRegistryEnvVars.each { expectedEnvVar ->
+                    assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(expectedEnvVar)
+                }
+                twoRegistriesEnvVars.each { expectedEnvVar ->
+                    assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).doesNotContain(expectedEnvVar)
+                }
+            }
         }
     }
 
@@ -710,6 +740,7 @@ class ArgoCDTest {
             def tmpDir = repo.absoluteLocalRepoTmpDir
             def jenkinsfile = new File(tmpDir, 'Jenkinsfile')
             assertThat(jenkinsfile).exists()
+            assertJenkinsfileRegistryCredentials()
 
             if (repo.scmmRepoTarget == 'argocd/petclinic-plain') {
                 assertBuildImagesInJenkinsfileReplaced(jenkinsfile)
@@ -782,6 +813,38 @@ class ArgoCDTest {
                 }
             } else {
                 fail("Unkown petclinic repo: $repo")
+            }
+        }
+    }
+
+    void assertJenkinsfileRegistryCredentials() {
+        List singleRegistryExpectedLines = [
+                'docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {',
+                'String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"',
+                'imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"'
+        ]
+        List twoRegistriesExpectedLines = [ 
+                'String pathPrefix = !dockerRegistryPushPath?.trim() ? "" : "${dockerRegistryPushPath}/"',
+                'imageName = "${dockerRegistryPushBaseUrl}/${pathPrefix}${application}:${imageTag}"',
+                'docker.withRegistry("http://${dockerRegistryPullBaseUrl}", dockerRegistryPullCredentials) {',
+                'docker.withRegistry("http://${dockerRegistryPushBaseUrl}", dockerRegistryPushCredentials) {' ]
+        
+        for (def petclinicRepo : petClinicRepos) {
+            String jenkinsfile = new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text
+            if (config.registry['twoRegistries']) {
+                twoRegistriesExpectedLines.each { expectedEnvVar ->
+                    assertThat(jenkinsfile).contains(expectedEnvVar)
+                }
+                singleRegistryExpectedLines.each { expectedEnvVar ->
+                    assertThat(jenkinsfile).doesNotContain(expectedEnvVar)
+                }
+            } else {
+                singleRegistryExpectedLines.each { expectedEnvVar ->
+                    assertThat(jenkinsfile).contains(expectedEnvVar)
+                }
+                twoRegistriesExpectedLines.each { expectedEnvVar ->
+                    assertThat(jenkinsfile).doesNotContain(expectedEnvVar)
+                }
             }
         }
     }


### PR DESCRIPTION
Useful for air-gapped environments.

`developers.md` contains info on how to test this feature.

Expected behavior is that after the Jenkins builds of the two petclinics are done, the two applications are running inside the cluster basing on `localhost:30000/push/` images:

```shell
kubectl get deployment -n example-apps-staging -o=jsonpath="{range .items[*]}{'\n'}{.metadata.name}{':\t'}{range .spec.template.spec.containers[*]}{.image}{', '}{end}{end}"

spring-petclinic-plain: localhost:30000/push/spring-petclinic-plain:202404261302-a026e65-main,
spring-petclinic-helm-springboot:       localhost:30000/push/spring-petclinic-helm:202404261303-3bbd2a9-main,
```