### PR TITLE
Disable pod resources by default

### DIFF
--- a/applications/argocd/nginx/helm-jenkins/k8s/values-shared.ftl.yaml
+++ b/applications/argocd/nginx/helm-jenkins/k8s/values-shared.ftl.yaml
@@ -34,7 +34,7 @@ extraVolumeMounts:
     readOnly: true
   </#if>
 
-
+<#if podResources == true>
 resources:
   limits:
     cpu: 1
@@ -42,3 +42,4 @@ resources:
   requests:
     cpu: 300m
     memory: 15Mi
+</#if>

--- a/applications/argocd/nginx/helm-umbrella/values.ftl.yaml
+++ b/applications/argocd/nginx/helm-umbrella/values.ftl.yaml
@@ -5,6 +5,7 @@ nginx:
     nodePorts:
       http: 30026
     type: <#if isRemote>LoadBalancer<#else>NodePort</#if>
+<#if podResources == true>
   resources:
     limits:
       cpu: 100m
@@ -12,6 +13,7 @@ nginx:
     requests:
       cpu: 30m
       memory: 15Mi
+</#if>
 
 <#if exampleApps.nginx.baseDomain?has_content>
   ingress:

--- a/applications/argocd/petclinic/helm/k8s/values-shared.ftl.yaml
+++ b/applications/argocd/petclinic/helm/k8s/values-shared.ftl.yaml
@@ -13,10 +13,16 @@ podinfo:
   ui:
     color: '#456456'
 
+<#if podResources == true>
 resources:
   limits:
-    cpu: 1
+    cpu: '1'
     memory: 1Gi
   requests:
     cpu: 300m
     memory: 650Mi
+<#else>
+<#-- Explicitly set to null, because the chart sets memory by default
+     https://github.com/cloudogu/spring-boot-helm-chart/blob/0.3.2/values.yaml#L40 -->
+resources: null
+</#if>

--- a/applications/argocd/petclinic/plain-k8s/k8s/production/deployment.ftl.yaml
+++ b/applications/argocd/petclinic/plain-k8s/k8s/production/deployment.ftl.yaml
@@ -34,35 +34,16 @@ spec:
           volumeMounts:
             - name: messages
               mountPath: /tmp/messages
-            - name: tmp
-              # Make /tmp writable with readOnlyRootFilesystem
-              mountPath: /tmp
+<#if podResources == true>
           resources:
             limits:
-              cpu: 1
+              cpu: '1'
               memory: 1Gi
             requests:
               cpu: 300m
               memory: 650Mi
-          securityContext: # Implement some least privilege good practices
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
-            # These two seem to cause problems with OpenShift, so we disable them for now
-            #runAsUser: 65312
-            #seccompProfile:
-            #  type: RuntimeDefault
-            # With k8s 1.30 apparmor is added 
-            # Won't work on k3d, though, because apparmor is not enabled
-            # apparmorProfile: "runtime/default"
-      enableServiceLinks: false
-      automountServiceAccountToken: false # When not communicating with API Server
+</#if>
       volumes:
         - name: messages
           configMap:
             name: messages
-        - name: tmp
-          emptyDir: {}

--- a/applications/argocd/petclinic/plain-k8s/k8s/staging/deployment.ftl.yaml
+++ b/applications/argocd/petclinic/plain-k8s/k8s/staging/deployment.ftl.yaml
@@ -34,14 +34,37 @@ spec:
           volumeMounts:
             - name: messages
               mountPath: /tmp/messages
+            - name: tmp
+              # Make /tmp writable with readOnlyRootFilesystem
+              mountPath: /tmp
+<#if podResources == true>
           resources:
             limits:
-              cpu: 1
+              cpu: '1'
               memory: 1Gi
             requests:
               cpu: 300m
               memory: 650Mi
