### PR TITLE
Implement air-gapped mode for PrometheusStack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,9 @@
 !scm-manager/
 !scripts/jenkins/
 !scripts/scm-manager/
-!scripts/get-remote-url
 !scripts/utils.sh
 !scripts/apply-ng.sh
+!scripts/downloadHelmCharts.sh
 !.curlrc
 !LICENSE
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ terraform/account.json
 
 gitops-playground.jar
 jenkins-plugins
+/charts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN /jenkins/download-plugins.sh /dist/gitops/jenkins-plugins
 
 RUN mkdir -p /dist/gitops/charts
 COPY src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy /tmp/
-RUN chartDetails=$(grep -C2 kube-prometheus-stack  /tmp/ApplicationConfigurator.groovy) \
+RUN chartDetails=$(grep -C3 kube-prometheus-stack  /tmp/ApplicationConfigurator.groovy) \
   repo=$(echo "$chartDetails"  | grep -oP "repoURL\s*:\s*'\K[^']+") \
   chart=$(echo "$chartDetails" | grep -oP "chart\s*:\s*'\K[^']+") \
   version=$(echo "$chartDetails" | grep -oP "version\s*:\s*'\K[^']+") && \

--- a/argocd/argocd/argocd/values.ftl.yaml
+++ b/argocd/argocd/argocd/values.ftl.yaml
@@ -74,14 +74,25 @@ argo-cd:
         name: nginx-helm-umbrella
         url: ${scmm.baseUrl}/repo/${namePrefix}argocd/nginx-helm-umbrella
         <#if isInsecure>insecure: "true"</#if>
-      bitnami:
-        name: bitnami
-        type: helm
-        url: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+<#if airGapped>
+      prometheus:
+        name: prometheus
+        url: ${scmm.baseUrl}/repo/3rd-party-dependencies/kube-prometheus-stack
+        <#if isInsecure>insecure: "true"</#if>
+      grafana:
+        name: grafana
+        url: ${scmm.baseUrl}/repo/3rd-party-dependencies/grafana
+        <#if isInsecure>insecure: "true"</#if>
+<#else>
       prometheus:
         name: prometheus-community
         type: helm
         url: https://prometheus-community.github.io/helm-charts
+</#if>
+      bitnami:
+        name: bitnami
+        type: helm
+        url: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
       codecentric:
         name: codecentric
         type: helm

--- a/argocd/argocd/argocd/values.ftl.yaml
+++ b/argocd/argocd/argocd/values.ftl.yaml
@@ -79,10 +79,6 @@ argo-cd:
         name: prometheus
         url: ${scmm.baseUrl}/repo/3rd-party-dependencies/kube-prometheus-stack
         <#if isInsecure>insecure: "true"</#if>
-      grafana:
-        name: grafana
-        url: ${scmm.baseUrl}/repo/3rd-party-dependencies/grafana
-        <#if isInsecure>insecure: "true"</#if>
 <#else>
       prometheus:
         name: prometheus-community

--- a/argocd/argocd/argocd/values.ftl.yaml
+++ b/argocd/argocd/argocd/values.ftl.yaml
@@ -74,7 +74,7 @@ argo-cd:
         name: nginx-helm-umbrella
         url: ${scmm.baseUrl}/repo/${namePrefix}argocd/nginx-helm-umbrella
         <#if isInsecure>insecure: "true"</#if>
-<#if airGapped>
+<#if mirrorRepos>
       prometheus:
         name: prometheus
         url: ${scmm.baseUrl}/repo/3rd-party-dependencies/kube-prometheus-stack

--- a/argocd/argocd/projects/cluster-resources.ftl.yaml
+++ b/argocd/argocd/projects/cluster-resources.ftl.yaml
@@ -19,7 +19,7 @@ spec:
   - https://charts.external-secrets.io
   - https://helm.releases.hashicorp.com
   - https://kubernetes.github.io/ingress-nginx
-<#if airGapped>
+<#if mirrorRepos>
   - ${scmm.baseUrl}/repo/3rd-party-dependencies/kube-prometheus-stack
 <#else>
   - https://prometheus-community.github.io/helm-charts

--- a/argocd/argocd/projects/cluster-resources.ftl.yaml
+++ b/argocd/argocd/projects/cluster-resources.ftl.yaml
@@ -18,8 +18,13 @@ spec:
   - https://codecentric.github.io/helm-charts
   - https://charts.external-secrets.io
   - https://helm.releases.hashicorp.com
-  - https://prometheus-community.github.io/helm-charts
   - https://kubernetes.github.io/ingress-nginx
+<#if airGapped>
+  - ${scmm.baseUrl}/repo/3rd-party-dependencies/kube-prometheus-stack
+  - ${scmm.baseUrl}/repo/3rd-party-dependencies/grafana
+<#else>
+  - https://prometheus-community.github.io/helm-charts
+</#if>
 
   # allow to only see application resources from the specified namespace
   sourceNamespaces:

--- a/argocd/argocd/projects/cluster-resources.ftl.yaml
+++ b/argocd/argocd/projects/cluster-resources.ftl.yaml
@@ -21,7 +21,6 @@ spec:
   - https://kubernetes.github.io/ingress-nginx
 <#if airGapped>
   - ${scmm.baseUrl}/repo/3rd-party-dependencies/kube-prometheus-stack
-  - ${scmm.baseUrl}/repo/3rd-party-dependencies/grafana
 <#else>
   - https://prometheus-community.github.io/helm-charts
 </#if>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <exec.mainClass>com.cloudogu.gitops.cli.GitopsPlaygroundCliMain</exec.mainClass>
 
     <okhttpVersion>4.11.0</okhttpVersion>
+    <retrofitVersion>2.9.0</retrofitVersion>
     <groovy.version>4.0.12</groovy.version>
   </properties>
 
@@ -163,7 +164,14 @@
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
-      <version>2.9.0</version>
+      <version>${retrofitVersion}</version>
+    </dependency>
+    
+    <dependency>
+      <!-- Converts HTTP body objects from groovy to JSON -->
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>converter-jackson</artifactId>
+      <version>${retrofitVersion}</version>
     </dependency>
 
     <dependency>

--- a/scripts/downloadHelmCharts.sh
+++ b/scripts/downloadHelmCharts.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+#charts=( 'monitoring' 'externalSecrets' 'vault' 'mailhog' 'ingressNginx' )
+charts=( 'monitoring' )
+APPLICATION_CONFIGURATOR_GROOVY="${1:-src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy}"
+
+tmpRepoFile="$(mktemp)"
+
+mkdir -p charts
+
+for chart in "${charts[@]}"; do
+  chartDetails=$(grep -EA10 "${chart}.*:" "${APPLICATION_CONFIGURATOR_GROOVY}" \
+  | grep -m1 -EA5 'helm.*:')
+  
+  repo=$(echo "$chartDetails"  | grep -oP "repoURL\s*:\s*'\K[^']+")
+  chart=$(echo "$chartDetails" | grep -oP "chart\s*:\s*'\K[^']+") 
+  version=$(echo "$chartDetails" | grep -oP "version\s*:\s*'\K[^']+")
+  
+  helm repo add "$chart" "$repo" --repository-config="${tmpRepoFile}" 
+  helm pull --untar --untardir ./charts "$chart/$chart" --version "$version" --repository-config="${tmpRepoFile}"
+  # Note that keeping charts as tgx would need only 1/10 of storage
+  # But untaring them in groovy would need additional libraries.
+  # As layers of the image are compressed anyway, we'll do the untar process here, pragmatically
+  
+  # Do a simple verification
+   helm template test "./charts/$chart" > /dev/null
+done

