### PR TITLE
Prometheus: watch CRs in all namespaces

### DIFF
--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -162,6 +162,22 @@ grafana:
 
 prometheus:
   prometheusSpec:
+    # Find podMonitors, serviceMonitor, etc. in all namespaces
+    serviceMonitorNamespaceSelector:
+      matchLabels: {}
+    # With this, we don't need the label "release: kube-prometheus-stack" on the service monitor
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorNamespaceSelector:
+      matchLabels: {}
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleNamespaceSelector:
+      matchLabels: {}
+    ruleSelectorNilUsesHelmValues: false
+    scrapeConfigSelectorNilUsesHelmValues: false
+    probeNamespaceSelector:
+      matchLabels: {}
+    probeSelectorNilUsesHelmValues: false
+      
 <#if podResources == true>
     resources:
       limits:


### PR DESCRIPTION
This allows application to create ServiceMonitors in their own namespace .
Fits much better with our least privilege and multi-tenancy approaches.


You can validate if it works by solving this exercise:
https://cloudogu.github.io/workshop-cloudland24/#/exercise-monitoring