+</#if>
+          securityContext: # Implement some least privilege good practices
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            # These two seem to cause problems with OpenShift, so we disable them for now
+            #runAsUser: 65312
+            #seccompProfile:
+            #  type: RuntimeDefault
+            # With k8s 1.30 apparmor is added 
+            # Won't work on k3d, though, because apparmor is not enabled
+            # apparmorProfile: "runtime/default"
+      enableServiceLinks: false
+      automountServiceAccountToken: false # When not communicating with API Server
       volumes:
         - name: messages
           configMap:
             name: messages
+        - name: tmp
+          emptyDir: {}

--- a/applications/cluster-resources/ingress-nginx-helm-values.ftl.yaml
+++ b/applications/cluster-resources/ingress-nginx-helm-values.ftl.yaml
@@ -10,11 +10,20 @@ controller:
     # https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     externalTrafficPolicy: Local
   replicaCount: 2
+<#if podResources == true>
   resources:
-    # Leave limits open for now, because our ingress controller is Single Point of failure
-    ##  limits:
-    ##    cpu: 100m
-    ##    memory: 90Mi
+    # Be generous to our Single Point of failure
+    limits:
+       cpu: '1'
+       memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 90Mi
+<#else>
+<#-- Explicitly set to null, because the chart sets requests by default
+     https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.9.1/charts/ingress-nginx/values.yaml#L361 -->
+  resources: null
+</#if>
   ingressClassResource:
     enabled: true
     default: true

--- a/applications/cluster-resources/mailhog-helm-values.ftl.yaml
+++ b/applications/cluster-resources/mailhog-helm-values.ftl.yaml
@@ -16,6 +16,17 @@ auth:
   enabled: true
   fileName: auth.txt
   fileContents: "${username}:${passwordCrypt}"
+<#if mail.host?has_content>
+
+ingress:
+  enabled: true
+  hosts:
+    - host: ${mail.host}
+      paths:
+        - path: "/"
+          pathType: Prefix
+</#if>
+<#if podResources == true>
 
 resources:
   limits:
@@ -24,13 +35,4 @@ resources:
   requests:
     memory: 10Mi
     cpu: 20m
-  
-<#if mail.host?has_content>
-ingress:
-  enabled: true
-  hosts:
-    - host: ${mail.host}
-      paths:
-        - path: "/"
-          pathType: Prefix
 </#if>

--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -48,6 +48,7 @@ prometheusOperator:
     # MountVolume.SetUp failed for volume "tls-secret" : secret "...-kube-prometh-admission" not found
     # This can be worked around by disabling tls altogether
     enabled: false
+<#if podResources == true>
   resources:
     limits:
       cpu: 300m
@@ -55,6 +56,7 @@ prometheusOperator:
     requests:
       cpu: 20m
       memory: 40Mi
+</#if>
 kubelet:
   enabled: false
 kubeControllerManager:
@@ -88,6 +90,7 @@ grafana:
       #this needs to be added so that the label will become 'label: grafana_dashboards: "1"'
       labelValue: 1
       searchNamespace: "ALL"
+<#if podResources == true>
     resources:
       limits:
         cpu: 100m
@@ -95,6 +98,7 @@ grafana:
       requests:
         cpu: 35m
         memory: 65Mi
+</#if>
 <#if mail.active??>
   notifiers:
     notifiers.yaml:
@@ -146,16 +150,19 @@ grafana:
     GF_SMTP_HOST: mailhog.${namePrefix}monitoring.svc.cluster.local:1025
  </#if>
 </#if>
+<#if podResources == true>
   resources:
     limits:
-      cpu: 1
+      cpu: '1'
       memory: 140Mi
     requests:
       cpu: 350m
       memory: 70Mi
+</#if>
 
 prometheus:
   prometheusSpec:
+<#if podResources == true>
     resources:
       limits:
         cpu: 500m
@@ -163,6 +170,7 @@ prometheus:
       requests:
         cpu: 50m
         memory: 450Mi
+</#if>
     secrets:
       - prometheus-metrics-creds-scmm
       - prometheus-metrics-creds-jenkins

--- a/applications/cluster-resources/secrets/external-secrets/values.ftl.yaml
+++ b/applications/cluster-resources/secrets/external-secrets/values.ftl.yaml
@@ -1,13 +1,6 @@
 installCRDs: true
 
