### PR TITLE
init-cluster.sh: Bind Ingress by default and allow for binding additional ports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,7 +255,7 @@ def startK3d(clusterName) {
                          "PATH=${WORKSPACE}/.local/bin:${PATH}"]) {
 
                     // Start k3d cluster, binding to an arbitrary registry port
-                    sh "yes | ./scripts/init-cluster.sh --cluster-name=${clusterName} --bind-localhost=false --bind-registry-port=0"
+                    sh "yes | ./scripts/init-cluster.sh --bind-ingress-port=0 --cluster-name=${clusterName} --bind-registry-port=0"
                 }
             }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can try the GitOps Playground on a local Kubernetes cluster by running a sin
 
 ```shell
 bash <(curl -s \
-  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh) --bind-ingress-port=80 \
+  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh) \
   && docker run --rm -t --pull=always -u $(id -u) \
     -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
     --net=host \
@@ -358,9 +358,8 @@ The ingresses can also be used when running the playground on your local machine
 * Ingresses are required [for running on Windows/Mac](#windows-or-mac).
 
 To use them locally, 
-* init your cluster (`init-cluster.sh`) with `--bind-ingress-port`, e.g. `80` or `8080`.
+* init your cluster (`init-cluster.sh`).
 * apply your playground with the following parameters  
-  (when using a port other than 80, append `:port`, e.g. `localhost:8080`): 
   * `--base-url=http://localhost` 
     * this is possible on Windows (tested on 11), Mac (tested on Ventura) or when using Linux with [systemd-resolved](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html) (default in Ubuntu, not Debian)  
       As an alternative, you could add all `*.localhost` entries to your `hosts` file.  
@@ -371,6 +370,8 @@ To use them locally,
     * Then, you can reach argocd on `http://argocd.local.gd`, for example
 * Note that when using port 80, the URLs are shorter, but you run into issues because port 80 is regarded as a privileged port. 
   Java applications seem not to be able to reach `localhost:80` or even `127.0.0.1:80` (`NoRouteToHostException`)
+* You can change the port using `init-cluster.sh --bind-ingress-port=8080`.  
+  When you do, make sure to append the same port when applying the playground: `--base-url=http://localhost:8080`
 * If your setup requires you to bind to a specific interface, you can just pass it with e.g. `--bind-ingress-port=127.0.0.1:80`
 
 ##### Deploy GitOps operators
@@ -552,7 +553,7 @@ Recommendation: 16GB.
 
 ```bash
 bash <(curl -s \
-  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh) --bind-ingress-port=80 \
+  https://raw.githubusercontent.com/cloudogu/gitops-playground/main/scripts/init-cluster.sh) \
   && docker run --rm -t --pull=always -u $(id -u) \
     -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
     --net=host \
@@ -561,7 +562,7 @@ bash <(curl -s \
 ```
 
 When you encounter errors with port 80 you might want to use e.g. 
-* `--bind-ingress-port=8080` and 
+* `init-cluster.sh) --bind-ingress-port=8080` and 
 * `--base-url=http://localhost:8080` instead.
 
 #### Windows Docker Desktop

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -169,8 +169,8 @@ scripts/apply-ng.sh #params
 ## Running multiple instances on one machine
 
 Sometimes it makes sense to run more than one instance on your developer machine.
-For example, you might want to conduct multiple long-running tests in parallel or
-you might be interested to see how the latest stable version behaved in comparission to you local build.
+For example, you might want to conduct multiple long-running tests in parallel, or 
+you might be interested to see how the latest stable version behaved in comparison to you local build.
 
 You have to options to do this
 
@@ -201,8 +201,8 @@ This will work on linux only
 ```bash
 INSTANCE=3
 
-scripts/init-cluster.sh --bind-localhost=false \
-  --cluster-name="gitops-playground$INSTANCE" --bind-registry-port="3000$INSTANCE" 
+scripts/init-cluster.sh \
+  --cluster-name="gitops-playground$INSTANCE" --bind-ingress-port=- --bind-registry-port="3000$INSTANCE " 
 
 docker run --rm -t -u $(id -u) \
  -v "$HOME/.config/k3d/kubeconfig-gitops-playground$INSTANCE.yaml:/home/.kube/config" \
@@ -439,7 +439,7 @@ That is, for most helm charts, you'll need to set an individual value.
 ```shell
 # Stop other cluster, if necessary
 # k3d cluster stop gitops-playground
