### PR TITLE
Fix dev image

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategy.groovy
@@ -6,11 +6,13 @@ import com.cloudogu.gitops.scmm.ScmmRepoProvider
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import groovy.util.logging.Slf4j
 import jakarta.inject.Singleton
 
 import java.nio.file.Path
 
 @Singleton
+@Slf4j
 class ArgoCdApplicationStrategy implements DeploymentStrategy {
     private FileSystemUtils fileSystemUtils
     private Map config
@@ -30,13 +32,14 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
     @SuppressWarnings('GroovyGStringKey') // Using dynamic strings as keys seems an easy to read way to avoid more ifs
     void deployFeature(String repoURL, String repoName, String chartOrPath, String version, String namespace,
                        String releaseName, Path helmValuesPath, RepoType repoType) {
+        log.trace("Deploying helm chart via ArgoCD: ${releaseName}. Reading values from ${helmValuesPath}")
         def namePrefix = config.application['namePrefix']
 
         ScmmRepo clusterResourcesRepo = scmmRepoProvider.getRepo('argocd/cluster-resources')
         clusterResourcesRepo.cloneRepo()
 
         // Inline values from tmpHelmValues file into ArgoCD Application YAML
-        def inlineValues = helmValuesPath.text
+        def inlineValues = helmValuesPath.toFile().text
 
         // Write chart, repoURL and version into a ArgoCD Application YAML
 


### PR DESCRIPTION
23fb76a1 actually starts to interpret groovy code. Before, we unknowingly
 executed the bytecode (class files) from the jar.

So we never knew about this bug:
`ArgoCdApplicationStrategy.groovy` ran `Path.text` even though Path in groovy does not have a text property.

The compiler somehow seems to make this right but the groovy interpreter does not 🤷‍♂️

Exception was as follows:
```
❯ docker run --rm -t -u $(id -u)  --pull=always \
    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
    --net=host \
ghcr.io/cloudogu/gitops-playground:a19d91f-dev --yes --argocd  --ingress-nginx --base-url=http://localhost
a19d91f-dev: Pulling from cloudogu/gitops-playground
Digest: sha256:5188edab4e513b531922ff6b63df24c4224f4c165fdc2657cd28d33e3a5386e0
Status: Image is up to date for ghcr.io/cloudogu/gitops-playground:a19d91f-dev
11:34:26.204 INFO  - Installing Feature Registry
11:34:28.528 INFO  - Installing Feature ScmManager
11:34:44.664 INFO  - Installing Feature Jenkins
11:37:03.866 INFO  - Installing Feature ArgoCD
11:37:17.607 INFO  - Installing Feature IngressNginx
groovy.lang.MissingPropertyException: No such property: text for class: sun.nio.fs.UnixPath
Possible solutions: root
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:67)
        at org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.unwrap(IndyGuardsFiltersAndSignatures.java:161)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.features.deployment.ArgoCdApplicationStrategy.deployFeature(ArgoCdApplicationStrategy.groovy:39)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.features.deployment.Deployer.deployFeature(Deployer.groovy:26)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.features.deployment.DeploymentStrategy$Trait$Helper.deployFeature(DeploymentStrategy.groovy:11)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.features.deployment.Deployer.deployFeature(Deployer.groovy)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.features.IngressNginx.enable(IngressNginx.groovy:98)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.Feature.install(Feature.groovy:11)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.Application$_start_closure1.doCall(Application.groovy:23)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:279)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1006)
        at groovy.lang.Closure.call(Closure.java:418)
        at org.codehaus.groovy.runtime.ConvertedClosure.invokeCustom(ConvertedClosure.java:50)
        at org.codehaus.groovy.runtime.ConversionHandler.invoke(ConversionHandler.java:113)
        at jdk.proxy3/jdk.proxy3.$Proxy42.accept(Unknown Source)
        at java.base/java.util.ArrayList.forEach(Unknown Source)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.Application.start(Application.groovy:22)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.cli.GitopsPlaygroundCli.run(GitopsPlaygroundCli.groovy:245)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2026)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
        at picocli.CommandLine.execute(CommandLine.java:2170)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.cli.GitopsPlaygroundCliMain.exec(GitopsPlaygroundCliMain.groovy:23)
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
        at com.cloudogu.gitops.cli.GitopsPlaygroundCliMainScripted.main(GitopsPlaygroundCliMainScripted.groovy:40)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
        at groovy.lang.MetaClassImpl.invokeStaticMethod(MetaClassImpl.java:1584)
        at org.codehaus.groovy.runtime.InvokerHelper.invokeMethod(InvokerHelper.java:611)
        at groovy.lang.GroovyShell.runScriptOrMainOrTestOrRunnable(GroovyShell.java:296)
        at groovy.lang.GroovyShell.run(GroovyShell.java:393)
        at groovy.lang.GroovyShell.run(GroovyShell.java:382)
        at groovy.ui.GroovyMain.processOnce(GroovyMain.java:649)
```

This PR fixes this:
```
docker run --rm -t -u $(id -u)  \
    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
    --net=host \
ghcr.io/cloudogu/gitops-playground:a076946-dev --yes --argocd  --ingress-nginx --base-url=http://localhost
12:24:27.151 INFO  - Installing Feature Registry
12:24:28.381 INFO  - Installing Feature ScmManager
12:24:43.419 INFO  - Installing Feature Jenkins
12:25:56.301 INFO  - Installing Feature ArgoCD
12:26:10.754 INFO  - Installing Feature IngressNginx
12:26:10.882 INFO  -

  |----------------------------------------------------------------------------------------------|
  |                       Welcome to the GitOps playground by Cloudogu!
...
```