--- a/scripts/scm-manager/init-scmm.sh
+++ b/scripts/scm-manager/init-scmm.sh
@@ -122,7 +122,6 @@ function setDefaultBranch() {
 }
 
 function configureScmmManager() {
-  GITOPS_USERNAME="${NAME_PREFIX}gitops"
   GITOPS_PASSWORD=${SCMM_PASSWORD}
 
   METRICS_USERNAME="${NAME_PREFIX}metrics"

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -129,6 +129,8 @@ class GitopsPlaygroundCli  implements Runnable {
     private String baseUrl
     @Option(names = ['--url-separator-hyphen'], description = 'Use hyphens instead of dots to separate application name from base-url')
     private Boolean urlSeparatorHyphen
+    @Option(names = ['--air-gapped'], description = 'Changes the sources of the deployed tools so they are not pulled from the internet and work in air-gapped environments.')
+    private Boolean airGapped
 
     // args group metrics
     @Option(names = ['--metrics', '--monitoring'], description = 'Installs the Kube-Prometheus-Stack. This includes Prometheus, the Prometheus operator, Grafana and some extra resources')
@@ -370,6 +372,7 @@ class GitopsPlaygroundCli  implements Runnable {
                 ],
                 application: [
                         remote        : remote,
+                        airGapped     : airGapped, 
                         insecure      : insecure,
                         debug         : debug,
                         trace         : trace,

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -129,8 +129,8 @@ class GitopsPlaygroundCli  implements Runnable {
     private String baseUrl
     @Option(names = ['--url-separator-hyphen'], description = 'Use hyphens instead of dots to separate application name from base-url')
     private Boolean urlSeparatorHyphen
-    @Option(names = ['--air-gapped'], description = 'Changes the sources of the deployed tools so they are not pulled from the internet and work in air-gapped environments.')
-    private Boolean airGapped
+    @Option(names = ['--mirror-repos'], description = 'Changes the sources of deployed tools so they are not pulled from the internet, but are pulled from git and work in air-gapped environments.')
+    private Boolean mirrorRepos
 
     // args group metrics
     @Option(names = ['--metrics', '--monitoring'], description = 'Installs the Kube-Prometheus-Stack. This includes Prometheus, the Prometheus operator, Grafana and some extra resources')
@@ -372,7 +372,7 @@ class GitopsPlaygroundCli  implements Runnable {
                 ],
                 application: [
                         remote        : remote,
-                        airGapped     : airGapped, 
+                        mirrorRepos     : mirrorRepos, 
                         insecure      : insecure,
                         debug         : debug,
                         trace         : trace,

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -106,7 +106,7 @@ class ApplicationConfigurator {
             ],
             application: [
                     remote        : false,
-                    airGapped     : false,
+                    mirrorRepos     : false,
                     // Take from env because the Dockerfile provides a local copy of the repo for air-gapped mode
                     localHelmChartFolder: System.getenv('LOCAL_HELM_CHART_FOLDER'),
                     insecure      : false,

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -105,6 +105,7 @@ class ApplicationConfigurator {
             ],
             application: [
                     remote        : false,
+                    airGapped     : false,
                     insecure      : false,
                     username      : DEFAULT_ADMIN_USER,
                     password      : DEFAULT_ADMIN_PW,
@@ -177,13 +178,12 @@ class ApplicationConfigurator {
                             helm  : [
                                     /* Before allowing to override this via config, we have to change
                                        ArgoCD.groovy to extract the monitoring CRD from the chart instead of applying 
-                                       from GitHub.
-                                        
-                                        First approach: 
-                                        helm template prometheus-community/kube-prometheus-stack --version XYZ --include-crds */
+                                       from GitHub.*/
                                     chart  : 'kube-prometheus-stack',
                                     repoURL: 'https://prometheus-community.github.io/helm-charts',
                                     version: '58.2.1',
+                                    // Take from env because the Dockerfile provides a local copy of the repo for air-gapped mode
+                                    localFolder: System.getenv('KUBE_PROM_STACK_HELMCHART_PATH'), 
                                     grafanaImage: '',
                                     grafanaSidecarImage: '',
                                     prometheusImage: '',

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -54,7 +54,7 @@ class Schema {
 
      static class ApplicationSchema {
          boolean remote = false
-         boolean airGapped = false
+         boolean mirrorRepos = false
          boolean insecure = false
          boolean yes = false
          String username = ""

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -54,6 +54,7 @@ class Schema {
 
      static class ApplicationSchema {
          boolean remote = false
+         boolean airGapped = false
          boolean insecure = false
          boolean yes = false
          String username = ""

--- a/src/main/groovy/com/cloudogu/gitops/dependencyinjection/RetrofitFactory.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/dependencyinjection/RetrofitFactory.groovy
@@ -12,6 +12,7 @@ import jakarta.inject.Singleton
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
 
 @Factory
 class RetrofitFactory {
@@ -30,6 +31,8 @@ class RetrofitFactory {
         return new Retrofit.Builder()
                 .baseUrl(configuration.config.scmm['url'] as String + '/api/')
                 .client(okHttpClient)
+                 // Converts HTTP body objects from groovy to JSON
+                .addConverterFactory(JacksonConverterFactory.create())
                 .build()
     }
 

--- a/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
@@ -119,30 +119,12 @@ class PrometheusStack extends Feature {
 
 
         if (config.application['airGapped']) {
-            log.debug("Air-gapped mode: Deploying prometheus and grafana separately from mirrored repos from Git")
+            log.debug("Air-gapped mode: Deploying prometheus from local git repo")
 
-            def grafanaHelmValuesFile = fileSystemUtils.createTempFile()
-            fileSystemUtils.writeYaml(helmValuesYaml['grafana'] as Map, grafanaHelmValuesFile.toFile())
+            String prometheusVersion =
+                    new YamlSlurper().parse(Path.of(config['features']['monitoring']['helm']['localFolder'] as String,
+                    'Chart.yaml'))['version']
             
-            helmValuesYaml.remove('grafana')
-            fileSystemUtils.writeYaml(helmValuesYaml, prometheusHelmValuesFile.toFile())
-
-            def ys = new YamlSlurper()
-            String grafanaVersion = 
-                    ys.parse(Path.of("${config['features']['monitoring']['helm']['localFolder']}/charts/grafana",
-                    'Chart.yaml'))['version']
-            String prometheusVersion = 
-                    ys.parse(Path.of(config['features']['monitoring']['helm']['localFolder'] as String,
-                    'Chart.yaml'))['version']
-
-            deployer.deployFeature(
-                    "${scmmUri}/repo/${ScmManager.NAMESPACE_3RD_PARTY_DEPENDENCIES}/grafana",
-                    'grafana',
-                    '.',
-                    grafanaVersion,
-                    'monitoring',
-                    'grafana',
-                    grafanaHelmValuesFile, RepoType.GIT)
             deployer.deployFeature(
                     "${scmmUri}/repo/${ScmManager.NAMESPACE_3RD_PARTY_DEPENDENCIES}/kube-prometheus-stack",
                     'prometheusstack',

--- a/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
@@ -121,8 +121,8 @@ class PrometheusStack extends Feature {
         setCustomImages(helmConfig, helmValuesYaml)
 
 
-        if (config.application['airGapped']) {
-            log.debug("Air-gapped mode: Deploying prometheus from local git repo")
+        if (config.application['mirrorRepos']) {
+            log.debug("Mirroring repos: Deploying prometheus from local git repo")
 
             def repoNamespaceAndName = airGappedUtils.mirrorHelmRepoToGit(config['features']['monitoring']['helm'] as Map)
 

--- a/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
@@ -4,21 +4,12 @@ import com.cloudogu.gitops.Feature
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.features.deployment.DeploymentStrategy
 import com.cloudogu.gitops.features.deployment.HelmStrategy
-import com.cloudogu.gitops.scmm.ScmmRepo
-import com.cloudogu.gitops.scmm.ScmmRepoProvider
-import com.cloudogu.gitops.scmm.api.Permission
-import com.cloudogu.gitops.scmm.api.Repository
-import com.cloudogu.gitops.scmm.api.RepositoryApi
 import com.cloudogu.gitops.utils.CommandExecutor
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.cloudogu.gitops.utils.TemplatingEngine
 import groovy.util.logging.Slf4j
-import groovy.yaml.YamlSlurper
 import io.micronaut.core.annotation.Order
 import jakarta.inject.Singleton
-import retrofit2.Response
-
-import java.nio.file.Path
 
 @Slf4j
 @Singleton
@@ -26,32 +17,23 @@ import java.nio.file.Path
 class ScmManager extends Feature {
 
     static final String HELM_VALUES_PATH = "scm-manager/values.ftl.yaml"
-    static final String NAMESPACE_3RD_PARTY_DEPENDENCIES = '3rd-party-dependencies'
 
     private Map config
     private CommandExecutor commandExecutor
     private FileSystemUtils fileSystemUtils
     private DeploymentStrategy deployer
-    private ScmmRepoProvider repoProvider
-    private RepositoryApi repositoryApi
-    private String gitOpsUsername
 
     ScmManager(
             Configuration config,
             CommandExecutor commandExecutor,
             FileSystemUtils fileSystemUtils,
-            ScmmRepoProvider repoProvider,
-            RepositoryApi repositoryApi,
             // For now we deploy imperatively using helm to avoid order problems. In future we could deploy via argocd.
             HelmStrategy deployer
     ) {
         this.config = config.getConfig()
         this.commandExecutor = commandExecutor
         this.fileSystemUtils = fileSystemUtils
-        this.repoProvider = repoProvider
-        this.repositoryApi = repositoryApi
         this.deployer = deployer
-        this.gitOpsUsername = "${this.config.application['namePrefix']}gitops"
     }
 
     @Override
@@ -89,7 +71,7 @@ class ScmManager extends Feature {
                 GIT_COMMITTER_EMAIL          : config.application['gitEmail'],
                 GIT_AUTHOR_NAME              : config.application['gitName'],
                 GIT_AUTHOR_EMAIL             : config.application['gitEmail'],
-                GITOPS_USERNAME              : gitOpsUsername,
+                GITOPS_USERNAME              : config.scmm['gitOpsUsername'],
                 TRACE                        : config.application['trace'],
                 SCMM_URL                     : config.scmm['url'],
                 SCMM_USERNAME                : config.scmm['username'],
@@ -107,90 +89,5 @@ class ScmManager extends Feature {
                 NAME_PREFIX                  : config.application['namePrefix'],
                 INSECURE                     : config.application['insecure'],
         ])
-
-        if (config.application['airGapped']) {
-            log.debug("Air-gapped mode: Preparing mirrored repos")
-            
-            // In air-gapped mode, the chart's dependencies can't be resolved.
-            // As helm does not provide an option for changing them interactively, we push the charts into a separate repo.
-            // We alter these repos to resolve dependencies locally
-            
-            preparePrometheusRepo()
-        }
-    }
-
-    private void preparePrometheusRepo() {
-        if (!config['features']['monitoring']['active']) {
-            return
-        }
-        
-        log.debug("Air-gapped mode: Preparing Prometheus")
-        def helmConfig = config['features']['monitoring']['helm']
-        def namespace = NAMESPACE_3RD_PARTY_DEPENDENCIES
-        String repoName = helmConfig['chart']
-        
-        createRepo(namespace, repoName, "Mirror of Helm chart $repoName from ${helmConfig['repoURL']}")
-
-        ScmmRepo prometheusRepo = repoProvider.getRepo("$namespace/${repoName}")
-        prometheusRepo.cloneRepo()
-        prometheusRepo.copyDirectoryContents(helmConfig['localFolder'] as String)
-
-        def prometheusChartYaml = localizeChartYaml(prometheusRepo)
-
-        // Chart.lock contains pinned dependencies and digest. 
-        // We either have to update or remove them. Take the easier approach.
-        new File(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.lock').delete()
-
-        prometheusRepo.commitAndPush("Chart ${prometheusChartYaml.name}, version: ${prometheusChartYaml.version}\n\n" +
-                "Source: ${helmConfig['repoURL']}\n" +
-                "Dependencies localized to run in air-gapped environments", prometheusChartYaml.version as String)
-    }
-
-    private void createRepo(String namespace, String repoName, String description) {
-        def repo = new Repository(namespace, repoName, description)
-        def createResponse = repositoryApi.create(repo, true).execute()
-        handleResponse(createResponse, repo)
-        
-        def permission = new Permission(gitOpsUsername, Permission.Role.WRITE)
-        def permissionResponse = repositoryApi.createPermission(namespace, repoName, permission).execute()
-        handleResponse(permissionResponse, permission, "for repo $namespace/$repoName")
-    }
-
-    private void handleResponse(Response<Void> response, Object body, String additionalMessage = '') {
-        if (response.code() == 409) {
-            // Here, we could consider sending another request for changing the existing object to become proper idempotent
-            log.debug("${body.class.simpleName} already exists ${additionalMessage}, ignoring: ${body}")
-        } else if (response.code() != 201) {
-            throw new RuntimeException("Could not create ${body.class.simpleName} ${additionalMessage}.\n${body}\n" +
-                    "HTTP Details: ${response.code()} ${response.message()}: ${response.errorBody().string()}")
-        }
-    }
-
-    private Map localizeChartYaml(ScmmRepo scmmRepo) {
-        log.debug("Preparing repo ${scmmRepo.scmmRepoTarget} for air-gapped use: Changing Chart.yaml to resolve depencies locally")
-        
-        def chartYamlPath = Path.of(scmmRepo.absoluteLocalRepoTmpDir, 'Chart.yaml')
-        def chartLockPath = Path.of(scmmRepo.absoluteLocalRepoTmpDir, 'Chart.lock')
-
-        def ys = new YamlSlurper()
-        Map chartYaml = ys.parse(chartYamlPath) as Map
-        Map chartLock = ys.parse(chartLockPath) as Map
-        
-        (chartYaml['dependencies'] as List).each { chartYamlDep ->
-            // Resolve proper dependency version from Chart.lock, e.g. 5.18.* -> 5.18.1
-            def chartLockDep = chartLock.dependencies.find { dep -> dep['name'] == chartYamlDep['name'] }
-            if (chartLockDep) {
-                chartYamlDep['version'] = chartLockDep['version']
-            } else if ((chartYamlDep['version'] as String).contains('*')) {
-                throw new RuntimeException("Unable to determine proper version for dependency " +
-                        "${chartYamlDep['name']} (version: ${chartYamlDep['version']}) from repo ${scmmRepo.scmmRepoTarget}")
-            }
-            
-            // Remove link to external repo, to force using local one
-            chartYamlDep['repository'] = ''
-        }
-        
-        fileSystemUtils.writeYaml(chartYaml, chartYamlPath.toFile())
-        return chartYaml
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
@@ -4,12 +4,21 @@ import com.cloudogu.gitops.Feature
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.features.deployment.DeploymentStrategy
 import com.cloudogu.gitops.features.deployment.HelmStrategy
+import com.cloudogu.gitops.scmm.ScmmRepo
+import com.cloudogu.gitops.scmm.ScmmRepoProvider
+import com.cloudogu.gitops.scmm.api.Permission
+import com.cloudogu.gitops.scmm.api.Repository
+import com.cloudogu.gitops.scmm.api.RepositoryApi
 import com.cloudogu.gitops.utils.CommandExecutor
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.cloudogu.gitops.utils.TemplatingEngine
 import groovy.util.logging.Slf4j
+import groovy.yaml.YamlSlurper
 import io.micronaut.core.annotation.Order
 import jakarta.inject.Singleton
+import retrofit2.Response
+
+import java.nio.file.Path
 
 @Slf4j
 @Singleton
@@ -17,23 +26,36 @@ import jakarta.inject.Singleton
 class ScmManager extends Feature {
 
     static final String HELM_VALUES_PATH = "scm-manager/values.ftl.yaml"
+    static final String NAMESPACE_3RD_PARTY_DEPENDENCIES = '3rd-party-dependencies'
 
     private Map config
     private CommandExecutor commandExecutor
     private FileSystemUtils fileSystemUtils
     private DeploymentStrategy deployer
+    private String gitName
+    private String gitEmail
+    private ScmmRepoProvider repoProvider
+    private RepositoryApi repositoryApi
+    private String gitOpsUsername
 
     ScmManager(
             Configuration config,
             CommandExecutor commandExecutor,
             FileSystemUtils fileSystemUtils,
+            ScmmRepoProvider repoProvider,
+            RepositoryApi repositoryApi,
             // For now we deploy imperatively using helm to avoid order problems. In future we could deploy via argocd.
             HelmStrategy deployer
     ) {
         this.config = config.getConfig()
         this.commandExecutor = commandExecutor
         this.fileSystemUtils = fileSystemUtils
+        this.repoProvider = repoProvider
+        this.repositoryApi = repositoryApi
         this.deployer = deployer
+        this.gitName = this.config['application']['gitName']
+        this.gitEmail = this.config['application']['gitEmail']
+        this.gitOpsUsername = "${this.config.application['namePrefix']}gitops"
     }
 
     @Override
@@ -71,6 +93,7 @@ class ScmManager extends Feature {
                 GIT_COMMITTER_EMAIL          : config.application['gitEmail'],
                 GIT_AUTHOR_NAME              : config.application['gitName'],
                 GIT_AUTHOR_EMAIL             : config.application['gitEmail'],
+                GITOPS_USERNAME              : gitOpsUsername,
                 TRACE                        : config.application['trace'],
                 SCMM_URL                     : config.scmm['url'],
                 SCMM_USERNAME                : config.scmm['username'],
@@ -88,5 +111,102 @@ class ScmManager extends Feature {
                 NAME_PREFIX                  : config.application['namePrefix'],
                 INSECURE                     : config.application['insecure'],
         ])
+
+        if (config.application['airGapped']) {
+            log.debug("Air-gapped mode: Preparing mirrored repos")
+            
+            // In air-gapped mode, the chart's dependencies can't be resolved.
+            // As helm does not provide an option for changing them interactively, we push the charts into a separate repo.
+            // There, we remove all dependencies, and deploy them separately.
+            
+            // TODO only when monitoring active!
+            
+            def helmConfig = config['features']['monitoring']['helm']
+            // TODO move to AppConfigurator
+            if (!helmConfig['localFolder']) {
+                // This should only happen when run outside the image, i.e. during development
+                throw new RuntimeException("Missing config for localFolder of helm chart ${helmConfig['chart']}.\n " +
+                        "Either run inside the official container image or setting env var" +
+                        "KUBE_PROM_STACK_HELMCHART_PATH='charts/kube-prometheus-stack' after running this:\n" +
+                        "helm repo add prometheus-community ${helmConfig['repoURL']}\n" +
+                        "helm pull --untar --untardir charts prometheus-community/${helmConfig['chart']} --version ${helmConfig['version']}")
+            }
+
+            preparePrometheusRepo()
+
+            prepareGrafanaRepo()
+        }
+    }
+
+    protected void preparePrometheusRepo() {
+        def helmConfig = config['features']['monitoring']['helm']
+        def namespace = NAMESPACE_3RD_PARTY_DEPENDENCIES
+        String repoName = helmConfig['chart']
+        def ys = new YamlSlurper()
+        
+        createRepo(namespace, repoName, "Mirror of Helm chart $repoName from ${helmConfig['repoURL']}")
+
+        ScmmRepo prometheusRepo = repoProvider.getRepo("$namespace/${repoName}")
+        prometheusRepo.cloneRepo()
+        prometheusRepo.copyDirectoryContents(helmConfig['localFolder'] as String)
+
+        log.debug("Preparing repo ${prometheusRepo.scmmRepoTarget} for air-gapped use: Removing external dependencies.")
+        def prometheusChartYamlPath = Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.yaml')
+        Map prometheusChartYaml = ys.parse(prometheusChartYamlPath) as Map
+        (prometheusChartYaml['dependencies'] as List).removeAll { it['name'] != 'crds' }
+        fileSystemUtils.writeYaml(prometheusChartYaml, prometheusChartYamlPath.toFile())
+
+        fileSystemUtils.deleteFilesExcept(new File(prometheusRepo.absoluteLocalRepoTmpDir, 'charts'), 'crds')
+        
+        // Chart.lock contains pinned dependencies and digest. 
+        // Both have to go because they no longer match after changes made above
+        new File(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.lock').delete()
+
+        prometheusRepo.commitAndPush("Chart ${prometheusChartYaml.name}, version: ${prometheusChartYaml.version}\n\n" +
+                "Source: ${helmConfig['repoURL']}\n" +
+                "Dependencies removed to run in air-gapped environments", prometheusChartYaml.version as String)
+    }
+
+    protected void prepareGrafanaRepo() {
+        def helmConfig = config['features']['monitoring']['helm']
+        def namespace = NAMESPACE_3RD_PARTY_DEPENDENCIES
+        def repoName = 'grafana'
+        def ys = new YamlSlurper()
+        
+        def prometheusChartYamlPath = Path.of(helmConfig['localFolder'] as String, 'Chart.yaml')
+        Map grafanaDependencyFromPrometheusChart = ys.parse(prometheusChartYamlPath)['dependencies'].find { it['name'] == 'grafana' } as Map
+        def repositoryUrl = grafanaDependencyFromPrometheusChart.repository
+
+        createRepo(namespace, repoName, "Mirror of Helm chart ${repoName} from ${repositoryUrl}")
+
+        ScmmRepo grafanaRepo =  repoProvider.getRepo("$namespace/${repoName}")
+        grafanaRepo.cloneRepo()
+        grafanaRepo.copyDirectoryContents("${helmConfig['localFolder']}/charts/$repoName")
+
+        def grafanaChartYamlPath = Path.of(grafanaRepo.absoluteLocalRepoTmpDir, 'Chart.yaml')
+        Map grafanaChartYaml = ys.parse(grafanaChartYamlPath) as Map
+
+        grafanaRepo.commitAndPush("Chart ${repoName}, version: ${grafanaChartYaml.version}\n\n" +
+                "Source: ${repositoryUrl}", grafanaChartYaml.version as String)
+    }
+
+    void createRepo(String namespace, String repoName, String description) {
+        def repo = new Repository(namespace, repoName, description)
+        def createResponse = repositoryApi.create(repo, true).execute()
+        handleResponse(createResponse, repo)
+        
+        def permission = new Permission(gitOpsUsername, Permission.Role.WRITE)
+        def permissionResponse = repositoryApi.createPermission(namespace, repoName, permission).execute()
+        handleResponse(permissionResponse, permission, "for repo $namespace/$repoName")
+    }
+
+    protected void handleResponse(Response<Void> response, Object body, String additionalMessage = '') {
+        if (response.code() == 409) {
+            // Here, we could consider sending another request for changing the existing object to become proper idempotent
+            log.debug("${body.class.simpleName} already exists ${additionalMessage}, ignoring: ${body}")
+        } else if (response.code() != 201) {
+            throw new RuntimeException("Could not create ${body.class.simpleName} ${additionalMessage}.\n${body}\n" +
+                    "HTTP Details: ${response.code()} ${response.message()}: ${response.errorBody().string()}")
+        }
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -198,7 +198,7 @@ class ArgoCD extends Feature {
             k8sClient.createNamespace('monitoring')
 
             def serviceMonitorCrdYaml
-            if (config.application['airGapped']) {
+            if (config.application['mirrorRepos']) {
                 serviceMonitorCrdYaml = Path.of(
                         "${config.application['localHelmChartFolder']}/${config['features']['monitoring']['helm']['chart']}/charts/crds/crds/crd-servicemonitors.yaml"
                 ).toString()
@@ -342,7 +342,7 @@ class ArgoCD extends Feature {
                     isRemote            : config.application['remote'],
                     isInsecure          : config.application['insecure'],
                     urlSeparatorHyphen  : config.application['urlSeparatorHyphen'],
-                    airGapped           : config.application['airGapped'],
+                    mirrorRepos           : config.application['mirrorRepos'],
                     argocd              : [
                             // Note that passing the URL object here leads to problems in Graal Native image, see Git history
                             host: config.features['argocd']['url'] ? new URL(config.features['argocd']['url'] as String).host : "",

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -195,7 +195,11 @@ class ArgoCD extends Feature {
         
         log.debug("Creating namespace for monitoring, so argocd can add its service monitors there")
         k8sClient.createNamespace('monitoring')
+        
         log.debug("Applying ServiceMonitor CRD; Argo CD fails if it is not there. Chicken-egg-problem.")
+        // Instead of applying this straight from github we should extract the CRDs from the chart
+        // Either from the one packaged in the image or like this:
+        // helm template prometheus-community/kube-prometheus-stack --version XYZ --include-crds
         k8sClient.applyYaml("https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${config['features']['monitoring']['helm']['version']}/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml")
 
         log.debug("Creating repo credential secret that is used by argocd to access repos in SCM-Manager")
@@ -327,6 +331,7 @@ class ArgoCD extends Feature {
                     isRemote            : config.application['remote'],
                     isInsecure          : config.application['insecure'],
                     urlSeparatorHyphen  : config.application['urlSeparatorHyphen'],
+                    airGapped           : config.application['airGapped'],
                     argocd              : [
                             // Note that passing the URL object here leads to problems in Graal Native image, see Git history
                             host: config.features['argocd']['url'] ? new URL(config.features['argocd']['url'] as String).host : "",

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -199,8 +199,9 @@ class ArgoCD extends Feature {
 
             def serviceMonitorCrdYaml
             if (config.application['airGapped']) {
-                serviceMonitorCrdYaml = Path.of(config['features']['monitoring']['helm']['localFolder'] as String,
-                        'charts/crds/crds/crd-servicemonitors.yaml').toString()
+                serviceMonitorCrdYaml = Path.of(
+                        "${config.application['localHelmChartFolder']}/${config['features']['monitoring']['helm']['chart']}/charts/crds/crds/crd-servicemonitors.yaml"
+                ).toString()
             } else {
                 serviceMonitorCrdYaml = 
                         "https://raw.githubusercontent.com/prometheus-community/helm-charts/" +

--- a/src/main/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategy.groovy
@@ -27,7 +27,7 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
     }
 
     @Override
-    @SuppressWarnings('GroovyGStringKey') // Using key string seems an easy to read way avoid more ifs
+    @SuppressWarnings('GroovyGStringKey') // Using dynamic strings as keys seems an easy to read way to avoid more ifs
     void deployFeature(String repoURL, String repoName, String chartOrPath, String version, String namespace,
                        String releaseName, Path helmValuesPath, RepoType repoType) {
         def namePrefix = config.application['namePrefix']

--- a/src/main/groovy/com/cloudogu/gitops/features/deployment/Deployer.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/deployment/Deployer.groovy
@@ -20,11 +20,12 @@ class Deployer implements DeploymentStrategy {
     }
 
     @Override
-    void deployFeature(String repoURL, String repoName, String chart, String version, String namespace, String releaseName, Path helmValuesPath) {
+    void deployFeature(String repoURL, String repoName, String chartOrPath, String version, String namespace,
+                       String releaseName, Path helmValuesPath, RepoType repoType) {
         if (config.features['argocd']['active']) {
-            argoCdStrategy.deployFeature(repoURL, repoName, chart, version, namespace, releaseName, helmValuesPath)
+            argoCdStrategy.deployFeature(repoURL, repoName, chartOrPath, version, namespace, releaseName, helmValuesPath, repoType)
         } else {
-            helmStrategy.deployFeature(repoURL, repoName, chart, version, namespace, releaseName, helmValuesPath)
+            helmStrategy.deployFeature(repoURL, repoName, chartOrPath, version, namespace, releaseName, helmValuesPath, repoType)
         }
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/deployment/DeploymentStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/deployment/DeploymentStrategy.groovy
@@ -3,5 +3,13 @@ package com.cloudogu.gitops.features.deployment
 import java.nio.file.Path
 
 interface DeploymentStrategy {
-    void deployFeature(String repoURL, String repoName, String chart, String version, String namespace, String releaseName, Path helmValuesPath)
+    void deployFeature(String repoURL, String repoName, String chartOrPath, String version, String namespace,
+                       String releaseName, Path helmValuesPath, RepoType repoType)
+
+    default void deployFeature(String repoURL, String repoName, String chart, String version, String namespace,
+                               String releaseName, Path helmValuesPath) {
+        deployFeature(repoURL, repoName, chart, version, namespace, releaseName, helmValuesPath, RepoType.HELM)
+    }
+    
+    enum RepoType { HELM, GIT }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/deployment/HelmStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/deployment/HelmStrategy.groovy
@@ -17,11 +17,19 @@ class HelmStrategy implements DeploymentStrategy {
     }
 
     @Override
-    void deployFeature(String repoURL, String repoName, String chart, String version, String namespace, String releaseName, Path helmValuesPath) {
+    void deployFeature(String repoURL, String repoName, String chartOrPath, String version, String namespace,
+                       String releaseName, Path helmValuesPath, RepoType repoType) {
+        
+        if (repoType == RepoType.GIT) {
+            // This would be possible with plugins or by pulling the repo first, but for now, we don't need it
+            throw new RuntimeException("Unable to deploy helm chart via Helm CLI from Git URL, because helm does not support this out of the box.\n" +
+                    "Repo URL: ${repoURL}")
+        }
+        
         def namePrefix = config.application['namePrefix']
 
         helmClient.addRepo(repoName, repoURL)
-        helmClient.upgrade(releaseName, "$repoName/$chart",
+        helmClient.upgrade(releaseName, "$repoName/$chartOrPath",
                 [namespace: "${namePrefix}${namespace}".toString(),
                  version  : version,
                  values   : helmValuesPath.toString()])

--- a/src/main/groovy/com/cloudogu/gitops/scmm/ScmmRepo.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/scmm/ScmmRepo.groovy
@@ -17,6 +17,8 @@ import java.util.regex.Pattern
 @Slf4j
 class ScmmRepo {
 
+    static final String NAMESPACE_3RD_PARTY_DEPENDENCIES = '3rd-party-dependencies'
+    
     private String scmmRepoTarget
     private String username
     private String password
@@ -36,7 +38,8 @@ class ScmmRepo {
         this.username =  config.scmm["internal"] ? config.application["username"] : config.scmm["username"]
         this.password = config.scmm["internal"] ? config.application["password"] : config.scmm["password"]
         this.scmmUrl = "${config.scmm["protocol"]}://${config.scmm["host"]}"
-        this.scmmRepoTarget =  "${config.application['namePrefix']}${scmmRepoTarget}"
+        this.scmmRepoTarget =  scmmRepoTarget.startsWith(NAMESPACE_3RD_PARTY_DEPENDENCIES) ? scmmRepoTarget : 
+                "${config.application['namePrefix']}${scmmRepoTarget}"
         this.absoluteLocalRepoTmpDir = tmpDir.absolutePath
         this.fileSystemUtils = fileSystemUtils
         this.insecure = config.application['insecure']

--- a/src/main/groovy/com/cloudogu/gitops/scmm/api/Permission.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/scmm/api/Permission.groovy
@@ -1,0 +1,24 @@
+package com.cloudogu.gitops.scmm.api
+
+class Permission {
+    final String name
+    final Role role
+    final List<String> verbs
+    final boolean groupPermission
+
+    Permission(String name, Role role, boolean groupPermission = false, List<String> verbs = []) {
+        this.name = name
+        this.role = role
+        this.verbs = verbs
+        this.groupPermission = groupPermission
+    }
+
+    @Override
+    String toString() {
+        "Permission{name='$name', role=$role, verbs=$verbs, groupPermission=$groupPermission}"
+    }
+
+    enum Role {
+        READ, WRITE,OWNER
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/scmm/api/Repository.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/scmm/api/Repository.groovy
@@ -1,0 +1,22 @@
+package com.cloudogu.gitops.scmm.api
+
+class Repository {
+    final String name
+    final String namespace
+    final String type
+    final String contact
+    final String description
+
+    Repository(String namespace, String name, String description = null, String contact = null, String type = 'git') {
+        this.namespace = namespace
+        this.name = name
+        this.type = type
+        this.contact = contact
+        this.description = description
+    }
+
+    @Override
+    String toString() {
+        "Repository{name='$name', namespace='$namespace', type='$type', contact='$contact', description='$description'}"
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/scmm/api/RepositoryApi.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/scmm/api/RepositoryApi.groovy
@@ -2,10 +2,17 @@ package com.cloudogu.gitops.scmm.api
 
 import okhttp3.ResponseBody
 import retrofit2.Call
-import retrofit2.http.DELETE
-import retrofit2.http.Path
+import retrofit2.http.*
 
 interface RepositoryApi {
     @DELETE("v2/repositories/{namespace}/{name}")
     Call<ResponseBody> delete(@Path("namespace") String namespace, @Path("name") String name)
+
+    @POST("v2/repositories/")
+    @Headers("Content-Type: application/vnd.scmm-repository+json;v=2")
+    Call<Void> create(@Body Repository repository, @Query("initialize") boolean initialize)
+
+    @POST("v2/repositories/{namespace}/{name}/permissions/")
+    @Headers("Content-Type: application/vnd.scmm-repositoryPermission+json")
+    Call<Void> createPermission(@Path("namespace") String namespace, @Path("name") String name, @Body Permission permission)
 }

--- a/src/main/groovy/com/cloudogu/gitops/utils/AirGappedUtils.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/AirGappedUtils.groovy
@@ -110,7 +110,7 @@ class AirGappedUtils {
         def dependencies = chartYaml['dependencies'] ?: []
         (dependencies as List).each { chartYamlDep ->
             // Resolve proper dependency version from Chart.lock, e.g. 5.18.* -> 5.18.1
-            def chartLockDep = chartLock.dependencies.find { dep -> dep['name'] == chartYamlDep['name'] }
+            def chartLockDep = findByName(chartLock.dependencies as List, chartYamlDep['name'] as String)
             if (chartLockDep) {
                 chartYamlDep['version'] = chartLockDep['version']
             } else if ((chartYamlDep['version'] as String).contains('*')) {
@@ -124,5 +124,14 @@ class AirGappedUtils {
 
         fileSystemUtils.writeYaml(chartYaml, chartYamlPath.toFile())
         return chartYaml
+    }
+
+    Map findByName(List<Map> list, String name) {
+        if (!list) return [:]
+        // Note that list.find{} does not work in GraalVM native image: 
+        // UnsupportedFeatureError: Runtime reflection is not supported
+        list.stream()
+                .filter(map -> map['name'] == name)
+                .findFirst().orElse([:])
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/utils/AirGappedUtils.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/AirGappedUtils.groovy
@@ -1,0 +1,113 @@
+package com.cloudogu.gitops.utils
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.scmm.ScmmRepo
+import com.cloudogu.gitops.scmm.ScmmRepoProvider
+import com.cloudogu.gitops.scmm.api.Permission
+import com.cloudogu.gitops.scmm.api.Repository
+import com.cloudogu.gitops.scmm.api.RepositoryApi
+import groovy.util.logging.Slf4j
+import groovy.yaml.YamlSlurper
+import jakarta.inject.Singleton
+import retrofit2.Response
+
+import java.nio.file.Path
+
+@Slf4j
+@Singleton
+class AirGappedUtils {
+
+    private Map config
+    private ScmmRepoProvider repoProvider
+    private RepositoryApi repositoryApi
+    private FileSystemUtils fileSystemUtils
+
+    AirGappedUtils(Configuration config, ScmmRepoProvider repoProvider, RepositoryApi repositoryApi, FileSystemUtils fileSystemUtils) {
+        this.config = config.getConfig()
+        this.repoProvider = repoProvider
+        this.repositoryApi = repositoryApi
+        this.fileSystemUtils = fileSystemUtils
+    }
+
+    /**
+     * In air-gapped mode, the chart's dependencies can't be resolved.
+     * As helm does not provide an option for changing them interactively, we push the charts into a separate repo. 
+     * We alter these repos to resolve dependencies locally from SCM.
+     * 
+     * @return the repo namespace and name
+     */
+    String mirrorHelmRepoToGit(Map helmConfig) {
+        String repoName = helmConfig['chart']
+        String namespace = ScmmRepo.NAMESPACE_3RD_PARTY_DEPENDENCIES
+        def repoNamespaceAndName = "${namespace}/${repoName}"
+        def localHelmChartFolder = "${config.application['localHelmChartFolder']}/${repoName}"
+        // TODO check if folder exists
+
+        createRepo(namespace, repoName,"Mirror of Helm chart $repoName from ${helmConfig['repoURL']}")
+
+        ScmmRepo repo = repoProvider.getRepo(repoNamespaceAndName)
+        repo.cloneRepo()
+
+        repo.copyDirectoryContents(localHelmChartFolder)
+
+        def chartYaml = localizeChartYaml(repo)
+
+        // Chart.lock contains pinned dependencies and digest.
+        // We either have to update or remove them. Take the easier approach.
+        new File(repo.absoluteLocalRepoTmpDir, 'Chart.lock').delete()
+
+        repo.commitAndPush("Chart ${chartYaml.name}, version: ${chartYaml.version}\n\n" +
+                "Source: ${helmConfig['repoURL']}\n" +
+                "Dependencies localized to run in air-gapped environments", chartYaml.version as String)
+        return repoNamespaceAndName
+    }
+
+    // This could be moved to ScmmRepo, if needed
+    private void createRepo(String namespace, String repoName, String description) {
+        def repo = new Repository(namespace, repoName, description)
+        def createResponse = repositoryApi.create(repo, true).execute()
+        handleResponse(createResponse, repo)
+
+        def permission = new Permission(config.scmm['gitOpsUsername'] as String, Permission.Role.WRITE)
+        def permissionResponse = repositoryApi.createPermission(namespace, repoName, permission).execute()
+        handleResponse(permissionResponse, permission, "for repo $namespace/$repoName")
+    }
+
+    private static void handleResponse(Response<Void> response, Object body, String additionalMessage = '') {
+        if (response.code() == 409) {
+            // Here, we could consider sending another request for changing the existing object to become proper idempotent
+            log.debug("${body.class.simpleName} already exists ${additionalMessage}, ignoring: ${body}")
+        } else if (response.code() != 201) {
+            throw new RuntimeException("Could not create ${body.class.simpleName} ${additionalMessage}.\n${body}\n" +
+                    "HTTP Details: ${response.code()} ${response.message()}: ${response.errorBody().string()}")
+        }
+    }
+
+    private Map localizeChartYaml(ScmmRepo scmmRepo) {
+        log.debug("Preparing repo ${scmmRepo.scmmRepoTarget} for air-gapped use: Changing Chart.yaml to resolve depencies locally")
+
+        def chartYamlPath = Path.of(scmmRepo.absoluteLocalRepoTmpDir, 'Chart.yaml')
+        def chartLockPath = Path.of(scmmRepo.absoluteLocalRepoTmpDir, 'Chart.lock')
+
+        def ys = new YamlSlurper()
+        Map chartYaml = ys.parse(chartYamlPath) as Map
+        Map chartLock = ys.parse(chartLockPath) as Map
+
+        (chartYaml['dependencies'] as List).each { chartYamlDep ->
+            // Resolve proper dependency version from Chart.lock, e.g. 5.18.* -> 5.18.1
+            def chartLockDep = chartLock.dependencies.find { dep -> dep['name'] == chartYamlDep['name'] }
+            if (chartLockDep) {
+                chartYamlDep['version'] = chartLockDep['version']
+            } else if ((chartYamlDep['version'] as String).contains('*')) {
+                throw new RuntimeException("Unable to determine proper version for dependency " +
+                        "${chartYamlDep['name']} (version: ${chartYamlDep['version']}) from repo ${scmmRepo.scmmRepoTarget}")
+            }
+
+            // Remove link to external repo, to force using local one
+            chartYamlDep['repository'] = ''
+        }
+
+        fileSystemUtils.writeYaml(chartYaml, chartYamlPath.toFile())
+        return chartYaml
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/utils/FileSystemUtils.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/FileSystemUtils.groovy
@@ -163,4 +163,17 @@ class FileSystemUtils {
         builder yaml
         file.setText(builder.toString())
     }
+
+    void deleteFilesExcept(File parentPath, String ... fileOrFolderNamesToKeep) {
+        for(File file: parentPath.listFiles()) {
+            if (file.name in fileOrFolderNamesToKeep) {
+                continue
+            }
+            if (!file.isDirectory()) {
+                file.delete()
+            } else {
+                file.deleteDir()
+            }
+        }
+    }
 }

--- a/src/main/groovy/com/cloudogu/gitops/utils/HelmClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/HelmClient.groovy
@@ -15,21 +15,32 @@ class HelmClient {
     }
 
     String addRepo(String repoName, String url) {
-        commandExecutor.execute("helm repo add ${repoName} ${url}").stdOut
+        helm(['repo', 'add', repoName, url ])
     }
     
     String dependencyBuild(String path) {
-        String command =  "helm dependency build ${path}"
-        commandExecutor.execute(command).stdOut
+        helm(['dependency', 'build', path ])
     }
     
     String upgrade(String release, String chartOrPath, Map args) {
-        String command =  "helm upgrade -i ${release} ${chartOrPath} " +
-                "${args.version? "--version ${args.version} " : ''}" +
-                "${args.values? "--values ${args.values} " : ''}" +
-                "${args.namespace? "--namespace ${args.namespace} " : ''}" +
-                '--create-namespace '
-        commandExecutor.execute(command).stdOut
+        helm(['upgrade', '-i', release, chartOrPath, '--create-namespace' ], args)
+    }
+    
+    String template(String release, String chartOrPath, Map args = [:]) {
+        helm(['template', release, chartOrPath ], args)
+    }
+    
+    private String helm(List<String> verbAndParams, Map args = [:]) {
+        List<String> command = ['helm'] + verbAndParams 
+        
+        for (entry in args) {
+            String key = entry.key
+            String value = entry.value
+            command += "--${key}".toString()
+            command += value
+        }
+
+        commandExecutor.execute(command as String[]).stdOut
     }
 
     String uninstall(String release, String namespace) {

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
@@ -37,7 +37,9 @@ class ApplicationConfiguratorTest {
     private FileSystemUtils fileSystemUtils
     private TestLogger testLogger
     Map testConfig = [
-            application: [:],
+            application: [
+                    localHelmChartFolder : 'someValue',
+            ],
             registry   : [
                     url         : EXPECTED_REGISTRY_URL,
                     pullUrl: "pull-$EXPECTED_REGISTRY_URL",
@@ -61,11 +63,7 @@ class ApplicationConfiguratorTest {
                             ]
                     ],
                     mail: [:],
-                    monitoring: [
-                            helm: [
-                                    localFolder: 'someValue'
-                            ]
-                    ],
+                    monitoring: [:],
                     exampleApps: [
                             petclinic: [:],
                             nginx    : [:],
@@ -75,13 +73,9 @@ class ApplicationConfiguratorTest {
     
     // We have to set this value using env vars, which makes tests complicated, so ignore it
     Map almostEmptyConfig = [
-            features: [
-                    monitoring: [
-                            helm: [
-                                    localFolder: 'someValue'
-                            ]
-                    ]
-            ]
+            application: [
+                    localHelmChartFolder : 'someValue',
+            ],
     ]
     
     @BeforeEach
@@ -173,15 +167,14 @@ class ApplicationConfiguratorTest {
     
     @Test
     void 'Fails if monitoring local is not set'() {
-        testConfig['features']['monitoring']['helm']['localFolder'] = ''
+        testConfig['application']['localHelmChartFolder'] = ''
         
         def exception = shouldFail(RuntimeException) {
             applicationConfigurator.setConfig(testConfig)
         }
-        assertThat(exception.message).isEqualTo('Missing config for localFolder of helm chart kube-prometheus-stack.\n' +
-                'Either run inside the official container image or setting env var KUBE_PROM_STACK_HELMCHART_PATH=\'charts/kube-prometheus-stack\' after running this:\n' +
-                'helm repo add prometheus-community https://prometheus-community.github.io/helm-charts\n' +
-                'helm pull --untar --untardir charts prometheus-community/kube-prometheus-stack --version 58.2.1')
+        assertThat(exception.message).isEqualTo('Missing config for localHelmChartFolder.\n' +
+                'Either run inside the official container image or setting env var LOCAL_HELM_CHART_FOLDER=\'charts\' ' +
+                'after running \'scripts/downloadHelmCharts.sh\' from the repo')
     }
     
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
@@ -13,7 +13,8 @@ class ApplicationTest {
                     password: "the-password"
             ],
             scmm: [
-                    internal: true
+                    internal: true,
+                    url: 'http://localhost'
             ],
             jenkins: [:]
     ]

--- a/src/test/groovy/com/cloudogu/gitops/features/ExternalSecretsOperatorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ExternalSecretsOperatorTest.groovy
@@ -51,9 +51,11 @@ class ExternalSecretsOperatorTest {
 
         assertThat(commandExecutor.actualCommands[0].trim()).isEqualTo(
                 'helm repo add externalsecretsoperator https://charts.external-secrets.io')
-        assertThat(commandExecutor.actualCommands[1].trim()).isEqualTo(
-                'helm upgrade -i external-secrets externalsecretsoperator/external-secrets --version 0.6.0' +
-                        " --values $temporaryYamlFile --namespace foo-secrets --create-namespace")
+        assertThat(commandExecutor.actualCommands[1].trim()).startsWith(
+                'helm upgrade -i external-secrets externalsecretsoperator/external-secrets --create-namespace')
+        assertThat(commandExecutor.actualCommands[1].trim()).contains('--version 0.6.0')
+        assertThat(commandExecutor.actualCommands[1].trim()).contains("--values $temporaryYamlFile")
+        assertThat(commandExecutor.actualCommands[1].trim()).contains('--namespace foo-secrets')
     }
 
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
@@ -152,9 +152,10 @@ class MailhogTest {
     protected void assertMailhogInstalledImperativelyViaHelm() {
         assertThat(commandExecutor.actualCommands[0].trim()).isEqualTo(
                 'helm repo add mailhog https://codecentric.github.io/helm-charts')
-        assertThat(commandExecutor.actualCommands[1].trim()).isEqualTo(
-                'helm upgrade -i mailhog mailhog/mailhog --version 5.0.1' +
-                        " --values ${temporaryYamlFile} --namespace foo-monitoring --create-namespace")
+        assertThat(commandExecutor.actualCommands[1].trim()).startsWith(
+                'helm upgrade -i mailhog mailhog/mailhog --create-namespace')
+        assertThat(commandExecutor.actualCommands[1].trim()).contains('--version 5.0.1')
+        assertThat(commandExecutor.actualCommands[1].trim()).contains('--namespace foo-monitoring')
     }
 
     private Mailhog createMailhog() {

--- a/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
@@ -37,7 +37,7 @@ class PrometheusStackTest {
                     password: '123',
                     remote  : false,
                     namePrefix: "foo-",
-                    airGapped: false
+                    mirrorRepos: false
             ],
             features   : [
                     monitoring: [
@@ -366,7 +366,7 @@ policies:
     
     @Test
     void 'helm releases are installed in air-gapped mode'() {
-        config.application['airGapped'] = true
+        config.application['mirrorRepos'] = true
         when(airGappedUtils.mirrorHelmRepoToGit(any(Map))).thenReturn('a/b')
 
         Path rootChartsFolder = Files.createTempDirectory(this.class.getSimpleName())

--- a/src/test/groovy/com/cloudogu/gitops/features/RegistryTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/RegistryTest.groovy
@@ -57,9 +57,11 @@ class RegistryTest {
         assertThat(parseActualYaml()['service']['type']).isEqualTo('NodePort')
         assertThat(helmCommands.actualCommands[0].trim()).isEqualTo(
                 'helm repo add registry https://charts.helm.sh/stable')
-        assertThat(helmCommands.actualCommands[1].trim()).isEqualTo(
-                'helm upgrade -i docker-registry registry/docker-registry --version 1.9.4' +
-                        " --values ${temporaryYamlFile} --namespace foo-default --create-namespace")
+        assertThat(helmCommands.actualCommands[1].trim()).startsWith(
+                'helm upgrade -i docker-registry registry/docker-registry --create-namespace')
+        assertThat(helmCommands.actualCommands[1].trim()).contains('--version 1.9.4')
+        assertThat(helmCommands.actualCommands[1].trim()).contains("--values ${temporaryYamlFile}")
+        assertThat(helmCommands.actualCommands[1].trim()).contains('--namespace foo-default')
         assertThat(k8sClient.commandExecutorForTest.actualCommands).isEmpty()
     }
 

--- a/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
@@ -83,9 +83,11 @@ class ScmManagerTest {
         assertThat(parseActualYaml()['ingress']).isEqualTo([ enabled: true, path: '/', hosts: [ 'scmm.localhost'] ])
         assertThat(helmCommands.actualCommands[0].trim()).isEqualTo(
                 'helm repo add scm-manager https://packages.scm-manager.org/repository/helm-v2-releases/')
-        assertThat(helmCommands.actualCommands[1].trim()).isEqualTo(
-                'helm upgrade -i scmm scm-manager/scm-manager-chart --version 2.47.0' +
-                        " --values ${temporaryYamlFile} --namespace foo-default --create-namespace")
+        assertThat(helmCommands.actualCommands[1].trim()).startsWith(
+                'helm upgrade -i scmm scm-manager/scm-manager-chart --create-namespace')
+        assertThat(helmCommands.actualCommands[1].trim()).contains('--version 2.47.0')
+        assertThat(helmCommands.actualCommands[1].trim()).contains(" --values ${temporaryYamlFile}")
+        assertThat(helmCommands.actualCommands[1].trim()).contains('--namespace foo-default')
 
         def env = getEnvAsMap()
         assertThat(commandExecutor.actualCommands[0]).isEqualTo(

--- a/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
@@ -1,90 +1,67 @@
 package com.cloudogu.gitops.features
 
+
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.features.deployment.HelmStrategy
-import com.cloudogu.gitops.scmm.ScmmRepo
-import com.cloudogu.gitops.scmm.api.Permission
-import com.cloudogu.gitops.scmm.api.Repository
-import com.cloudogu.gitops.scmm.api.RepositoryApi
 import com.cloudogu.gitops.utils.CommandExecutorForTest
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.cloudogu.gitops.utils.HelmClient
-import com.cloudogu.gitops.utils.TestScmmRepoProvider
 import groovy.yaml.YamlSlurper
-import okhttp3.internal.http.RealResponseBody
-import okio.BufferedSource
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.lib.Ref
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentCaptor
-import retrofit2.Call
-import retrofit2.Response
 
-import java.nio.file.Files
 import java.nio.file.Path
 
-import static groovy.test.GroovyAssert.shouldFail
 import static org.assertj.core.api.Assertions.assertThat
-import static org.mockito.ArgumentMatchers.*
-import static org.mockito.Mockito.*
 
 class ScmManagerTest {
 
     Map config = [
-            application : [
+            application: [
                     username  : 'abc',
                     password  : '123',
                     remote    : false,
                     namePrefix: "foo-",
                     trace     : true,
                     //baseUrl : 'http://localhost',
-                    insecure  : false,
-                    gitName   : 'Cloudogu',
-                    gitEmail  : 'hello@cloudogu.com',
+                    insecure : false,
+                    gitName : 'Cloudogu',
+                    gitEmail : 'hello@cloudogu.com',
             ],
-            scmm        : [
-                    url          : 'http://scmm',
-                    internal     : true,
-                    protocol     : 'https',
-                    host         : 'abc',
-                    ingress      : 'scmm.localhost',
-                    username     : 'scmm-usr',
-                    password     : 'scmm-pw',
-                    urlForJenkins: 'http://scmm4jenkins',
-                    helm         : [
+            scmm       : [
+                    url: 'http://scmm',
+                    internal: true,
+                    protocol: 'https',
+                    host    : 'abc',
+                    ingress : 'scmm.localhost',
+                    username: 'scmm-usr',
+                    password: 'scmm-pw',
+                    gitOpsUsername: 'foo-gitops',
+                    urlForJenkins : 'http://scmm4jenkins',
+                    helm  : [
                             chart  : 'scm-manager-chart',
                             version: '2.47.0',
                             repoURL: 'https://packages.scm-manager.org/repository/helm-v2-releases/',
                     ]
             ],
-            jenkins     : [
-                    internal  : true,
-                    url       : 'http://jenkins',
-                    urlForScmm: 'http://jenkins4scm',
+            jenkins    : [
+                    internal       : true,
+                    url            : 'http://jenkins',
+                    urlForScmm     : 'http://jenkins4scm',
             ],
-            features    : [
+            features   : [
                     argocd: [
                             active: true,
-                    ],
-                    monitoring: [
-                            active: true,
-                            helm  : [
-                                    chart  : 'kube-prometheus-stack',
-                                    repoURL: 'https://kube-prometheus-stack-repo-url',
-                                    version: '58.2.1',
-                                    localFolder: ''
-                                    ]
                     ]
             ],
-            repositories: [
+            repositories : [
                     springBootHelmChart: [
                             url: 'springBootHelmChartUrl',
                             ref: '1.2.3'
                     ],
-                    gitopsBuildLib     : [
+                    gitopsBuildLib: [
                             url: 'gitopsBuildLibUrl'
                     ],
-                    cesBuildLib        : [
+                    cesBuildLib: [
                             url: 'cesBuildLibUrl'
                     ]
             ],
@@ -95,9 +72,6 @@ class ScmManagerTest {
     File temporaryYamlFile
     CommandExecutorForTest helmCommands = new CommandExecutorForTest()
     HelmClient helmClient = new HelmClient(helmCommands)
-    TestScmmRepoProvider scmmRepoProvider = new TestScmmRepoProvider(new Configuration(config), new FileSystemUtils())
-    FileSystemUtils fileSystemUtils = new FileSystemUtils()
-    RepositoryApi repositoryApi = mock(RepositoryApi)
 
     @Test
     void 'Installs SCMM and calls script with proper params'() {
@@ -105,8 +79,8 @@ class ScmManagerTest {
 
         assertThat(parseActualYaml()['extraEnv'] as String).contains('SCM_WEBAPP_INITIALUSER\n  value: "scmm-usr"')
         assertThat(parseActualYaml()['extraEnv'] as String).contains('SCM_WEBAPP_INITIALPASSWORD\n  value: "scmm-pw"')
-        assertThat(parseActualYaml()['service']).isEqualTo([nodePort: 9091, type: 'NodePort'])
-        assertThat(parseActualYaml()['ingress']).isEqualTo([enabled: true, path: '/', hosts: ['scmm.localhost']])
+        assertThat(parseActualYaml()['service']).isEqualTo([ nodePort: 9091, type: 'NodePort' ])
+        assertThat(parseActualYaml()['ingress']).isEqualTo([ enabled: true, path: '/', hosts: [ 'scmm.localhost'] ])
         assertThat(helmCommands.actualCommands[0].trim()).isEqualTo(
                 'helm repo add scm-manager https://packages.scm-manager.org/repository/helm-v2-releases/')
         assertThat(helmCommands.actualCommands[1].trim()).isEqualTo(
@@ -126,9 +100,9 @@ class ScmManagerTest {
         assertThat(env['SCMM_URL']).isEqualTo('http://scmm')
         assertThat(env['SCMM_USERNAME']).isEqualTo('scmm-usr')
         assertThat(env['SCMM_PASSWORD']).isEqualTo('scmm-pw')
-        assertThat(env['JENKINS_URL']).isEqualTo('http://jenkins')
-        assertThat(env['JENKINS_URL_FOR_SCMM']).isEqualTo('http://jenkins4scm')
-        assertThat(env['SCMM_URL_FOR_JENKINS']).isEqualTo('http://scmm4jenkins')
+        assertThat(env['JENKINS_URL']).isEqualTo( 'http://jenkins')
+        assertThat(env['JENKINS_URL_FOR_SCMM']).isEqualTo( 'http://jenkins4scm')
+        assertThat(env['SCMM_URL_FOR_JENKINS']).isEqualTo( 'http://scmm4jenkins')
         assertThat(env['REMOTE_CLUSTER']).isEqualTo('false')
         assertThat(env['INSTALL_ARGOCD']).isEqualTo('true')
         assertThat(env['SPRING_BOOT_HELM_CHART_COMMIT']).isEqualTo('1.2.3')
@@ -159,208 +133,6 @@ class ScmManagerTest {
         assertThat(temporaryYamlFile).isNull()
     }
 
-    @Test
-    void 'Prepares repos for air-gapped use'() {
-        setupForAirgappedUse()
-        
-        def response = mockSuccessfulResponse(201)
-        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(response)
-        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(response)
-        
-        createScmManager().install()
-
-        assertAirGapped()
-    }
-
-    @Test
-    void 'Air-gapped: Fails when unable to resolve version of dependencies'() {
-        setupForAirgappedUse([:])
-        def exception = shouldFail(RuntimeException) {
-            createScmManager().install()
-        }
-        
-        assertThat(exception.message).isEqualTo(
-                'Unable to determine proper version for dependency grafana (version: 7.3.*) ' +
-                        'from repo foo-3rd-party-dependencies/kube-prometheus-stack'
-        )
-    }
-
-    @Test
-    void 'Air-gapped: Prometheus only applied when monitoring active'() {
-        config['features']['monitoring']['active'] = false
-        createScmManager().install()
-
-        assertThat(scmmRepoProvider.repos['3rd-party-dependencies/kube-prometheus-stack']).isNull()
-    }
-    
-    @Test
-    void 'Ignores existing Repos'() {
-        setupForAirgappedUse()
-
-        def errorResponse = this.mockErrorResponse(409)
-        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(errorResponse)
-
-        createScmManager().install()
-
-        assertAirGapped()
-    }
-    
-    @Test
-    void 'Ignores existing Permissions'() {
-        setupForAirgappedUse()
-
-        def errorResponse = mockErrorResponse(409)
-        def successfulResponse = mockSuccessfulResponse(201)
-
-        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(successfulResponse)
-        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(errorResponse)
-
-        createScmManager().install()
-
-        assertAirGapped()
-    }
-    
-    @Test
-    void 'Handles failures to SCMM-API for Repos'() {
-        setupForAirgappedUse()
-
-        def errorResponse = this.mockErrorResponse(500)
-
-        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(errorResponse)
-
-        def exception = shouldFail(RuntimeException) {
-            createScmManager().install()
-        }
-        assertThat(exception.message).startsWith('Could not create Repository')
-        assertThat(exception.message).contains('3rd-party-dependencies')
-        assertThat(exception.message).contains('kube-prometheus-stack')
-        assertThat(exception.message).contains('500')
-    }
-    
-    @Test
-    void 'Handles failures to SCMM-API for Permissions'() {
-        setupForAirgappedUse()
-
-        def errorResponse = mockErrorResponse(500)
-        def successfulResponse = mockSuccessfulResponse(201)
-
-        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(successfulResponse)
-        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(errorResponse)
-
-        def exception = shouldFail(RuntimeException) {
-            createScmManager().install()
-        }
-        assertThat(exception.message).startsWith('Could not create Permission for repo 3rd-party-dependencies/kube-prometheus-stack')
-        assertThat(exception.message).contains('foo-gitops')
-        assertThat(exception.message).contains(Permission.Role.WRITE.name())
-        assertThat(exception.message).contains('500')
-    }
-
-    protected void setupForAirgappedUse(Map prometheusChartLock = null) {
-        def response = mockSuccessfulResponse(201)
-        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(response)
-        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(response)
-
-        Path prometheusSourceChart = Files.createTempDirectory(this.class.getSimpleName())
-        Map prometheusChartYaml = [
-                version     : '1.2.3',
-                name        : 'kube-prometheus-stack-chart',
-                dependencies: [
-                        [
-                                condition: 'crds.enabled',
-                                name: 'crds',
-                                repository: '',
-                                version: '0.0.0'
-                        ],
-                        [
-                                condition : 'grafana.enabled',
-                                name      : 'grafana',
-                                repository: 'https://grafana-repo-url',
-                                version   : '7.3.*',
-                        ]
-                ]
-        ]
-        fileSystemUtils.writeYaml(prometheusChartYaml, prometheusSourceChart.resolve('Chart.yaml').toFile())
-
-        if(prometheusChartLock == null) {
-            prometheusChartLock = [
-                dependencies: [
-                        [
-                                name: 'crds',
-                                repository: "",
-                                version: '0.0.0'
-                        ],
-                        [
-                                name: 'grafana',
-                                repository: 'https://grafana.github.io/helm-charts',
-                                version: '7.3.9'
-                        ]
-                ]
-            ]
-        }
-        fileSystemUtils.writeYaml(prometheusChartLock, prometheusSourceChart.resolve('Chart.lock').toFile())
-
-        config.application['airGapped'] = true
-        config.features['monitoring']['helm']['localFolder'] = prometheusSourceChart.toString()
-    }
-
-    protected void assertAirGapped() {
-        ScmmRepo prometheusRepo = scmmRepoProvider.repos['3rd-party-dependencies/kube-prometheus-stack']
-        assertThat(prometheusRepo).isNotNull()
-        assertThat(Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.lock')).doesNotExist()
-
-        def ys = new YamlSlurper()
-        def actualPrometheusChartYaml = ys.parse(Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.yaml'))
-        assertThat(actualPrometheusChartYaml['name']).isEqualTo('kube-prometheus-stack-chart')
-        
-        def dependencies = actualPrometheusChartYaml['dependencies'] as List
-        assertThat(dependencies).hasSize(2)
-        assertThat(dependencies[0]['name']).isEqualTo('crds')
-        assertThat(dependencies[0]['version']).isEqualTo('0.0.0')
-        assertThat(dependencies[0]['repository']).isEqualTo('')
-        assertThat(dependencies[1]['name']).isEqualTo('grafana')
-        assertThat(dependencies[1]['version']).isEqualTo('7.3.9')
-        assertThat(dependencies[1]['repository']).isEqualTo('')
-        
-        assertHelmRepoCommits(prometheusRepo, '1.2.3', 'Chart kube-prometheus-stack-chart, version: 1.2.3\n\n' +
-                'Source: https://kube-prometheus-stack-repo-url\nDependencies localized to run in air-gapped environments')
-
-        def repoCreateArgument = ArgumentCaptor.forClass(Repository)
-        verify(repositoryApi, times(1)).create(repoCreateArgument.capture(), eq(true))
-        assertThat(repoCreateArgument.allValues[0].namespace).isEqualTo(ScmManager.NAMESPACE_3RD_PARTY_DEPENDENCIES)
-        assertThat(repoCreateArgument.allValues[0].name).isEqualTo('kube-prometheus-stack')
-        assertThat(repoCreateArgument.allValues[0].description).isEqualTo('Mirror of Helm chart kube-prometheus-stack from https://kube-prometheus-stack-repo-url')
-
-        def permissionCreateArgument = ArgumentCaptor.forClass(Permission)
-        verify(repositoryApi, times(1)).createPermission(anyString(), anyString(), permissionCreateArgument.capture())
-        assertThat(permissionCreateArgument.allValues[0].name).isEqualTo('foo-gitops')
-        assertThat(permissionCreateArgument.allValues[0].role).isEqualTo(Permission.Role.WRITE)
-    }
-    
-    Call<Void> mockSuccessfulResponse(int expectedReturnCode) {
-        def expectedCall = mock(Call<Void>)
-        when(expectedCall.execute()).thenReturn(Response.success(expectedReturnCode, null))
-        expectedCall
-    }
-    
-    Call<Void> mockErrorResponse(int expectedReturnCode) {
-        def expectedCall = mock(Call<Void>)
-        // Response is a final class that cannot be mocked 😠
-        Response<Void> errorResponse = Response.error(expectedReturnCode, new RealResponseBody('dontcare', 0, mock(BufferedSource)))
-        when(expectedCall.execute()).thenReturn(errorResponse)
-        expectedCall
-    }
-
-    void assertHelmRepoCommits(ScmmRepo repo, String expectedTag, String expectedCommitMessage) {
-        def commits = Git.open(new File(repo.absoluteLocalRepoTmpDir)).log().setMaxCount(1).all().call().collect()
-        assertThat(commits.size()).isEqualTo(1)
-        assertThat(commits[0].fullMessage).isEqualTo(expectedCommitMessage)
-
-        List<Ref> tags = Git.open(new File(repo.absoluteLocalRepoTmpDir)).tagList().call()
-        assertThat(tags.size()).isEqualTo(1)
-        assertThat(tags[0].name).isEqualTo("refs/tags/${expectedTag}".toString())
-    }
-    
     protected Map<String, String> getEnvAsMap() {
         commandExecutor.environment.collectEntries { it.split('=') }
     }
@@ -371,15 +143,13 @@ class ScmManagerTest {
     }
 
     private ScmManager createScmManager() {
-        new ScmManager(new Configuration(config), commandExecutor, new FileSystemUtils() {
+        new ScmManager(new Configuration(config), commandExecutor,  new FileSystemUtils() {
             @Override
             Path copyToTempDir(String filePath) {
-            Path ret = super.copyToTempDir(filePath)
-            temporaryYamlFile = Path.of(ret.toString().replace(".ftl", "")).toFile()
-            // Path after template invocation
-            return ret
+                Path ret = super.copyToTempDir(filePath)
+                temporaryYamlFile = Path.of(ret.toString().replace(".ftl", "")).toFile() // Path after template invocation
+                return ret
             }
-        }, scmmRepoProvider, repositoryApi,
-        new HelmStrategy(new Configuration(config), helmClient))
+        },  new HelmStrategy(new Configuration(config), helmClient))
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
@@ -67,6 +67,7 @@ class ScmManagerTest {
                             active: true,
                     ],
                     monitoring: [
+                            active: true,
                             helm  : [
                                     chart  : 'kube-prometheus-stack',
                                     repoURL: 'https://kube-prometheus-stack-repo-url',
@@ -182,6 +183,14 @@ class ScmManagerTest {
                 'Unable to determine proper version for dependency grafana (version: 7.3.*) ' +
                         'from repo foo-3rd-party-dependencies/kube-prometheus-stack'
         )
+    }
+
+    @Test
+    void 'Air-gapped: Prometheus only applied when monitoring active'() {
+        config['features']['monitoring']['active'] = false
+        createScmManager().install()
+
+        assertThat(scmmRepoProvider.repos['3rd-party-dependencies/kube-prometheus-stack']).isNull()
     }
     
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
@@ -1,76 +1,103 @@
 package com.cloudogu.gitops.features
 
-
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.features.deployment.HelmStrategy
+import com.cloudogu.gitops.scmm.ScmmRepo
+import com.cloudogu.gitops.scmm.api.Permission
+import com.cloudogu.gitops.scmm.api.Repository
+import com.cloudogu.gitops.scmm.api.RepositoryApi
 import com.cloudogu.gitops.utils.CommandExecutorForTest
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.cloudogu.gitops.utils.HelmClient
+import com.cloudogu.gitops.utils.TestScmmRepoProvider
 import groovy.yaml.YamlSlurper
+import okhttp3.internal.http.RealResponseBody
+import okio.BufferedSource
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Ref
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import retrofit2.Call
+import retrofit2.Response
 
+import java.nio.file.Files
 import java.nio.file.Path
+import java.util.stream.Collectors
 
-import static org.assertj.core.api.Assertions.assertThat 
+import static groovy.test.GroovyAssert.shouldFail
+import static org.assertj.core.api.Assertions.assertThat
+import static org.mockito.ArgumentMatchers.*
+import static org.mockito.Mockito.*
 
 class ScmManagerTest {
 
     Map config = [
-            application: [
+            application : [
                     username  : 'abc',
                     password  : '123',
                     remote    : false,
                     namePrefix: "foo-",
                     trace     : true,
                     //baseUrl : 'http://localhost',
-                    insecure : false,
-                    gitName : 'Cloudogu',
-                    gitEmail : 'hello@cloudogu.com',
+                    insecure  : false,
+                    gitName   : 'Cloudogu',
+                    gitEmail  : 'hello@cloudogu.com',
             ],
-            scmm       : [
-                    url: 'http://scmm',
-                    internal: true,
-                    protocol: 'https',
-                    host    : 'abc',
-                    ingress : 'scmm.localhost',
-                    username: 'scmm-usr',
-                    password: 'scmm-pw',
-                    urlForJenkins : 'http://scmm4jenkins',
-                    helm  : [
+            scmm        : [
+                    url          : 'http://scmm',
+                    internal     : true,
+                    protocol     : 'https',
+                    host         : 'abc',
+                    ingress      : 'scmm.localhost',
+                    username     : 'scmm-usr',
+                    password     : 'scmm-pw',
+                    urlForJenkins: 'http://scmm4jenkins',
+                    helm         : [
                             chart  : 'scm-manager-chart',
                             version: '2.47.0',
                             repoURL: 'https://packages.scm-manager.org/repository/helm-v2-releases/',
                     ]
             ],
-            jenkins    : [
-                    internal       : true,
-                    url            : 'http://jenkins',
-                    urlForScmm     : 'http://jenkins4scm',
+            jenkins     : [
+                    internal  : true,
+                    url       : 'http://jenkins',
+                    urlForScmm: 'http://jenkins4scm',
             ],
-            features   : [
+            features    : [
                     argocd: [
                             active: true,
+                    ],
+                    monitoring: [
+                            helm  : [
+                                    chart  : 'kube-prometheus-stack',
+                                    repoURL: 'https://kube-prometheus-stack-repo-url',
+                                    version: '58.2.1',
+                                    localFolder: ''
+                                    ]
                     ]
             ],
-            repositories : [
+            repositories: [
                     springBootHelmChart: [
                             url: 'springBootHelmChartUrl',
                             ref: '1.2.3'
                     ],
-                    gitopsBuildLib: [
+                    gitopsBuildLib     : [
                             url: 'gitopsBuildLibUrl'
                     ],
-                    cesBuildLib: [
+                    cesBuildLib        : [
                             url: 'cesBuildLibUrl'
                     ]
             ],
     ]
-    
+
     CommandExecutorForTest commandExecutor = new CommandExecutorForTest()
 
     File temporaryYamlFile
     CommandExecutorForTest helmCommands = new CommandExecutorForTest()
     HelmClient helmClient = new HelmClient(helmCommands)
+    TestScmmRepoProvider scmmRepoProvider = new TestScmmRepoProvider(new Configuration(config), new FileSystemUtils())
+    FileSystemUtils fileSystemUtils = new FileSystemUtils()
+    RepositoryApi repositoryApi = mock(RepositoryApi)
 
     @Test
     void 'Installs SCMM and calls script with proper params'() {
@@ -78,8 +105,8 @@ class ScmManagerTest {
 
         assertThat(parseActualYaml()['extraEnv'] as String).contains('SCM_WEBAPP_INITIALUSER\n  value: "scmm-usr"')
         assertThat(parseActualYaml()['extraEnv'] as String).contains('SCM_WEBAPP_INITIALPASSWORD\n  value: "scmm-pw"')
-        assertThat(parseActualYaml()['service']).isEqualTo([ nodePort: 9091, type: 'NodePort' ])
-        assertThat(parseActualYaml()['ingress']).isEqualTo([ enabled: true, path: '/', hosts: [ 'scmm.localhost'] ])
+        assertThat(parseActualYaml()['service']).isEqualTo([nodePort: 9091, type: 'NodePort'])
+        assertThat(parseActualYaml()['ingress']).isEqualTo([enabled: true, path: '/', hosts: ['scmm.localhost']])
         assertThat(helmCommands.actualCommands[0].trim()).isEqualTo(
                 'helm repo add scm-manager https://packages.scm-manager.org/repository/helm-v2-releases/')
         assertThat(helmCommands.actualCommands[1].trim()).isEqualTo(
@@ -94,13 +121,14 @@ class ScmManagerTest {
         assertThat(env['GIT_COMMITTER_EMAIL']).isEqualTo('hello@cloudogu.com')
         assertThat(env['GIT_AUTHOR_NAME']).isEqualTo('Cloudogu')
         assertThat(env['GIT_AUTHOR_EMAIL']).isEqualTo('hello@cloudogu.com')
+        assertThat(env['GITOPS_USERNAME']).isEqualTo('foo-gitops')
         assertThat(env['TRACE']).isEqualTo('true')
         assertThat(env['SCMM_URL']).isEqualTo('http://scmm')
         assertThat(env['SCMM_USERNAME']).isEqualTo('scmm-usr')
         assertThat(env['SCMM_PASSWORD']).isEqualTo('scmm-pw')
-        assertThat(env['JENKINS_URL']).isEqualTo( 'http://jenkins')
-        assertThat(env['JENKINS_URL_FOR_SCMM']).isEqualTo( 'http://jenkins4scm')
-        assertThat(env['SCMM_URL_FOR_JENKINS']).isEqualTo( 'http://scmm4jenkins')
+        assertThat(env['JENKINS_URL']).isEqualTo('http://jenkins')
+        assertThat(env['JENKINS_URL_FOR_SCMM']).isEqualTo('http://jenkins4scm')
+        assertThat(env['SCMM_URL_FOR_JENKINS']).isEqualTo('http://scmm4jenkins')
         assertThat(env['REMOTE_CLUSTER']).isEqualTo('false')
         assertThat(env['INSTALL_ARGOCD']).isEqualTo('true')
         assertThat(env['SPRING_BOOT_HELM_CHART_COMMIT']).isEqualTo('1.2.3')
@@ -116,9 +144,9 @@ class ScmManagerTest {
         config.application['remote'] = true
         config.scmm['ingress'] = ''
         createScmManager().install()
-        
+
         Map actualYaml = parseActualYaml() as Map
-        
+
         assertThat(actualYaml).doesNotContainKey('service')
         assertThat(actualYaml).doesNotContainKey('ingress')
     }
@@ -127,8 +155,193 @@ class ScmManagerTest {
     void 'Installs only if internal'() {
         config.scmm['internal'] = false
         createScmManager().install()
-        
+
         assertThat(temporaryYamlFile).isNull()
+    }
+
+    @Test
+    void 'Prepares repos for air-gapped use'() {
+        setupForAirgappedUse()
+        
+        def response = mockSuccessfulResponse(201)
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(response)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(response)
+        
+        createScmManager().install()
+
+        assertAirGapped()
+    }
+    
+    @Test
+    void 'Ignores existing Repos'() {
+        setupForAirgappedUse()
+
+        def errorResponse = this.mockErrorResponse(409)
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(errorResponse)
+
+        createScmManager().install()
+
+        assertAirGapped()
+    }
+    
+    @Test
+    void 'Ignores existing Permissions'() {
+        setupForAirgappedUse()
+
+        def errorResponse = mockErrorResponse(409)
+        def successfulResponse = mockSuccessfulResponse(201)
+
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(successfulResponse)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(errorResponse)
+
+        createScmManager().install()
+
+        assertAirGapped()
+    }
+    
+    @Test
+    void 'Handles failures to SCMM-API for Repos'() {
+        setupForAirgappedUse()
+
+        def errorResponse = this.mockErrorResponse(500)
+
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(errorResponse)
+
+        def exception = shouldFail(RuntimeException) {
+            createScmManager().install()
+        }
+        assertThat(exception.message).startsWith('Could not create Repository')
+        assertThat(exception.message).contains('3rd-party-dependencies')
+        assertThat(exception.message).contains('kube-prometheus-stack')
+        assertThat(exception.message).contains('500')
+    }
+    
+    @Test
+    void 'Handles failures to SCMM-API for Permissions'() {
+        setupForAirgappedUse()
+
+        def errorResponse = mockErrorResponse(500)
+        def successfulResponse = mockSuccessfulResponse(201)
+
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(successfulResponse)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(errorResponse)
+
+        def exception = shouldFail(RuntimeException) {
+            createScmManager().install()
+        }
+        assertThat(exception.message).startsWith('Could not create Permission for repo 3rd-party-dependencies/kube-prometheus-stack')
+        assertThat(exception.message).contains('foo-gitops')
+        assertThat(exception.message).contains(Permission.Role.WRITE.name())
+        assertThat(exception.message).contains('500')
+    }
+
+    protected void setupForAirgappedUse() {
+        def response = mockSuccessfulResponse(201)
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(response)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(response)
+
+        Path prometheusSourceChart = Files.createTempDirectory(this.class.getSimpleName())
+        Map prometheusChartYaml = [
+                version     : '1.2.3',
+                name        : 'kube-prometheus-stack-chart',
+                dependencies: [
+                        [
+                                condition: 'crds.enabled',
+                                name: 'crds',
+                                repository: '',
+                                version: '0.0.0'
+                        ],
+                        [
+                                condition : 'grafana.enabled',
+                                name      : 'grafana',
+                                repository: 'https://grafana-repo-url',
+                                version   : '6.47.*',
+                        ]
+                ]
+        ]
+        fileSystemUtils.writeYaml(prometheusChartYaml, prometheusSourceChart.resolve('Chart.yaml').toFile())
+        def filePath = prometheusSourceChart.resolve "Chart.lock"
+        Files.write(filePath, 'promChartLock'.getBytes())
+
+        Path grafanaChartPath = prometheusSourceChart.resolve('charts/grafana')
+        Files.createDirectories(grafanaChartPath)
+        Files.createDirectories(prometheusSourceChart.resolve('charts/crds'))
+        Map grafanaChartYaml = [
+                version: 'x.y.z',
+                name   : 'grafana',
+        ]
+        fileSystemUtils.writeYaml(grafanaChartYaml, grafanaChartPath.resolve('Chart.yaml').toFile())
+
+        config.application['airGapped'] = true
+        config.features['monitoring']['helm']['localFolder'] = prometheusSourceChart.toString()
+    }
+
+    protected void assertAirGapped() {
+        ScmmRepo prometheusRepo = scmmRepoProvider.repos['3rd-party-dependencies/kube-prometheus-stack']
+        assertThat(prometheusRepo).isNotNull()
+        assertThat(Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.lock')).doesNotExist()
+
+        List<Path> chartSubFolders = Files.list(Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'charts')).collect(Collectors.toList())
+        assertThat(chartSubFolders).hasSize(1)
+        assertThat(chartSubFolders[0].fileName.toString()).isEqualTo('crds')
+
+        def ys = new YamlSlurper()
+        def actualPrometheusChartYaml = ys.parse(Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.yaml'))
+        assertThat(actualPrometheusChartYaml['name']).isEqualTo('kube-prometheus-stack-chart')
+        def dependencies = actualPrometheusChartYaml['dependencies'] as List
+        assertThat(dependencies).hasSize(1)
+        assertThat(dependencies[0]['name']).isEqualTo('crds')
+        assertHelmRepoCommits(prometheusRepo, '1.2.3', 'Chart kube-prometheus-stack-chart, version: 1.2.3\n\n' +
+                'Source: https://kube-prometheus-stack-repo-url\nDependencies removed to run in air-gapped environments')
+
+        def repoCreateArgument = ArgumentCaptor.forClass(Repository)
+        verify(repositoryApi, times(2)).create(repoCreateArgument.capture(), eq(true))
+        assertThat(repoCreateArgument.allValues[0].namespace).isEqualTo(ScmManager.NAMESPACE_3RD_PARTY_DEPENDENCIES)
+        assertThat(repoCreateArgument.allValues[0].name).isEqualTo('kube-prometheus-stack')
+        assertThat(repoCreateArgument.allValues[0].description).isEqualTo('Mirror of Helm chart kube-prometheus-stack from https://kube-prometheus-stack-repo-url')
+
+        def permissionCreateArgument = ArgumentCaptor.forClass(Permission)
+        verify(repositoryApi, times(2)).createPermission(anyString(), anyString(), permissionCreateArgument.capture())
+        assertThat(permissionCreateArgument.allValues[0].name).isEqualTo('foo-gitops')
+        assertThat(permissionCreateArgument.allValues[0].role).isEqualTo(Permission.Role.WRITE)
+
+        ScmmRepo grafanaRepo = scmmRepoProvider.repos['3rd-party-dependencies/grafana']
+        assertThat(grafanaRepo).isNotNull()
+        def actualGrafanaChartYaml = ys.parse(Path.of(grafanaRepo.absoluteLocalRepoTmpDir, 'Chart.yaml'))
+        assertThat(actualGrafanaChartYaml['name']).isEqualTo('grafana')
+
+        assertHelmRepoCommits(grafanaRepo, 'x.y.z', 'Chart grafana, version: x.y.z\n\n' +
+                'Source: https://grafana-repo-url')
+        assertThat(repoCreateArgument.allValues[1].namespace).isEqualTo(ScmManager.NAMESPACE_3RD_PARTY_DEPENDENCIES)
+        assertThat(repoCreateArgument.allValues[1].name).isEqualTo('grafana')
+        assertThat(repoCreateArgument.allValues[1].description).isEqualTo('Mirror of Helm chart grafana from https://grafana-repo-url')
+
+        assertThat(permissionCreateArgument.allValues[1].name).isEqualTo('foo-gitops')
+        assertThat(permissionCreateArgument.allValues[1].role).isEqualTo(Permission.Role.WRITE)
+    }
+    
+    Call<Void> mockSuccessfulResponse(int expectedReturnCode) {
+        def expectedCall = mock(Call<Void>)
+        when(expectedCall.execute()).thenReturn(Response.success(expectedReturnCode, null))
+        expectedCall
+    }
+    
+    Call<Void> mockErrorResponse(int expectedReturnCode) {
+        def expectedCall = mock(Call<Void>)
+        // Response is a final class that cannot be mocked 😠
+        Response<Void> errorResponse = Response.error(expectedReturnCode, new RealResponseBody('dontcare', 0, mock(BufferedSource)))
+        when(expectedCall.execute()).thenReturn(errorResponse)
+        expectedCall
+    }
+
+    void assertHelmRepoCommits(ScmmRepo repo, String expectedTag, String expectedCommitMessage) {
+        def commits = Git.open(new File(repo.absoluteLocalRepoTmpDir)).log().setMaxCount(1).all().call().collect()
+        assertThat(commits.size()).isEqualTo(1)
+        assertThat(commits[0].fullMessage).isEqualTo(expectedCommitMessage)
+
+        List<Ref> tags = Git.open(new File(repo.absoluteLocalRepoTmpDir)).tagList().call()
+        assertThat(tags.size()).isEqualTo(1)
+        assertThat(tags[0].name).isEqualTo("refs/tags/${expectedTag}".toString())
     }
     
     protected Map<String, String> getEnvAsMap() {
@@ -139,15 +352,17 @@ class ScmManagerTest {
         def ys = new YamlSlurper()
         return ys.parse(temporaryYamlFile)
     }
-    
+
     private ScmManager createScmManager() {
-        new ScmManager(new Configuration(config), commandExecutor,  new FileSystemUtils() {
+        new ScmManager(new Configuration(config), commandExecutor, new FileSystemUtils() {
             @Override
             Path copyToTempDir(String filePath) {
-                Path ret = super.copyToTempDir(filePath)
-                temporaryYamlFile = Path.of(ret.toString().replace(".ftl", "")).toFile() // Path after template invocation
-                return ret
+            Path ret = super.copyToTempDir(filePath)
+            temporaryYamlFile = Path.of(ret.toString().replace(".ftl", "")).toFile()
+            // Path after template invocation
+            return ret
             }
-        },  new HelmStrategy(new Configuration(config), helmClient))
+        }, scmmRepoProvider, repositoryApi,
+        new HelmStrategy(new Configuration(config), helmClient))
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/features/VaultTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/VaultTest.groovy
@@ -160,9 +160,11 @@ class VaultTest {
 
         assertThat(helmCommands.actualCommands[0].trim()).isEqualTo(
                 'helm repo add vault https://vault-reg')
-        assertThat(helmCommands.actualCommands[1].trim()).isEqualTo(
-                'helm upgrade -i vault vault/vault --version 42.23.0' +
-                        " --values ${temporaryYamlFile} --namespace foo-secrets --create-namespace")
+        assertThat(helmCommands.actualCommands[1].trim()).startsWith(
+                'helm upgrade -i vault vault/vault --create-namespace')
+        assertThat(helmCommands.actualCommands[1].trim()).contains('--version 42.23.0')
+        assertThat(helmCommands.actualCommands[1].trim()).contains(" --values ${temporaryYamlFile}")
+        assertThat(helmCommands.actualCommands[1].trim()).contains('--namespace foo-secrets')
     }
 
     private Vault createVault() {

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -90,6 +90,7 @@ class ArgoCDTest {
                     monitoring : [
                             active: true,
                             helm  : [
+                                    chart: 'kube-prometheus-stack',
                                     version: '42.0.3'
                                     ]
                     ],
@@ -470,10 +471,11 @@ class ArgoCDTest {
     void 'Applies Prometheus ServiceMonitor CRD from file before installing (air-gapped mode)'() {
         config['features']['monitoring']['active'] = true
         config.application['airGapped'] = true
-        Path prometheusSourceChart = Files.createTempDirectory(this.class.getSimpleName())
-        config.features['monitoring']['helm']['localFolder'] = prometheusSourceChart.toString()
 
-        Path crdPath = prometheusSourceChart.resolve('charts/crds/crds/crd-servicemonitors.yaml')
+        Path rootChartsFolder = Files.createTempDirectory(this.class.getSimpleName())
+        config.application['localHelmChartFolder'] = rootChartsFolder.toString()
+
+        Path crdPath = rootChartsFolder.resolve('kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml')
         Files.createDirectories(crdPath)
 
         createArgoCD().install()

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -43,7 +43,7 @@ class ArgoCDTest {
                     gitName             : 'Cloudogu',
                     gitEmail            : 'hello@cloudogu.com',
                     urlSeparatorHyphen  : false,
-                    airGapped           : false
+                    mirrorRepos         : false
             ],
             scmm        : [
                     internal: true,
@@ -453,7 +453,7 @@ class ArgoCDTest {
     @Test
     void 'Prepares repos for air-gapped mode'() {
         config['features']['monitoring']['active'] = false
-        config.application['airGapped'] = true
+        config.application['mirrorRepos'] = true
         
         createArgoCD().install()
 
@@ -470,7 +470,7 @@ class ArgoCDTest {
     @Test
     void 'Applies Prometheus ServiceMonitor CRD from file before installing (air-gapped mode)'() {
         config['features']['monitoring']['active'] = true
-        config.application['airGapped'] = true
+        config.application['mirrorRepos'] = true
 
         Path rootChartsFolder = Files.createTempDirectory(this.class.getSimpleName())
         config.application['localHelmChartFolder'] = rootChartsFolder.toString()

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -145,7 +145,7 @@ class ArgoCDTest {
         assertThat(helmCommands.actualCommands[1].trim()).isEqualTo(
                 "helm dependency build ${Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'argocd/')}".toString())
         assertThat(helmCommands.actualCommands[2].trim()).isEqualTo(
-                "helm upgrade -i argocd ${Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'argocd/')} --namespace argocd --create-namespace".toString())
+                "helm upgrade -i argocd ${Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'argocd/')} --create-namespace --namespace argocd".toString())
 
         // Check patched PW
         def patchCommand = k8sCommands.assertExecuted('kubectl patch secret argocd-secret -n argocd')

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -177,13 +177,13 @@ class ArgoCDTest {
         assertThat(yaml[1]['metadata']['name']).isEqualTo('example-apps-production')
 
         Map repos = parseActualYaml(actualHelmValuesFile)['argo-cd']['configs']['repositories'] as Map
-        assertThat(repos).doesNotContainKey('grafana')
         assertThat(repos['prometheus']['url']).isEqualTo('https://prometheus-community.github.io/helm-charts')
 
         def clusterRessourcesYaml = new YamlSlurper().parse(Path.of argocdRepo.getAbsoluteLocalRepoTmpDir(), 'projects/cluster-resources.yaml')
-        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).contains('https://prometheus-community.github.io/helm-charts')
-        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).doesNotContain('http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/kube-prometheus-stack',
-                'http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/grafana')
+        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).contains(
+                'https://prometheus-community.github.io/helm-charts')
+        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).doesNotContain(
+                'http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/kube-prometheus-stack')
     }
 
     @Test
@@ -459,14 +459,13 @@ class ArgoCDTest {
         createArgoCD().install()
 
         Map repos = parseActualYaml(actualHelmValuesFile)['argo-cd']['configs']['repositories'] as Map
-        assertThat(repos).containsKey('grafana')
-        assertThat(repos['grafana']['url']).isEqualTo('http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/grafana')
         assertThat(repos['prometheus']['url']).isEqualTo('http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/kube-prometheus-stack')
 
         def clusterRessourcesYaml = new YamlSlurper().parse(Path.of argocdRepo.getAbsoluteLocalRepoTmpDir(), 'projects/cluster-resources.yaml')
-        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).contains('http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/kube-prometheus-stack',
-                'http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/grafana')
-        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).doesNotContain('https://prometheus-community.github.io/helm-charts')
+        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).contains(
+                'http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/kube-prometheus-stack')
+        assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).doesNotContain(
+                'https://prometheus-community.github.io/helm-charts')
     }
     
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/features/deployment/DeployerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/deployment/DeployerTest.groovy
@@ -22,7 +22,8 @@ class DeployerTest {
         deployer.deployFeature("repoURL", "repoName", "chart", "version", "namespace", "releaseName", Path.of("values.yaml"))
 
         verify(argoCdStrat, never()).deployFeature(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(Path))
-        verify(helmStrat).deployFeature("repoURL", "repoName", "chart", "version", "namespace", "releaseName", Path.of("values.yaml"))
+        verify(helmStrat).deployFeature("repoURL", "repoName", "chart", "version", "namespace", 
+                "releaseName", Path.of("values.yaml"), DeploymentStrategy.RepoType.HELM)
     }
 
 
@@ -32,7 +33,8 @@ class DeployerTest {
 
         deployer.deployFeature("repoURL", "repoName", "chart", "version", "namespace", "releaseName", Path.of("values.yaml"))
 
-        verify(argoCdStrat).deployFeature("repoURL", "repoName", "chart", "version", "namespace", "releaseName", Path.of("values.yaml"))
+        verify(argoCdStrat).deployFeature("repoURL", "repoName", "chart", "version", "namespace",
+                "releaseName", Path.of("values.yaml"), DeploymentStrategy.RepoType.HELM)
         verify(helmStrat, never()).deployFeature(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(Path))
     }
 

--- a/src/test/groovy/com/cloudogu/gitops/features/deployment/HelmStrategyTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/deployment/HelmStrategyTest.groovy
@@ -6,20 +6,40 @@ import org.junit.jupiter.api.Test
 
 import java.nio.file.Path
 
+import static groovy.test.GroovyAssert.shouldFail
+import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.mock
-import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.verify 
 
 class HelmStrategyTest {
+
+    HelmClient helmClient = mock(HelmClient)
+    
     @Test
     void 'deploys feature using helm client'() {
-        def helmClient = mock(HelmClient)
-        def strategy = new HelmStrategy(new Configuration([application: [namePrefix: "foo-"]]), helmClient)
-        strategy.deployFeature("repoURL", "repoName", "chart", "version", "namespace", "releaseName", Path.of("values.yaml"))
+        createStrategy().deployFeature("repoURL", "repoName", "chart", "version", "namespace", "releaseName", Path.of("values.yaml"))
+        
         verify(helmClient).addRepo("repoName", "repoURL")
         verify(helmClient).upgrade("releaseName", "repoName/chart", [
                 namespace: "foo-namespace",
                 version: "version",
                 values: "values.yaml"
         ])
+    }
+
+    @Test
+    void 'Fails to deploy from git'() {
+        def exception = shouldFail(RuntimeException) {
+            createStrategy().deployFeature("http://repoURL", "repoName", "chart", "version", "namespace",
+                    "releaseName", Path.of("values.yaml"), DeploymentStrategy.RepoType.GIT)
+        }
+        assertThat(exception.message).isEqualTo(
+                "Unable to deploy helm chart via Helm CLI from Git URL, because helm does not support this out of the box.\n" +
+                "Repo URL: http://repoURL")
+        
+    }
+    
+    protected HelmStrategy createStrategy() {
+        new HelmStrategy(new Configuration([application: [namePrefix: "foo-"]]), helmClient)
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/utils/AirGappedUtilsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/AirGappedUtilsTest.groovy
@@ -1,0 +1,251 @@
+package com.cloudogu.gitops.utils
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.scmm.ScmmRepo
+import com.cloudogu.gitops.scmm.api.Permission
+import com.cloudogu.gitops.scmm.api.Repository
+import com.cloudogu.gitops.scmm.api.RepositoryApi
+import groovy.yaml.YamlSlurper
+import okhttp3.internal.http.RealResponseBody
+import okio.BufferedSource
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Ref
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import retrofit2.Call
+import retrofit2.Response
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static groovy.test.GroovyAssert.shouldFail
+import static org.assertj.core.api.Assertions.assertThat
+import static org.mockito.ArgumentMatchers.*
+import static org.mockito.Mockito.*
+
+class AirGappedUtilsTest {
+
+    Map config = [
+            application: [
+                    localHelmChartFolder : '',
+                    gitName : 'Cloudogu',
+                    gitEmail : 'hello@cloudogu.com',
+            ],
+            scmm: [
+                    username: 'scmm-usr',
+                    password: 'scmm-pw',
+                    gitOpsUsername: 'foo-gitops'
+            ]
+    ]
+    
+    Map helmConfig = [
+            chart  : 'kube-prometheus-stack',
+            repoURL: 'https://kube-prometheus-stack-repo-url',
+            version: '58.2.1'
+    ]
+    
+    Path rootChartsFolder = Files.createTempDirectory(this.class.getSimpleName())
+    TestScmmRepoProvider scmmRepoProvider = new TestScmmRepoProvider(new Configuration(config), new FileSystemUtils())
+    FileSystemUtils fileSystemUtils = new FileSystemUtils()
+    RepositoryApi repositoryApi = mock(RepositoryApi)
+
+    @Test
+    void 'Prepares repos for air-gapped use'() {
+        setupForAirgappedUse()
+
+        def response = mockSuccessfulResponse(201)
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(response)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(response)
+
+        def actualRepoNamespaceAndName = createAirGappedUtils().mirrorHelmRepoToGit(helmConfig)
+        
+        assertThat(actualRepoNamespaceAndName).isEqualTo(
+                "${ScmmRepo.NAMESPACE_3RD_PARTY_DEPENDENCIES}/kube-prometheus-stack".toString())
+        assertAirGapped()
+    }
+
+    @Test
+    void 'Air-gapped: Fails when unable to resolve version of dependencies'() {
+        setupForAirgappedUse([:])
+        def exception = shouldFail(RuntimeException) {
+            createAirGappedUtils().mirrorHelmRepoToGit(helmConfig)
+        }
+
+        assertThat(exception.message).isEqualTo(
+                'Unable to determine proper version for dependency grafana (version: 7.3.*) ' +
+                        'from repo 3rd-party-dependencies/kube-prometheus-stack'
+        )
+    }
+
+    @Test
+    void 'Ignores existing Repos'() {
+        setupForAirgappedUse()
+
+        def errorResponse = this.mockErrorResponse(409)
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(errorResponse)
+
+        createAirGappedUtils().mirrorHelmRepoToGit(helmConfig)
+
+        assertAirGapped()
+    }
+
+    @Test
+    void 'Ignores existing Permissions'() {
+        setupForAirgappedUse()
+
+        def errorResponse = mockErrorResponse(409)
+        def successfulResponse = mockSuccessfulResponse(201)
+
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(successfulResponse)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(errorResponse)
+
+        createAirGappedUtils().mirrorHelmRepoToGit(helmConfig)
+
+        assertAirGapped()
+    }
+
+    @Test
+    void 'Handles failures to SCMM-API for Repos'() {
+        setupForAirgappedUse()
+
+        def errorResponse = this.mockErrorResponse(500)
+
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(errorResponse)
+
+        def exception = shouldFail(RuntimeException) {
+            createAirGappedUtils().mirrorHelmRepoToGit(helmConfig)
+        }
+        assertThat(exception.message).startsWith('Could not create Repository')
+        assertThat(exception.message).contains('3rd-party-dependencies')
+        assertThat(exception.message).contains('kube-prometheus-stack')
+        assertThat(exception.message).contains('500')
+    }
+
+    @Test
+    void 'Handles failures to SCMM-API for Permissions'() {
+        setupForAirgappedUse()
+
+        def errorResponse = mockErrorResponse(500)
+        def successfulResponse = mockSuccessfulResponse(201)
+
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(successfulResponse)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(errorResponse)
+
+        def exception = shouldFail(RuntimeException) {
+            createAirGappedUtils().mirrorHelmRepoToGit(helmConfig)
+        }
+        assertThat(exception.message).startsWith('Could not create Permission for repo 3rd-party-dependencies/kube-prometheus-stack')
+        assertThat(exception.message).contains('foo-gitops')
+        assertThat(exception.message).contains(Permission.Role.WRITE.name())
+        assertThat(exception.message).contains('500')
+    }
+
+    protected void setupForAirgappedUse(Map chartLock = null) {
+        def response = mockSuccessfulResponse(201)
+        when(repositoryApi.create(any(Repository), anyBoolean())).thenReturn(response)
+        when(repositoryApi.createPermission(anyString(), anyString(), any(Permission))).thenReturn(response)
+
+        Path sourceChart = rootChartsFolder.resolve('kube-prometheus-stack')
+        Files.createDirectories(sourceChart)
+        Map prometheusChartYaml = [
+                version     : '1.2.3',
+                name        : 'kube-prometheus-stack-chart',
+                dependencies: [
+                        [
+                                condition: 'crds.enabled',
+                                name: 'crds',
+                                repository: '',
+                                version: '0.0.0'
+                        ],
+                        [
+                                condition : 'grafana.enabled',
+                                name      : 'grafana',
+                                repository: 'https://grafana-repo-url',
+                                version   : '7.3.*',
+                        ]
+                ]
+        ]
+        fileSystemUtils.writeYaml(prometheusChartYaml, sourceChart.resolve('Chart.yaml').toFile())
+
+        if(chartLock == null) {
+            chartLock = [
+                    dependencies: [
+                            [
+                                    name: 'crds',
+                                    repository: "",
+                                    version: '0.0.0'
+                            ],
+                            [
+                                    name: 'grafana',
+                                    repository: 'https://grafana.github.io/helm-charts',
+                                    version: '7.3.9'
+                            ]
+                    ]
+            ]
+        }
+        fileSystemUtils.writeYaml(chartLock, sourceChart.resolve('Chart.lock').toFile())
+
+        config.application['localHelmChartFolder'] = rootChartsFolder.toString()
+    }
+
+    protected void assertAirGapped() {
+        ScmmRepo prometheusRepo = scmmRepoProvider.repos['3rd-party-dependencies/kube-prometheus-stack']
+        assertThat(prometheusRepo).isNotNull()
+        assertThat(Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.lock')).doesNotExist()
+
+        def ys = new YamlSlurper()
+        def actualPrometheusChartYaml = ys.parse(Path.of(prometheusRepo.absoluteLocalRepoTmpDir, 'Chart.yaml'))
+        assertThat(actualPrometheusChartYaml['name']).isEqualTo('kube-prometheus-stack-chart')
+
+        def dependencies = actualPrometheusChartYaml['dependencies'] as List
+        assertThat(dependencies).hasSize(2)
+        assertThat(dependencies[0]['name']).isEqualTo('crds')
+        assertThat(dependencies[0]['version']).isEqualTo('0.0.0')
+        assertThat(dependencies[0]['repository']).isEqualTo('')
+        assertThat(dependencies[1]['name']).isEqualTo('grafana')
+        assertThat(dependencies[1]['version']).isEqualTo('7.3.9')
+        assertThat(dependencies[1]['repository']).isEqualTo('')
+
+        assertHelmRepoCommits(prometheusRepo, '1.2.3', 'Chart kube-prometheus-stack-chart, version: 1.2.3\n\n' +
+                'Source: https://kube-prometheus-stack-repo-url\nDependencies localized to run in air-gapped environments')
+
+        def repoCreateArgument = ArgumentCaptor.forClass(Repository)
+        verify(repositoryApi, times(1)).create(repoCreateArgument.capture(), eq(true))
+        assertThat(repoCreateArgument.allValues[0].namespace).isEqualTo(ScmmRepo.NAMESPACE_3RD_PARTY_DEPENDENCIES)
+        assertThat(repoCreateArgument.allValues[0].name).isEqualTo('kube-prometheus-stack')
+        assertThat(repoCreateArgument.allValues[0].description).isEqualTo('Mirror of Helm chart kube-prometheus-stack from https://kube-prometheus-stack-repo-url')
+
+        def permissionCreateArgument = ArgumentCaptor.forClass(Permission)
+        verify(repositoryApi, times(1)).createPermission(anyString(), anyString(), permissionCreateArgument.capture())
+        assertThat(permissionCreateArgument.allValues[0].name).isEqualTo('foo-gitops')
+        assertThat(permissionCreateArgument.allValues[0].role).isEqualTo(Permission.Role.WRITE)
+    }
+
+    Call<Void> mockSuccessfulResponse(int expectedReturnCode) {
+        def expectedCall = mock(Call<Void>)
+        when(expectedCall.execute()).thenReturn(Response.success(expectedReturnCode, null))
+        expectedCall
+    }
+
+    Call<Void> mockErrorResponse(int expectedReturnCode) {
+        def expectedCall = mock(Call<Void>)
+        // Response is a final class that cannot be mocked 😠
+        Response<Void> errorResponse = Response.error(expectedReturnCode, new RealResponseBody('dontcare', 0, mock(BufferedSource)))
+        when(expectedCall.execute()).thenReturn(errorResponse)
+        expectedCall
+    }
+
+    void assertHelmRepoCommits(ScmmRepo repo, String expectedTag, String expectedCommitMessage) {
+        def commits = Git.open(new File(repo.absoluteLocalRepoTmpDir)).log().setMaxCount(1).all().call().collect()
+        assertThat(commits.size()).isEqualTo(1)
+        assertThat(commits[0].fullMessage).isEqualTo(expectedCommitMessage)
+
+        List<Ref> tags = Git.open(new File(repo.absoluteLocalRepoTmpDir)).tagList().call()
+        assertThat(tags.size()).isEqualTo(1)
+        assertThat(tags[0].name).isEqualTo("refs/tags/${expectedTag}".toString())
+    }
+
+    AirGappedUtils createAirGappedUtils() {
+        new AirGappedUtils(new Configuration(config), scmmRepoProvider, repositoryApi, fileSystemUtils)
+    }
+}

--- a/src/test/groovy/com/cloudogu/gitops/utils/FileSystemUtilsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/FileSystemUtilsTest.groovy
@@ -2,7 +2,9 @@ package com.cloudogu.gitops.utils
 
 import org.junit.jupiter.api.Test
 
+import java.nio.file.Files
 import java.nio.file.Path
+import java.util.stream.Collectors
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -22,5 +24,24 @@ class FileSystemUtilsTest {
         
         assertThat(tmpFile.toAbsolutePath().toString()).isNotEqualTo(someFile.getAbsoluteFile())
         assertThat(tmpFile.toFile().getText().trim()).isEqualTo(expectedText)
+    }
+    
+    @Test
+    void 'deletes files except'() {
+        Path parentDir = Files.createTempDirectory(this.class.getSimpleName())
+        for (i in 0..<3) {
+            def filePath = parentDir.resolve i.toString()
+            Files.write(filePath, i.toString().getBytes())
+        }
+        for (i in 3..<7) {
+            Path dirPath = parentDir.resolve(i.toString())
+            Files.createDirectories(dirPath)
+        }
+        
+        fileSystemUtils.deleteFilesExcept(parentDir.toFile(), '0', '3')
+
+        List<Path> chartSubFolders = Files.list(parentDir).collect(Collectors.toList())
+        assertThat(chartSubFolders).hasSize(2)
+        assertThat(chartSubFolders).contains(parentDir.resolve('0'), parentDir.resolve('3'))
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/utils/HelmClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/HelmClientTest.groovy
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import static org.assertj.core.api.Assertions.assertThat
 
 class HelmClientTest {
+    
     @Test
     void 'assembles parameters for upgrade'() {
         def commandExecutor = new CommandExecutorForTest()
@@ -16,9 +17,33 @@ class HelmClientTest {
         new HelmClient(commandExecutor).upgrade("the-release", "path/to/chart", [:])
         new HelmClient(commandExecutor).upgrade("the-release", "path/to/chart", [namespace: 'the-namespace'])
 
-        assertThat(commandExecutor.actualCommands[0]).isEqualTo('helm upgrade -i the-release path/to/chart --version the-version --values values.yaml --namespace the-namespace --create-namespace ')
-        assertThat(commandExecutor.actualCommands[1]).isEqualTo('helm upgrade -i the-release path/to/chart --create-namespace ')
-        assertThat(commandExecutor.actualCommands[2]).isEqualTo('helm upgrade -i the-release path/to/chart --namespace the-namespace --create-namespace ')
+        assertThat(commandExecutor.actualCommands[0]).startsWith('helm upgrade -i the-release path/to/chart --create-namespace')
+        assertThat(commandExecutor.actualCommands[0]).contains(' --version the-version')
+        assertThat(commandExecutor.actualCommands[0]).contains(' --values values.yaml')
+        assertThat(commandExecutor.actualCommands[0]).contains(' --namespace the-namespace')
+
+        assertThat(commandExecutor.actualCommands[1]).isEqualTo('helm upgrade -i the-release path/to/chart --create-namespace')
+        assertThat(commandExecutor.actualCommands[2]).isEqualTo('helm upgrade -i the-release path/to/chart --create-namespace --namespace the-namespace')
+    }
+    
+    @Test
+    void 'runs helm template'() {
+        def commandExecutor = new CommandExecutorForTest()
+        new HelmClient(commandExecutor).template("the-release", "path/to/chart", [
+                version: 'the-version',
+                namespace: 'the-namespace',
+                values: 'values.yaml',
+        ])
+        new HelmClient(commandExecutor).template("the-release", "path/to/chart", [:])
+        new HelmClient(commandExecutor).template("the-release", "path/to/chart", [namespace: 'the-namespace'])
+
+        assertThat(commandExecutor.actualCommands[0]).startsWith('helm template the-release path/to/chart ')
+        assertThat(commandExecutor.actualCommands[0]).contains(' --version the-version')
+        assertThat(commandExecutor.actualCommands[0]).contains(' --values values.yaml')
+        assertThat(commandExecutor.actualCommands[0]).contains(' --namespace the-namespace')
+        
+        assertThat(commandExecutor.actualCommands[1]).isEqualTo('helm template the-release path/to/chart')
+        assertThat(commandExecutor.actualCommands[2]).isEqualTo('helm template the-release path/to/chart --namespace the-namespace')
     }
 
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/utils/ScmmRepoTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/ScmmRepoTest.groovy
@@ -3,10 +3,11 @@ package com.cloudogu.gitops.utils
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.scmm.ScmmRepo
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Ref
 import org.junit.jupiter.api.Test
 
 import static groovy.test.GroovyAssert.shouldFail
-import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assertions.assertThat 
 
 class ScmmRepoTest {
 
@@ -123,6 +124,33 @@ class ScmmRepoTest {
         assertThat(commits[0].authorIdent.name).isEqualTo('Cloudogu')
         assertThat(commits[0].committerIdent.emailAddress).isEqualTo('hello@cloudogu.com')
         assertThat(commits[0].committerIdent.name).isEqualTo("Cloudogu")
+
+        List<Ref> tags = Git.open(new File(repo.absoluteLocalRepoTmpDir)).tagList().call()
+        assertThat(tags.size()).isEqualTo(0)
+    }
+    
+    @Test
+    void 'pushes changes to remote directory with tag'() {
+        def repo = createRepo()
+        def expectedTag = '1.0'
+
+        repo.cloneRepo()
+        def readme = new File(repo.absoluteLocalRepoTmpDir, 'README.md')
+        readme.text = 'This text should be in the readme afterwards'
+        // Create existing tag to test for idempotence
+        Git.open(new File(repo.absoluteLocalRepoTmpDir)).tag().setName(expectedTag).call()
+        
+        repo.commitAndPush("The commit message", expectedTag)
+
+
+        List<Ref> tags = Git.open(new File(repo.absoluteLocalRepoTmpDir)).tagList().call()
+        assertThat(tags.size()).isEqualTo(1)
+        assertThat(tags[0].name).isEqualTo("refs/tags/$expectedTag".toString())
+        // It would be a good idea to check if the git tag is set on the commit. 
+        // However, it's extremely complicated with jgit
+        // The "official" example code throws an exception here: Ref peeledRef = repository.getRefDatabase().peel(ref)
+        // https://github.com/centic9/jgit-cookbook/blob/d923e18b2ce2e55761858fd2e8e402dd252e0766/src/main/java/org/dstadler/jgit/porcelain/ListTags.java
+        // 🤷
     }
 
     private ScmmRepo createRepo(String repoTarget = "dont-care-repo-target") {

--- a/src/test/groovy/com/cloudogu/gitops/utils/ScmmRepoTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/ScmmRepoTest.groovy
@@ -97,6 +97,13 @@ class ScmmRepoTest {
         def repo = createRepo('expectedRepoTarget')
         assertThat(repo.scmmRepoTarget).isEqualTo('abc-expectedRepoTarget')
     }
+    
+    @Test
+    void 'Creates repo without name-prefix when in namespace 3rd-party-deps'(){
+        config.application['namePrefix'] = 'abc-'
+        def repo = createRepo("${ScmmRepo.NAMESPACE_3RD_PARTY_DEPENDENCIES}/foo")
+        assertThat(repo.scmmRepoTarget).isEqualTo("${ScmmRepo.NAMESPACE_3RD_PARTY_DEPENDENCIES}/foo".toString())
+    }
 
     @Test
     void 'Clones and checks out main'() {

--- a/src/test/groovy/com/cloudogu/gitops/utils/TestScmmRepoProvider.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/TestScmmRepoProvider.groovy
@@ -7,13 +7,15 @@ import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.api.Git
 
 class TestScmmRepoProvider extends ScmmRepoProvider {
+    Map<String, ScmmRepo> repos = [:]
+    
     TestScmmRepoProvider(Configuration configuration, FileSystemUtils fileSystemUtils) {
         super(configuration, fileSystemUtils)
     }
 
     @Override
     ScmmRepo getRepo(String repoTarget) {
-        return new ScmmRepo(configuration.config, repoTarget, fileSystemUtils) {
+        ScmmRepo repo = new ScmmRepo(configuration.config, repoTarget, fileSystemUtils) {
             @Override
             protected String getGitRepositoryUrl() {
                 def tempDir = File.createTempDir('gitops-playground-repocopy')
@@ -36,5 +38,7 @@ class TestScmmRepoProvider extends ScmmRepoProvider {
                         .call()
             }
         }
+        repos.put(repoTarget, repo)
+        return repo
     }
 }


### PR DESCRIPTION
I see at least the following test cases:

  * With `--mirror-repos`: Apply twice and make sure that it does not fail the 2nd time (when repo already exists)
  * Without `--mirror-repos`: Everything must still work as before, i.e. the [KubePromStack chart](http://scmm.localhost/scm/repo/argocd/cluster-resources/code/sources/main/argocd/kube-prometheus-stack.yaml/) refers to the source from the internet. No SCMM repo is created for prometheus in 3rd-party-dependencies
  * Git repo for Prometheus chart is only created if `mirror-repos` and `monitoring` are active
  * Grafana dashboards for Jenkins and SCMM still have to work.