-scripts/init-cluster.sh --bind-ingress-port=80 --cluster-name=two-regs
+scripts/init-cluster.sh --cluster-name=two-regs
 ```
 * Setup harbor as stated [above](#external-registry-for-development), but with Port `30000`.  
   Wait for harbor to startup: ` kubectl get pod -n harbor`  
@@ -533,9 +533,8 @@ like images or helm charts.
 
 ### Setup cluster
 
-```
-scripts/init-cluster.sh --bind-localhost=false --cluster-name=airgapped-playground
-# This will start the cluster in its own network namespace, so no accessing via localhost from your machine
+```bash
+scripts/init-cluster.sh --cluster-name=airgapped-playground
 # Note that at this point the cluster is not yet airgapped
 
 # Get the "nodeport" IP

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -107,6 +107,15 @@ function createCluster() {
             "-p ${BIND_INGRESS_PORT}:80@server:0:direct"
             )
     fi
+    
+    IFS=","
+    read -ra values <<< "$BIND_PORTS"
+    for portBinding in "${values[@]}"; do
+        K3D_ARGS+=(
+            "-p ${portBinding}@server:0:direct"
+            )
+    done
+    unset IFS
   fi
 
   echo "Creating cluster '${CLUSTER_NAME}'"
@@ -143,6 +152,7 @@ function printParameters() {
   echo "    | --bind-localhost=BOOLEAN   >> Bind the k3d container to host network. Exposes all k8s nodePorts to localhost. Defaults to true."
   echo "    | --bind-ingress-port=INT   >> Bind the ingress controller to this localhost port. Sets --bind-localhost=false. Defaults to empty."
   echo "    | --bind-registry-port=INT   >> Specify a custom port for the container registry to bind to localhost port. Only use this when port 30000 is blocked and --bind-localhost=true. Defaults to 30000 (default used by the playground)."
+  echo "    | --bind-ports=STRING   >> A comma, separated list of additional port bindings like 443:443,9090:9090. Ignored when --bind-localhost."
   echo
   echo " -x | --trace         >> Debug + Show each command executed (set -x)"
 }
@@ -190,6 +200,7 @@ readParameters() {
   BIND_INGRESS_PORT=""
   # Use default port for playground registry, because no parameter is required when applying
   BIND_REGISTRY_PORT="30000"
+  BIND_PORTS=""
   TRACE=false
 
   while [ $# -gt 0 ]; do
@@ -204,6 +215,8 @@ readParameters() {
       --bind-ingress-port*) BIND_INGRESS_PORT=$(get_longopt_value "--bind-ingress-port" "$@")
         if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
       --bind-registry-port*) BIND_REGISTRY_PORT=$(get_longopt_value "--bind-registry-port" "$@") 
+        if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
+      --bind-ports*) BIND_PORTS=$(get_longopt_value "--bind-ports" "$@"); 
         if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
       --) shift; break ;;
     *) break ;;

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -164,14 +164,21 @@ function confirm() {
 }
 
 get_longopt_value(){
-  # ensure $1 has the form --longopt=value
-  VALUE=$(echo "$1" | sed -e 's/^[^=]*=//')
+  # args
+  # 1='--expected'
+  # possibilities
+  # 2='--expected=value'
+  # or
+  # 2='--expected'
+  # 3='value'
+  
+  # check $2 has the form --longopt=value
+  VALUE=$(echo "$2" | sed -e 's/^[^=]*=//')
   if [ -z "$VALUE" ]; then
-    echo "missing value of paramater $2" >&2
+    echo "missing value of paramater $1" >&2
     exit 1
   elif [ "$VALUE" = "$1" ]; then
-    echo "missing value of paramater $2" >&2
-    exit 1
+    echo "$3"
   else
     echo "$VALUE"
   fi
@@ -187,12 +194,17 @@ readParameters() {
 
   while [ $# -gt 0 ]; do
     case "$1" in
-      -h | --help   )   printParameters; exit 0 ;;
-      --cluster-name*)   CLUSTER_NAME=$(get_longopt_value $1 "--cluster-name"); shift ;;
-      --bind-localhost*) BIND_LOCALHOST=$(get_longopt_value $1 "--bind-localhost"); shift ;;
-      --bind-ingress-port*) BIND_INGRESS_PORT=$(get_longopt_value $1 "--bind-ingress-port"); shift ;;
-      --bind-registry-port*) BIND_REGISTRY_PORT=$(get_longopt_value $1 "--bind-registry-port"); shift ;;
+      -h | --help   ) printParameters; exit 0 ;;
       -x | --trace    ) TRACE=true; shift ;;
+      --cluster-name*) CLUSTER_NAME=$(get_longopt_value "--cluster-name" "$@")
+        # Allow passing values with and without '=' 
+        if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
+      --bind-localhost*) BIND_LOCALHOST=$(get_longopt_value $1 "--bind-localhost")
+        if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
+      --bind-ingress-port*) BIND_INGRESS_PORT=$(get_longopt_value "--bind-ingress-port" "$@")
+        if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
+      --bind-registry-port*) BIND_REGISTRY_PORT=$(get_longopt_value "--bind-registry-port" "$@") 
+        if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
       --) shift; break ;;
     *) break ;;
     esac

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -64,7 +64,7 @@ function createCluster() {
 
   HOST_PORT_RANGE='8010-65535'
   K3D_ARGS=(
-    # Allow services to bind to ports < 30000 > 32xxx
+    # Allow services to bind to portBindings < 30000 > 32xxx
     "--k3s-arg=--kube-apiserver-arg=service-node-port-range=${HOST_PORT_RANGE}@server:0"
     # Used by Jenkins Agents pods
     '-v /var/run/docker.sock:/var/run/docker.sock@server:0'
@@ -101,21 +101,30 @@ function createCluster() {
     
     # Bind ingress port only when requested by parameter. 
     # On linux the pods can be reached without ingress via the k3d container's network address and the node port. 
-    if [[ -n "${BIND_INGRESS_PORT}" ]]; then
+    if [[ "${BIND_REGISTRY_PORT}" == '0' ]]; then
+      # User wants us to choose an arbitrary port.
+      # The port must then be passed when applying the playground as --base-url=localhost:PORT (printed after creation)
+      K3D_ARGS+=(
+       '-p 80@server:0:direct'
+      )
+    elif [[ "${BIND_INGRESS_PORT}" != '-' ]]; then
         # Note that 127.0.0.1:$BIND_INGRESS_PORT would be more secure, but then requests to localhost fail
         K3D_ARGS+=(
             "-p ${BIND_INGRESS_PORT}:80@server:0:direct"
             )
     fi
     
-    IFS=","
-    read -ra values <<< "$BIND_PORTS"
-    for portBinding in "${values[@]}"; do
-        K3D_ARGS+=(
-            "-p ${portBinding}@server:0:direct"
-            )
-    done
-    unset IFS
+    if [ -n "$BIND_PORTS" ]; then
+      IFS=","
+      read -ra portBindings <<< "$BIND_PORTS"
+      unset IFS
+      
+      for portBinding in "${portBindings[@]}"; do
+          K3D_ARGS+=(
+              "-p ${portBinding}@server:0:direct"
+              )
+      done
+    fi
   fi
 
   echo "Creating cluster '${CLUSTER_NAME}'"
@@ -130,9 +139,13 @@ function createCluster() {
     echoHightlighted "Make sure to pass --internal-registry-port=${registryPort} when applying the playground."
   fi
   
-  if [[ -n "${BIND_INGRESS_PORT}" ]]; then
-    echo "Bound ingress port to localhost:${BIND_INGRESS_PORT}."
-    echoHightlighted "Make sure to pass a base-url, e.g. --ingress-nginx --base-url=http://localhost$(if [ "$BIND_INGRESS_PORT" -ne 80 ]; then echo ":${BIND_INGRESS_PORT}"; fi) when applying the playground."
+  if [[ "${BIND_INGRESS_PORT}" != '-' ]]; then
+    local ingressPort
+    ingressPort=$(docker inspect \
+      --format='{{ with (index .NetworkSettings.Ports "80/tcp") }}{{ (index . 0).HostPort }}{{ end }}' \
+       k3d-${CLUSTER_NAME}-server-0)
+    echo "Bound ingress port to localhost:${ingressPort}."
+    echoHightlighted "Make sure to pass a base-url, e.g. --ingress-nginx --base-url=http://localhost$(if [ "${ingressPort}" -ne 80 ]; then echo ":${ingressPort}"; fi) when applying the playground."
   fi
 
   # Write ~/.config/k3d/kubeconfig-${CLUSTER_NAME}.yaml
@@ -150,9 +163,9 @@ function printParameters() {
   echo "    | --cluster-name=STRING   >> Set your preferred cluster name to install k3d. Defaults to 'gitops-playground'."
   
   echo "    | --bind-localhost=BOOLEAN   >> Bind the k3d container to host network. Exposes all k8s nodePorts to localhost. Defaults to true."
-  echo "    | --bind-ingress-port=INT   >> Bind the ingress controller to this localhost port. Sets --bind-localhost=false. Defaults to empty."
+  echo "    | --bind-ingress-port=INT   >> Bind the ingress controller to this localhost port. Defaults to 80. Set to - to disable."
   echo "    | --bind-registry-port=INT   >> Specify a custom port for the container registry to bind to localhost port. Only use this when port 30000 is blocked and --bind-localhost=true. Defaults to 30000 (default used by the playground)."
-  echo "    | --bind-ports=STRING   >> A comma, separated list of additional port bindings like 443:443,9090:9090. Ignored when --bind-localhost."
+  echo "    | --bind-portBindings=STRING   >> A comma separated list of additional port bindings like 443:443,9090:9090. Ignored when --bind-localhost."
   echo
   echo " -x | --trace         >> Debug + Show each command executed (set -x)"
 }
@@ -196,8 +209,8 @@ get_longopt_value(){
 
 readParameters() {
   CLUSTER_NAME=gitops-playground
-  BIND_LOCALHOST=true
-  BIND_INGRESS_PORT=""
+  BIND_LOCALHOST=false
+  BIND_INGRESS_PORT="80"
   # Use default port for playground registry, because no parameter is required when applying
   BIND_REGISTRY_PORT="30000"
   BIND_PORTS=""
@@ -207,10 +220,9 @@ readParameters() {
     case "$1" in
       -h | --help   ) printParameters; exit 0 ;;
       -x | --trace    ) TRACE=true; shift ;;
+      --bind-localhost) BIND_LOCALHOST=true; shift ;;
       --cluster-name*) CLUSTER_NAME=$(get_longopt_value "--cluster-name" "$@")
-        # Allow passing values with and without '=' 
-        if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
-      --bind-localhost*) BIND_LOCALHOST=$(get_longopt_value $1 "--bind-localhost")
+        # Allow passing portBindings with and without '=' 
         if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
       --bind-ingress-port*) BIND_INGRESS_PORT=$(get_longopt_value "--bind-ingress-port" "$@")
         if [[ "$1" == *"="* ]]; then shift; else shift 2; fi ;;
@@ -222,11 +234,6 @@ readParameters() {
     *) break ;;
     esac
   done
-  
-  # bind-ingress-port takes precedence over bind-localhost  
-  if [[ -n "${BIND_INGRESS_PORT}" ]]; then
-    BIND_LOCALHOST=false
-  fi
 }
 
 function echoHightlighted() {


### PR DESCRIPTION
* Change: Bind to localhost:80 without parameters, i.e. `--bind-localhost=80`
```bash
scripts/init-cluster.sh
```
* Achieve former behavior without params:
```bash
scripts/init-cluster.sh --bind-localhost
```
* Unchanged: Bind to another ingress port
```bash
scripts/init-cluster.sh --bind-localhost=8080
```
* New Feature: Bind additional ports, e.g. reach Jenkins, SCMM and Argo CD without ingress via localhost:9090, etc.
```
scripts/init-cluster.sh --bind-ports=9090:9090,9091:9091,9092:9092
````
