### PR TITLE
Upgrade SCMM

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -102,7 +102,7 @@ class ApplicationConfigurator {
                     helm  : [
                             chart  : 'scm-manager',
                             repoURL: 'https://packages.scm-manager.org/repository/helm-v2-releases/',
-                            version: '3.1.0'
+                            version: '3.2.1'
                     ]
             ],
             application: [


### PR DESCRIPTION
Allows for latest review-plugin.

This likely avoid potential exception when querying PRs in example-apps repo:

sonia.scm.api.FallbackExceptionMapper - mapping unexpected java.lang.IllegalArgumentException to status code 500 java.lang.IllegalArgumentException: RESTEASY003830: NULL value for template parameter: branch
        at org.jboss.resteasy.specimpl.ResteasyUriBuilderImpl.replaceParameter(ResteasyUriBuilderImpl.java:625)
        at