-resources:
-  limits:
-    memory: 80Mi
-    cpu: 500m
-  requests:
-    memory: 40Mi
-    cpu: 50m
-
+<#if podResources == true>
 certController:
   resources:
     limits:
@@ -25,3 +18,12 @@ webhook:
     requests:
       memory: 25Mi
       cpu: 50m
+
+resources:
+  limits:
+    memory: 80Mi
+    cpu: 500m
+  requests:
+    memory: 40Mi
+    cpu: 50m
+</#if>

--- a/exercises/broken-application/broken-application.ftl.yaml
+++ b/exercises/broken-application/broken-application.ftl.yaml
@@ -17,6 +17,7 @@ spec:
           image: <#if nginxImage??>${nginxImage}<#else>bitnami/nginx:1.25.1</#if>
           ports:
             - containerPort: 8080
+<#if podResources == true>
           resources:
             limits:
               cpu: 100m
@@ -24,6 +25,7 @@ spec:
             requests:
               cpu: 30m
               memory: 15Mi
+</#if>
 
 ---
 

--- a/exercises/broken-application/broken-application.ftl.yaml
+++ b/exercises/broken-application/broken-application.ftl.yaml
@@ -1,18 +1,5 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: broken-application
-spec:
-  type: LoadBalancer
-  ports:
-    - port: 80
-      targetPort: 8080
-      nodePort: 30046
-  selector:
-    app: broken-application
----
 apiVersion: apps/v1
-kind: Deployment(z)
+kind: Deploymentz
 metadata:
   name: broken-application
 spec:
@@ -37,3 +24,49 @@ spec:
             requests:
               cpu: 30m
               memory: 15Mi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: broken-application
+  labels:
+    app: broken-application
+spec:
+  type: <#if isRemote>LoadBalancer<#else>NodePort</#if>
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      nodePort: 30046
+  selector:
+    app: broken-application
+
+<#if exampleApps.nginx.baseDomain?has_content>
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: broken-application
+  labels:
+    app: broken-application
+spec:
+  rules:
+    <#if urlSeparatorHyphen>
+    - host: broken-application-${exampleApps.nginx.baseDomain}
+    <#else>
+    - host: broken-application.${exampleApps.nginx.baseDomain}
+    </#if>
+      http:
+        paths:
+          - backend:
+              service:
+                name: broken-application
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+
+</#if>

--- a/exercises/nginx-validation/k8s/values-shared.ftl.yaml
+++ b/exercises/nginx-validation/k8s/values-shared.ftl.yaml
@@ -21,6 +21,7 @@ serverBlock: |-
     }
   }
 
+<#if podResources == true>
 resources:
   limits:
     cpu: 100m
@@ -28,3 +29,5 @@ resources:
   requests:
     cpu: 30m
     memory: 15Mi
+
+</#if>

--- a/exercises/petclinic-helm/k8s/values-shared.ftl.yaml
+++ b/exercises/petclinic-helm/k8s/values-shared.ftl.yaml
@@ -12,10 +12,16 @@ podinfo:
   ui:
     color: '#456456'
 
+<#if podResources == true>
 resources:
   limits:
-    cpu: 1
+    cpu: '1'
     memory: 1Gi
   requests:
     cpu: 300m
     memory: 650Mi
