### PR TITLE
Fix waiting for node on startup

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
@@ -26,21 +26,40 @@ class K8sClient {
     }
 
     String getInternalNodeIp() {
-        String foundNodeIp = "0.0.0.0"
         String node = waitForNode()
 
         // For k3d this is either the host's IP or the IP address of the k3d API server's container IP (when --bind-localhost=false)
         // Note that this might return multiple InternalIP (IPV4 and IPV6) - we assume the first one is IPV4 (break after first)
         String[] command = ["kubectl", "get", "$node", 
                             "--template='{{range .status.addresses}}{{ if eq .type \"InternalIP\" }}{{.address}}{{break}}{{end}}{{end}}'"]
-        foundNodeIp = commandExecutor.execute(command).stdOut
-        return foundNodeIp
+        return commandExecutor.execute(command).stdOut
     }
 
     private String waitForNode() {
         String[] command1 = ['kubectl', 'get', 'node', '-oname']
         String[] command2 = ['head', '-n1']
-        return commandExecutor.execute(command1, command2).stdOut
+
+        int maxTries = 120
+        int sleepMillis = 1000
+        int tryCount = 0
+        String output = ""
+
+        log.debug("Waiting for first node of the cluster to become ready")
+        while (output.isEmpty() && tryCount < maxTries) {
+            output = commandExecutor.execute(command1, command2).stdOut
+            
+            if (output.isEmpty()) {
+                tryCount++
+                log.debug("Still waiting for first node of the cluster to become ready (try $tryCount/$maxTries)")
+                sleep(sleepMillis)
+            }
+        }
+
+        if (output.isEmpty()) {
+            throw new RuntimeException("Back up waiting for first node of the cluster to become ready after $maxTries tries")
+        }
+        log.debug("First node of the cluster is ready: $output")
+        return output
     }
 
     String applyYaml(String yamlLocation) {

--- a/src/test/groovy/com/cloudogu/gitops/utils/NetworkingUtilsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/NetworkingUtilsTest.groovy
@@ -22,7 +22,7 @@ class NetworkingUtilsTest {
         def internalNodeIp = "1.2.3.4"
         def localIp = "5.6.7.8"
         // getInternalNodeIp -> waitForNode()
-        k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', '', 0))
+        k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/something', 0))
         // getInternalNodeIp -> actual exec
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', internalNodeIp, 0))
         commandExecutor.enqueueOutput(new CommandExecutor.Output('', 
@@ -39,7 +39,7 @@ class NetworkingUtilsTest {
         assertThat(internalNodeIp).isNotEmpty()
         
         // getInternalNodeIp -> waitForNode(), don't care
-        k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', '', 0))
+        k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/something', 0))
         // getInternalNodeIp -> actual exec
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', internalNodeIp, 0))
 
@@ -52,7 +52,7 @@ class NetworkingUtilsTest {
     void 'clusterBindAddress: fails when no potential bind address'() {
         def internalNodeIp = ''
         // getInternalNodeIp -> waitForNode()
-        k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', '', 0))
+        k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/something', 0))
         // getInternalNodeIp -> actual exec
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', internalNodeIp, 0))
         commandExecutor.enqueueOutput(new CommandExecutor.Output('',


### PR DESCRIPTION
K8sClient.waitForNode(): The method name claimed something the method did not do - waiting.

Before d2f218c1 / #174 we had a bash method of the same name that actually waited.
It was called before the Groovy code was called.
So all those years `K8sClient.waitForNode()` lied about its implementation, but it was no problem.

After the bash implementation was gone, however, our build started to become flaky with these kinds of errors:

```
TRACE c.c.gitops.utils.CommandExecutor - Executing command: '[kubectl, get, node, -oname]' 
TRACE c.c.gitops.utils.CommandExecutor - Executing command: '[head, -n1]'
TRACE c.c.gitops.utils.CommandExecutor - Executing command: '[kubectl, get, , --template='{{range .status.addresses}}{{ if eq .type "InternalIP" }}{{.address}}{{break}}{{end}}{{end}}']' 11:34:12  error: the server doesn't have a resource type ""
```

The problem likely being that the k3d cluster wasn't ready, yet and returned empty on `get node'` without waiting.
The empty returned was then passed to the following function which then failed.
This should no be fixed.