+<#else>
+<#-- Explicitly set to null, because the chart sets memory by default
+     https://github.com/cloudogu/spring-boot-helm-chart/blob/0.3.2/values.yaml#L40 -->
+resources: null
+</#if>

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -189,6 +189,8 @@ class GitopsPlaygroundCli  implements Runnable {
     String configMap
     @Option(names = ['--output-config-file'], description = 'Output current config as config file as much as possible')
     Boolean outputConfigFile
+    @Option(names = ['--pod-resources'], description = 'Write kubernetes resource requests and limits on each pod')
+    Boolean podResources
 
     // args group ArgoCD operator
     @Option(names = ['--argocd'], description = 'Install ArgoCD ')
@@ -383,6 +385,7 @@ class GitopsPlaygroundCli  implements Runnable {
                         password      : password,
                         pipeYes       : pipeYes,
                         namePrefix    : namePrefix,
+                        podResources : podResources,
                         baseUrl : baseUrl,
                         gitName: gitName,
                         gitEmail: gitEmail,

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -117,6 +117,7 @@ class ApplicationConfigurator {
                     runningInsideK8s : false, // Set dynamically
                     clusterBindAddress : '', // Set dynamically
                     namePrefix    : '',
+                    podResources : false,
                     namePrefixForEnvVars    : '', // Set dynamically
                     baseUrl: null,
                     gitName: 'Cloudogu',

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -61,6 +61,7 @@ class Schema {
          String username = ""
          String password = ""
          String namePrefix = ""
+         boolean podResources = false
          String gitName = ""
          String gitEmail = ""
          boolean urlSeparatorHyphen = false

--- a/src/main/groovy/com/cloudogu/gitops/features/IngressNginx.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/IngressNginx.groovy
@@ -41,8 +41,8 @@ class IngressNginx extends Feature {
         
         def templatedMap = new YamlSlurper().parseText(
                 new TemplatingEngine().template(new File(HELM_VALUES_PATH),
-                    [:
-                       // once we introduce new parameters, we pass them to template here
+                    [
+                            podResources: config.application['podResources'],
                     ])) as Map
 
         def valuesFromConfig = config['features']['ingressNginx']['helm']['values'] as Map

--- a/src/main/groovy/com/cloudogu/gitops/features/Mailhog.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Mailhog.groovy
@@ -52,6 +52,7 @@ class Mailhog extends Feature {
                 isRemote: config.application['remote'],
                 username: username,
                 passwordCrypt: bcryptMailhogPassword,
+                podResources: config.application['podResources'],
         ]).toPath()
 
         def helmConfig = config['features']['mail']['helm']

--- a/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
@@ -58,6 +58,7 @@ class PrometheusStack extends Feature {
 
         def tmpHelmValues = new TemplatingEngine().replaceTemplate(fileSystemUtils.copyToTempDir(HELM_VALUES_PATH).toFile(), [
                 namePrefix: namePrefix,
+                podResources: config.application['podResources'],
                 monitoring: [
                         grafanaEmailFrom: config.features['monitoring']['grafanaEmailFrom'] as String,
                         grafanaEmailTo: config.features['monitoring']['grafanaEmailTo'] as String,

--- a/src/main/groovy/com/cloudogu/gitops/features/Vault.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Vault.groovy
@@ -56,7 +56,10 @@ class Vault extends Feature {
                 ],
                 injector: [
                         enabled: false
-                ],
+                ]
+        ]
+        if (config['application']['podResources']){
+            MapUtils.deepMerge([
                 server: [
                         resources: [
                                 limits: [
@@ -69,7 +72,8 @@ class Vault extends Feature {
                                 ]
                         ]
                 ]
-        ]
+            ], yaml)
+        }
 
         if (!config.application['remote']) {
             log.debug("Setting Vault service.type to NodePort since it is not running in a remote cluster")

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -337,6 +337,7 @@ class ArgoCD extends Feature {
             repo.replaceTemplates(~/\.ftl/, [
                     namePrefix          : config.application['namePrefix'] as String,
                     namePrefixForEnvVars: config.application['namePrefixForEnvVars'] as String,
+                    podResources        : config.application['podResources'],
                     images              : config.images,
                     nginxImage          : config.images['nginx'] ? DockerImageParser.parse(config.images['nginx'] as String) : null,
                     isRemote            : config.application['remote'],


### PR DESCRIPTION
Current behavior is now opt-in: `--podResources` enables resource objects in all (well, most) pods.

This makes local execution of some apps like petclinic faster.
Maybe it will also lag on machine with less RAM or CPU. We'll see!

To avoid conflicts, this bases on #197. Please merge 197 first.