### PR TITLE
BREAKING: Refactor params registry-push + pull to registry-proxy

### DIFF
--- a/applications/argocd/petclinic/helm/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/helm/Jenkinsfile.ftl
@@ -4,16 +4,14 @@ String getApplication() { "spring-petclinic-helm" }
 String getScmManagerCredentials() { 'scmm-user' }
 String getConfigRepositoryPRBaseUrl() { env.SCMM_URL }
 String getConfigRepositoryPRRepo() { '${namePrefix}argocd/example-apps' }
-<#if registry.twoRegistries>
-String getDockerRegistryPullBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PULL_URL }
-String getDockerRegistryPullCredentials() { 'registry-pull-user' }
-String getDockerRegistryPushBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PUSH_URL }
-String getDockerRegistryPushPath() { env.${namePrefixForEnvVars}REGISTRY_PUSH_PATH }
-String getDockerRegistryPushCredentials() { 'registry-push-user' }
-<#else>
+
 String getDockerRegistryBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_URL }
 String getDockerRegistryPath() { env.${namePrefixForEnvVars}REGISTRY_PATH }
 String getDockerRegistryCredentials() { 'registry-user' }
+
+<#if registry.twoRegistries>
+String getDockerRegistryProxyBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PROXY_URL }
+String getDockerRegistryProxyCredentials() { 'registry-proxy-user' }
 </#if>
 
 <#noparse>
@@ -66,33 +64,24 @@ node {
         stage('Docker') {
             String imageTag = createImageTag()
 </#noparse>
+<#noparse>
+            String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
+            imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
+</#noparse>
 <#if registry.twoRegistries>
 <#noparse>
-            String pathPrefix = !dockerRegistryPushPath?.trim() ? "" : "${dockerRegistryPushPath}/"
-            imageName = "${dockerRegistryPushBaseUrl}/${pathPrefix}${application}:${imageTag}"
-            docker.withRegistry("http://${dockerRegistryPullBaseUrl}", dockerRegistryPullCredentials) {
+            docker.withRegistry("http://${dockerRegistryProxyBaseUrl}", dockerRegistryProxyCredentials) {
                 image = docker.build(imageName, '.')
             }
 </#noparse>
 <#else>
 <#noparse>
-            String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
-            imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
             image = docker.build(imageName, '.')
 </#noparse>
 </#if>
-
+<#noparse>
             if (isBuildSuccessful()) {
-<#if registry.twoRegistries>
-<#noparse>
-                docker.withRegistry("http://${dockerRegistryPushBaseUrl}", dockerRegistryPushCredentials) {
-</#noparse>
-<#else>
-<#noparse>
                 docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
-</#noparse>
-</#if>
-<#noparse>
                     image.push()
                 }
             } else {

--- a/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
@@ -4,17 +4,16 @@ String getApplication() { 'spring-petclinic-plain' }
 String getConfigRepositoryPRRepo() { '${namePrefix}argocd/example-apps' }
 String getScmManagerCredentials() { 'scmm-user' }
 String getConfigRepositoryPRBaseUrl() { env.SCMM_URL }
-<#if registry.twoRegistries>
-String getDockerRegistryPullBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PULL_URL }
-String getDockerRegistryPullCredentials() { 'registry-pull-user' }
-String getDockerRegistryPushBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PUSH_URL }
-String getDockerRegistryPushPath() { env.${namePrefixForEnvVars}REGISTRY_PUSH_PATH }
-String getDockerRegistryPushCredentials() { 'registry-push-user' }
-<#else>
+
 String getDockerRegistryBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_URL }
 String getDockerRegistryPath() { env.${namePrefixForEnvVars}REGISTRY_PATH }
 String getDockerRegistryCredentials() { 'registry-user' }
+
+<#if registry.twoRegistries>
+    String getDockerRegistryProxyBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PROXY_URL }
+    String getDockerRegistryProxyCredentials() { 'registry-proxy-user' }
 </#if>
+
 <#noparse>
 String getCesBuildLibRepo() { "${env.SCMM_URL}/repo/3rd-party-dependencies/ces-build-lib" }
 String getCesBuildLibVersion() { '2.2.0' }
@@ -57,33 +56,24 @@ node {
         stage('Docker') {
             String imageTag = createImageTag()
 </#noparse>
+<#noparse>
+            String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
+            imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
+</#noparse>
 <#if registry.twoRegistries>
 <#noparse>
-            String pathPrefix = !dockerRegistryPushPath?.trim() ? "" : "${dockerRegistryPushPath}/"
-            imageName = "${dockerRegistryPushBaseUrl}/${pathPrefix}${application}:${imageTag}"
-            docker.withRegistry("http://${dockerRegistryPullBaseUrl}", dockerRegistryPullCredentials) {
+            docker.withRegistry("http://${dockerRegistryProxyBaseUrl}", dockerRegistryProxyCredentials) {
                 image = docker.build(imageName, '.')
             }
 </#noparse>
 <#else>
 <#noparse>
-            String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
-                imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
-                image = docker.build(imageName, '.')
+            image = docker.build(imageName, '.')
 </#noparse>
 </#if>
-
+<#noparse>
             if (isBuildSuccessful()) {
-<#if registry.twoRegistries>
-<#noparse>
-                        docker.withRegistry("http://${dockerRegistryPushBaseUrl}", dockerRegistryPushCredentials) {
-</#noparse>
-<#else>
-<#noparse>
                 docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
-</#noparse>
-</#if>
-<#noparse>
                     image.push()
                 }
             } else {
@@ -136,7 +126,7 @@ node {
                 ]
 <#noparse>
                 addSpecificGitOpsConfig(gitopsConfig)
-                
+
                 deployViaGitops(gitopsConfig)
             } else {
                 echo 'Skipping deploy, because build not successful or not on main branch'
@@ -157,9 +147,9 @@ void addSpecificGitOpsConfig(gitopsConfig) {
         cesBuildLibRepo: cesBuildLibRepo,
         cesBuildLibVersion: cesBuildLibVersion,
         cesBuildLibCredentialsId: scmManagerCredentials,
-        
-        
-        // The GitOps playground provides parameters for overwriting the build images used by gitops-build-lib, so 
+
+
+        // The GitOps playground provides parameters for overwriting the build images used by gitops-build-lib, so
         // it also works in an offline context.
         // Those parameters overwrite the following parameters.
         // If you can access the internet, you can rely on the defaults, which load the images from public registries.
@@ -193,7 +183,7 @@ def loadLibraries() {
     // @Library(["github.com/cloudogu/ces-build-lib@${cesBuildLibVersion}", "github.com/cloudogu/gitops-build-lib@${gitOpsBuildLibRepo}"]) _
     //import com.cloudogu.ces.cesbuildlib.*
     //import com.cloudogu.ces.gitopsbuildlib.*
-    
+
     cesBuildLib = library(identifier: "ces-build-lib@${cesBuildLibVersion}",
             retriever: modernSCM([$class: 'GitSCMSource', remote: cesBuildLibRepo, credentialsId: scmManagerCredentials])
     ).com.cloudogu.ces.cesbuildlib

--- a/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
@@ -10,8 +10,8 @@ String getDockerRegistryPath() { env.${namePrefixForEnvVars}REGISTRY_PATH }
 String getDockerRegistryCredentials() { 'registry-user' }
 
 <#if registry.twoRegistries>
-    String getDockerRegistryProxyBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PROXY_URL }
-    String getDockerRegistryProxyCredentials() { 'registry-proxy-user' }
+String getDockerRegistryProxyBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PROXY_URL }
+String getDockerRegistryProxyCredentials() { 'registry-proxy-user' }
 </#if>
 
 <#noparse>

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -503,15 +503,15 @@
         },
         "proxyPassword" : {
           "type" : "string",
-          "description" : "Optional when registry-url is set"
+          "description" : "Use with registry-proxy-url, added to Jenkins as credentials."
         },
         "proxyUrl" : {
           "type" : "string",
-          "description" : "The url of your external proxy-registry. Make sure to always use this with registry-proxy-url"
+          "description" : "The url of your proxy-registry. Used in pipelines to authorize pull base images. Use in conjunction with petclinic base image."
         },
         "proxyUsername" : {
           "type" : "string",
-          "description" : "Optional when registry-proxy-url is set"
+          "description" : "Use with registry-proxy-url, added to Jenkins as credentials."
         },
         "url" : {
           "type" : "string",

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -501,33 +501,17 @@
           "type" : "string",
           "description" : "Optional when registry-url is set"
         },
-        "pullPassword" : {
+        "proxyPassword" : {
           "type" : "string",
-          "description" : "Optional when registry-pull-url is set"
+          "description" : "Optional when registry-url is set"
         },
-        "pullUrl" : {
+        "proxyUrl" : {
           "type" : "string",
-          "description" : "The url of your external pull-registry. Make sure to always use this with registry-push-url"
+          "description" : "The url of your external proxy-registry. Make sure to always use this with registry-proxy-url"
         },
-        "pullUsername" : {
+        "proxyUsername" : {
           "type" : "string",
-          "description" : "Optional when registry-pull-url is set"
-        },
-        "pushPassword" : {
-          "type" : "string",
-          "description" : "Optional when registry-push-url is set"
-        },
-        "pushPath" : {
-          "type" : "string",
-          "description" : "Optional when registry-push-url is set"
-        },
-        "pushUrl" : {
-          "type" : "string",
-          "description" : "The url of your external pull-registry. Make sure to always use this with registry-pull-url"
-        },
-        "pushUsername" : {
-          "type" : "string",
-          "description" : "Optional when registry-push-url is set"
+          "description" : "Optional when registry-proxy-url is set"
         },
         "url" : {
           "type" : "string",

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -430,7 +430,7 @@ That is, for most helm charts, you'll need to set an individual value.
 ### Very simple test
 * Start playground once,
 * then again with these parameters:  
-  `--registry-pull-url=localhost:30000 --registry-push-url=localhost:30000`
+  `--registry-proxy-url=localhost:30000`
 * The petclinic pipelines should still run
 
 ### Proper test
@@ -439,7 +439,7 @@ That is, for most helm charts, you'll need to set an individual value.
 ```shell
 # Stop other cluster, if necessary
 # k3d cluster stop gitops-playground
-scripts/init-cluster.sh --cluster-name=two-regs
+scripts/init-cluster.sh
 ```
 * Setup harbor as stated [above](#external-registry-for-development), but with Port `30000`.  
   Wait for harbor to startup: ` kubectl get pod -n harbor`  
@@ -447,7 +447,7 @@ scripts/init-cluster.sh --cluster-name=two-regs
 * Create registries and base image:
 
 ```bash
-operations=("Pull" "Push")
+operations=("Proxy" "Registry")
 
 for operation in "${operations[@]}"; do
 
@@ -465,25 +465,26 @@ for operation in "${operations[@]}"; do
     curl  --fail "http://localhost:30000/api/v2.0/projects/${projectId}/members" -X POST -u admin:Harbor12345    -H 'Content-Type: application/json' --data-raw "{\"role_id\":4,\"member_user\":{\"username\":\"$operation\"}}"
 done
 
-skopeo copy docker://eclipse-temurin:11-jre-alpine --dest-creds Pull:Pull12345 --dest-tls-verify=false  docker://localhost:30000/pull/eclipse-temurin:11-jre-alpine
+skopeo copy docker://eclipse-temurin:11-jre-alpine --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  docker://localhost:30000/proxy/eclipse-temurin:11-jre-alpine
 ```
 
 * Deploy playground:
 
 ```bash
-docker run --rm -t  -u $(id -u)  \
-    -v ~/.config/k3d/kubeconfig-two-regs.yaml:/home/.kube/config \
-    -v $(pwd)/gitops-playground.yaml:/config/gitops-playground.yaml \
-    --net=host \
-  gitops-playground:dev -x --yes --argocd  --ingress-nginx --base-url=http://localhost  \
-  --registry-push-url=localhost:30000 \
-  --registry-push-path=push \
-  --registry-push-username=Push \
-  --registry-push-password=Push12345 \
-  --registry-pull-url=localhost:30000 \
-  --registry-pull-username=Pull \
-  --registry-pull-password=Pull12345 \
-  --petclinic-image=localhost:30000/pull/eclipse-temurin:11-jre-alpine 
+docker run --rm -t -u $(id -u)  \
+   -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config  \
+    --net=host  \     
+    gitops-playground:tag \
+    --yes --argocd --ingress-nginx --base-url=http://localhost \
+    --registry-url=localhost:30000 \
+    --registry-path=registry \
+    --registry-username=Registry  \
+    --registry-password=Registry12345 \
+    --registry-proxy-url=localhost:30000 \
+    --registry-proxy-username=Proxy \
+    --registry-proxy-password=Proxy12345 \
+    --petclinic-image=localhost:30000/proxy/eclipse-temurin:11-jre-alpine 
+
 # Or with config file --config-file=/config/gitops-playground.yaml 
 ```
 
@@ -496,8 +497,8 @@ for namespace in "${namespaces[@]}"; do
   kubectl create secret docker-registry regcred \
   -n $namespace \
   --docker-server=localhost:30000 \
-  --docker-username=Push \
-  --docker-password=Push12345
+  --docker-username=Registry\
+  --docker-password=Registry12345
   kubectl patch serviceaccount default -n $namespace -p '{"imagePullSecrets": [{"name": "regcred"}]}'
 done
 ```
@@ -506,15 +507,15 @@ The same using a config file looks like so:
 
 ```yaml
 registry: 
-  pullUrl: localhost:30000
-  pullUsername: Pull
-  pullPassword: Pull12345
-  pushUrl: localhost:30000
-  pushUsername: Push
-  pushPassword: Push12345
-  pushPath: push
+  proxyUrl: localhost:30000
+  proxyUsername: Proxy
+  proxyPassword: Proxy12345
+  registryUrl: localhost:30000
+  registryUsername: Registry
+  registryPassword: Registry12345
+  registryPath: Registry
 images: 
-  petclinic: localhost:30000/pull/eclipse-temurin:11-jre-alpine
+  petclinic: localhost:30000/proxy/eclipse-temurin:11-jre-alpine
 ```
 
 ## Emulate an airgapped environment

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -427,18 +427,16 @@ That is, for most helm charts, you'll need to set an individual value.
 
 ## Testing two registries
 
-### Very simple test
+### Basic test
 * Start playground once,
 * then again with these parameters:  
-  `--registry-proxy-url=localhost:30000`
+  `--registry-url=localhost:30000 --registry-proxy-url=localhost:30000 --registry-proxy-username=Proxy --registry-proxy-password=Proxy12345`
 * The petclinic pipelines should still run
 
 ### Proper test
 
 * Start cluster:
 ```shell
-# Stop other cluster, if necessary
-# k3d cluster stop gitops-playground
 scripts/init-cluster.sh
 ```
 * Setup harbor as stated [above](#external-registry-for-development), but with Port `30000`.  
@@ -460,7 +458,7 @@ for operation in "${operations[@]}"; do
     echo creating user $operation with PW ${operation}12345
     curl -s  --fail 'http://localhost:30000/api/v2.0/users' -X POST -u admin:Harbor12345 -H 'Content-Type: application/json' --data-raw "{\"username\":\"$operation\",\"email\":\"$operation@example.com\",\"realname\":\"$operation example\",\"password\":\"${operation}12345\",\"comment\":null}"
     
-	echo "Adding member $operation to project $lower_operation; ID=${projectId}"
+    echo "Adding member $operation to project $lower_operation; ID=${projectId}"
 
     curl  --fail "http://localhost:30000/api/v2.0/projects/${projectId}/members" -X POST -u admin:Harbor12345    -H 'Content-Type: application/json' --data-raw "{\"role_id\":4,\"member_user\":{\"username\":\"$operation\"}}"
 done
@@ -473,8 +471,8 @@ skopeo copy docker://eclipse-temurin:11-jre-alpine --dest-creds Proxy:Proxy12345
 ```bash
 docker run --rm -t -u $(id -u)  \
    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config  \
-    --net=host  \     
-    gitops-playground:tag \
+    --net=host  \
+    gitops-playground:dev \
     --yes --argocd --ingress-nginx --base-url=http://localhost \
     --registry-url=localhost:30000 \
     --registry-path=registry \

--- a/exercises/petclinic-helm/Jenkinsfile.ftl
+++ b/exercises/petclinic-helm/Jenkinsfile.ftl
@@ -4,16 +4,14 @@ String getApplication() { "exercise-spring-petclinic-helm" }
 String getScmManagerCredentials() { 'scmm-user' }
 String getConfigRepositoryPRBaseUrl() { env.SCMM_URL }
 String getConfigRepositoryPRRepo() { '${namePrefix}argocd/example-apps' }
-<#if registry.twoRegistries>
-String getDockerRegistryPullBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PULL_URL }
-String getDockerRegistryPullCredentials() { 'registry-pull-user' }
-String getDockerRegistryPushBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PUSH_URL }
-String getDockerRegistryPushPath() { env.${namePrefixForEnvVars}REGISTRY_PUSH_PATH }
-String getDockerRegistryPushCredentials() { 'registry-push-user' }
-<#else>
+
 String getDockerRegistryBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_URL }
 String getDockerRegistryPath() { env.${namePrefixForEnvVars}REGISTRY_PATH }
 String getDockerRegistryCredentials() { 'registry-user' }
+
+<#if registry.twoRegistries>
+    String getDockerRegistryProxyCredentials() { 'registry-proxy-user' }
+    String getDockerRegistryProxyBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PROXY_URL }
 </#if>
 <#noparse>
 String getCesBuildLibRepo() { "${env.SCMM_URL}/repo/3rd-party-dependencies/ces-build-lib/" }
@@ -60,35 +58,25 @@ node {
         stage('Docker') {
             String imageTag = createImageTag()
 </#noparse>
+<#noparse>
+            String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
+            imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
+</#noparse>
 <#if registry.twoRegistries>
 <#noparse>
-            String pathPrefix = !dockerRegistryPushPath?.trim() ? "" : "${dockerRegistryPushPath}/"
-            imageName = "${dockerRegistryPushBaseUrl}/${pathPrefix}${application}:${imageTag}"
-            docker.withRegistry("http://${dockerRegistryPullBaseUrl}", dockerRegistryPullCredentials) {
+            docker.withRegistry("http://${dockerRegistryProxyBaseUrl}", dockerRegistryProxyCredentials) {
                 image = docker.build(imageName, '.')
             }
 </#noparse>
 <#else>
 <#noparse>
-            String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"
-            imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"
             image = docker.build(imageName, '.')
 </#noparse>
 </#if>
-
-
+<#noparse>
                 if (isBuildSuccessful()) {
-<#if registry.twoRegistries>
-<#noparse>
-                            docker.withRegistry("http://${dockerRegistryPushBaseUrl}", dockerRegistryPushCredentials) {
-</#noparse>
-<#else>
-<#noparse>
-                docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
-</#noparse>
-</#if>
-<#noparse>
-                    image.push()
+                    docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {
+                        image.push()
                 }
             } else {
                 echo 'Skipping docker push, because build not successful'

--- a/exercises/petclinic-helm/Jenkinsfile.ftl
+++ b/exercises/petclinic-helm/Jenkinsfile.ftl
@@ -10,8 +10,8 @@ String getDockerRegistryPath() { env.${namePrefixForEnvVars}REGISTRY_PATH }
 String getDockerRegistryCredentials() { 'registry-user' }
 
 <#if registry.twoRegistries>
-    String getDockerRegistryProxyCredentials() { 'registry-proxy-user' }
-    String getDockerRegistryProxyBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PROXY_URL }
+String getDockerRegistryProxyCredentials() { 'registry-proxy-user' }
+String getDockerRegistryProxyBaseUrl() { env.${namePrefixForEnvVars}REGISTRY_PROXY_URL }
 </#if>
 <#noparse>
 String getCesBuildLibRepo() { "${env.SCMM_URL}/repo/3rd-party-dependencies/ces-build-lib/" }

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -46,20 +46,14 @@ class GitopsPlaygroundCli  implements Runnable {
     private String registryUsername
     @Option(names = ['--registry-password'], description = REGISTRY_PASSWORD_DESCRIPTION)
     private String registryPassword
-    @Option(names = ['--registry-pull-url'], description = REGISTRY_PULL_URL_DESCRIPTION)
-    private String registryPullUrl
-    @Option(names = ['--registry-pull-username'], description = REGISTRY_PULL_USERNAME_DESCRIPTION)
-    private String registryPullUsername
-    @Option(names = ['--registry-pull-password'], description = REGISTRY_PULL_PASSWORD_DESCRIPTION)
-    private String registryPullPassword
-    @Option(names = ['--registry-push-url'], description = REGISTRY_PUSH_URL_DESCRIPTION)
-    private String registryPushUrl
-    @Option(names = ['--registry-push-path'], description = REGISTRY_PUSH_PATH_DESCRIPTION)
-    private String registryPushPath
-    @Option(names = ['--registry-push-username'], description = REGISTRY_PUSH_USERNAME_DESCRIPTION)
-    private String registryPushUsername
-    @Option(names = ['--registry-push-password'], description = REGISTRY_PUSH_PASSWORD_DESCRIPTION)
-    private String registryPushPassword
+    @Option(names = ['--registry-proxy-url'], description = 'The url of your external proxy-registry. Make sure to always use this with --registry-proxy-url')
+    private String registryProxyUrl
+    @Option(names = ['--registry-proxy-path'], description = 'Optional when --registry-proxy-url is set')
+    private String registryProxyPath
+    @Option(names = ['--registry-proxy-username'], description = 'Optional when --registry-proxy-url is set')
+    private String registryProxyUsername
+    @Option(names = ['--registry-proxy-password'], description = 'Optional when --registry-proxy-url is set')
+    private String registryProxyPassword
 
     // args group jenkins
     @Option(names = ['--jenkins-url'], description = JENKINS_URL_DESCRIPTION)
@@ -230,7 +224,7 @@ class GitopsPlaygroundCli  implements Runnable {
         
         def config = getConfig(context, false)
         register(context, new Configuration(config))
-        
+
         K8sClient k8sClient = context.getBean(K8sClient)
 
         if (config['application']['destroy']) {
@@ -359,13 +353,10 @@ class GitopsPlaygroundCli  implements Runnable {
                         path        : registryPath,
                         username    : registryUsername,
                         password    : registryPassword,
-                        pullUrl         : registryPullUrl,
-                        pullUsername    : registryPullUsername,
-                        pullPassword    : registryPullPassword,
-                        pushUrl         : registryPushUrl,
-                        pushPath        : registryPushPath,
-                        pushUsername    : registryPushUsername,
-                        pushPassword    : registryPushPassword,
+                        proxyUrl         : registryProxyUrl,
+                        proxyPath        : registryProxyPath,
+                        proxyUsername    : registryProxyUsername,
+                        proxyPassword    : registryProxyPassword,
                 ],
                 jenkins    : [
                         url     : jenkinsUrl,
@@ -461,8 +452,9 @@ class GitopsPlaygroundCli  implements Runnable {
                                 ]
                         ],
                         ingressNginx: [
-                               active: ingressNginx
+                               active: ingressNginx,
                         ],
+
                 ]
         ]
     }

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -39,15 +39,10 @@ class ApplicationConfigurator {
                     username    : '',
                     password    : '',
                     // Alternative: Use different registries, e.g. in air-gapped envs 
-                    // "Pull" registry for 3rd party images
-                    pullUrl         : '',
-                    pullUsername    : '',
-                    pullPassword    : '',
-                    // "Push" registry for writing application specific images
-                    pushUrl         : '',
-                    pushPath        : '',
-                    pushUsername    : '',
-                    pushPassword    : '',
+                    // "Proxy" registry for 3rd party images
+                    proxyUrl         : '',
+                    proxyUsername    : '',
+                    proxyPassword    : '',
                     helm  : [
                             chart  : 'docker-registry',
                             repoURL: 'https://helm.twun.io',
@@ -298,18 +293,11 @@ class ApplicationConfigurator {
     }
 
     private void addRegistryConfig(Map newConfig) {
-        if (newConfig.registry['pullUrl'] && newConfig.registry['pushUrl']) {
+        if (newConfig.registry['proxyUrl']) {
             newConfig.registry['twoRegistries'] = true
-        } else if (newConfig.registry['pullUrl'] && !newConfig.registry['pushUrl'] ||
-                newConfig.registry['pushUrl'] && !newConfig.registry['pullUrl']) {
-            throw new RuntimeException("Always set pull AND push URL. pullUrl=${newConfig.registry['pullUrl']}, pushUrl=${newConfig.registry['pushUrl']}")
         }
 
-        if (newConfig.registry['url'] && newConfig.registry['twoRegistries']) {
-            log.warn("Set both registry.url and registry.pullUrl/registry.pushUrl! Implicitly ignoring registry.url")
-        }
-
-        if (newConfig.registry['url'] || newConfig.registry['twoRegistries']) {
+        if (newConfig.registry['url']) {
             newConfig.registry['internal'] = false
         } else {
             /* Internal Docker registry must be on localhost. Otherwise docker will use HTTPS, leading to errors on 

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -295,6 +295,9 @@ class ApplicationConfigurator {
     private void addRegistryConfig(Map newConfig) {
         if (newConfig.registry['proxyUrl']) {
             newConfig.registry['twoRegistries'] = true
+            if (!newConfig.registry['proxyUsername'] || !newConfig.registry['proxyPassword'] ) {
+                throw new RuntimeException("Proxy URL needs to be used with proxy-username and proxy-password")
+            }
         }
 
         if (newConfig.registry['url']) {

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -9,10 +9,9 @@ interface ConfigConstants {
     String REGISTRY_USERNAME_DESCRIPTION = 'Optional when registry-url is set'
     String REGISTRY_PASSWORD_DESCRIPTION = 'Optional when registry-url is set'
 
-    String REGISTRY_PROXY_URL_DESCRIPTION = 'The url of your external proxy-registry. Make sure to always use this with registry-proxy-url'
-    String REGISTRY_PROXY_PATH_DESCRIPTION = 'Optional when registry-proxy-url is set'
-    String REGISTRY_PROXY_USERNAME_DESCRIPTION = 'Optional when registry-proxy-url is set'
-    String REGISTRY_PROXY_PASSWORD_DESCRIPTION = 'Optional when registry-proxy-url is set'
+    String REGISTRY_PROXY_URL_DESCRIPTION = 'The url of your proxy-registry. Used in pipelines to authorize pull base images. Use in conjunction with petclinic base image.'
+    String REGISTRY_PROXY_USERNAME_DESCRIPTION = 'Use with registry-proxy-url, added to Jenkins as credentials.'
+    String REGISTRY_PROXY_PASSWORD_DESCRIPTION = 'Use with registry-proxy-url, added to Jenkins as credentials.'
 
     String FEATURES_DESCRIPTION = 'Config parameters for features or tools'
     

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -8,13 +8,11 @@ interface ConfigConstants {
     String REGISTRY_PATH_DESCRIPTION = 'Optional when registry-url is set'
     String REGISTRY_USERNAME_DESCRIPTION = 'Optional when registry-url is set'
     String REGISTRY_PASSWORD_DESCRIPTION = 'Optional when registry-url is set'
-    String REGISTRY_PULL_URL_DESCRIPTION = 'The url of your external pull-registry. Make sure to always use this with registry-push-url'
-    String REGISTRY_PULL_USERNAME_DESCRIPTION = 'Optional when registry-pull-url is set'
-    String REGISTRY_PULL_PASSWORD_DESCRIPTION = 'Optional when registry-pull-url is set'
-    String REGISTRY_PUSH_URL_DESCRIPTION = 'The url of your external pull-registry. Make sure to always use this with registry-pull-url'
-    String REGISTRY_PUSH_PATH_DESCRIPTION = 'Optional when registry-push-url is set'
-    String REGISTRY_PUSH_USERNAME_DESCRIPTION = 'Optional when registry-push-url is set'
-    String REGISTRY_PUSH_PASSWORD_DESCRIPTION = 'Optional when registry-push-url is set'
+
+    String REGISTRY_PROXY_URL_DESCRIPTION = 'The url of your external proxy-registry. Make sure to always use this with registry-proxy-url'
+    String REGISTRY_PROXY_PATH_DESCRIPTION = 'Optional when registry-proxy-url is set'
+    String REGISTRY_PROXY_USERNAME_DESCRIPTION = 'Optional when registry-proxy-url is set'
+    String REGISTRY_PROXY_PASSWORD_DESCRIPTION = 'Optional when registry-proxy-url is set'
 
     String FEATURES_DESCRIPTION = 'Config parameters for features or tools'
     

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -57,22 +57,13 @@ class Schema {
         @JsonPropertyDescription(REGISTRY_PASSWORD_DESCRIPTION)
         String password = ""
         // Alternative: Use different registries, e.g. in air-gapped envs
-        // "Pull" registry for 3rd party images, e.g. base images
-        @JsonPropertyDescription(REGISTRY_PULL_URL_DESCRIPTION)
-        String pullUrl = ""
-        @JsonPropertyDescription(REGISTRY_PULL_USERNAME_DESCRIPTION)
-        String pullUsername = ""
-        @JsonPropertyDescription(REGISTRY_PULL_PASSWORD_DESCRIPTION)
-        String pullPassword = ""
-        // "Push" registry for writing application specific images
-        @JsonPropertyDescription(REGISTRY_PUSH_URL_DESCRIPTION)
-        String pushUrl = ""
-        @JsonPropertyDescription(REGISTRY_PUSH_PATH_DESCRIPTION)
-        String pushPath = ""
-        @JsonPropertyDescription(REGISTRY_PUSH_USERNAME_DESCRIPTION)
-        String pushUsername = ""
-        @JsonPropertyDescription(REGISTRY_PUSH_PASSWORD_DESCRIPTION)
-        String pushPassword = ""
+        // "Proxy" registry for 3rd party images, e.g. base images
+        @JsonPropertyDescription(REGISTRY_PROXY_URL_DESCRIPTION)
+        String proxyUrl = ""
+        @JsonPropertyDescription(REGISTRY_PROXY_USERNAME_DESCRIPTION)
+        String proxyUsername = ""
+        @JsonPropertyDescription(REGISTRY_PASSWORD_DESCRIPTION)
+        String proxyPassword = ""
 
         HelmConfig helm
     }
@@ -149,7 +140,7 @@ class Schema {
         // boolean outputConfigFile = false
         // These can't be set because they are evaluated first thing on app start, before config file is read
         // boolean debug = false
-        // boolean trace = false 
+        // boolean trace = false
         @JsonPropertyDescription(DESTROY_DESCRIPTION)
         boolean destroy = false
         @JsonPropertyDescription(POD_RESOURCES_DESCRIPTION)

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -62,7 +62,7 @@ class Schema {
         String proxyUrl = ""
         @JsonPropertyDescription(REGISTRY_PROXY_USERNAME_DESCRIPTION)
         String proxyUsername = ""
-        @JsonPropertyDescription(REGISTRY_PASSWORD_DESCRIPTION)
+        @JsonPropertyDescription(REGISTRY_PROXY_PASSWORD_DESCRIPTION)
         String proxyPassword = ""
 
         HelmConfig helm

--- a/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
@@ -25,9 +25,8 @@ class JenkinsDestructionHandler implements DestructionHandler {
         globalPropertyManager.deleteGlobalProperty("SCMM_URL")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_URL")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PATH")
-        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PULL_URL")
-        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PUSH_URL")
-        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PUSH_PATH")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PROXY_URL")
+        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PROXY_PATH")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}K8S_VERSION")
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/destroy/JenkinsDestructionHandler.groovy
@@ -26,7 +26,6 @@ class JenkinsDestructionHandler implements DestructionHandler {
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_URL")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PATH")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PROXY_URL")
-        globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}REGISTRY_PROXY_PATH")
         globalPropertyManager.deleteGlobalProperty("${configuration.getNamePrefixForEnvVars()}K8S_VERSION")
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -105,7 +105,7 @@ class Jenkins extends Feature {
                     "registry-user",
                     "${config.registry['username']}",
                     "${config.registry['password']}",
-                    'credentials for accessing the docker-registry')
+                    'credentials for accessing the docker-registry for writing images built on jenkins')
 
             if (config.registry['twoRegistries']) {
                 jobManger.createCredential(

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -69,13 +69,12 @@ class Jenkins extends Feature {
         ])
 
         globalPropertyManager.setGlobalProperty('SCMM_URL', config.scmm['url'] as String)
+
+        globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_URL", config.registry['url'] as String)
+        globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PATH", config.registry['path'] as String)
+
         if (config.registry['twoRegistries']) {
-            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PULL_URL", config.registry['pullUrl'] as String)
-            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PUSH_URL", config.registry['pushUrl'] as String)
-            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PUSH_PATH", config.registry['pushPath'] as String)
-        } else {
-            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_URL", config.registry['url'] as String)
-            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PATH", config.registry['path'] as String)
+            globalPropertyManager.setGlobalProperty("${config.application['namePrefixForEnvVars']}REGISTRY_PROXY_URL", config.registry['proxyUrl'] as String)
         }
 
         if (config.jenkins['mavenCentralMirror']) {
@@ -101,26 +100,21 @@ class Jenkins extends Feature {
                     "${config.scmm['password']}",
                     'credentials for accessing scm-manager')
 
+            jobManger.createCredential(
+                    "${config.application['namePrefix']}example-apps",
+                    "registry-user",
+                    "${config.registry['username']}",
+                    "${config.registry['password']}",
+                    'credentials for accessing the docker-registry')
+
             if (config.registry['twoRegistries']) {
                 jobManger.createCredential(
                         "${config.application['namePrefix']}example-apps",
-                        "registry-pull-user",
-                        "${config.registry['pullUsername']}",
-                        "${config.registry['pullPassword']}",
+                        "registry-proxy-user",
+                        "${config.registry['proxyUsername']}",
+                        "${config.registry['proxyPassword']}",
                         'credentials for accessing the docker-registry that contains 3rd party or base images')
-                jobManger.createCredential(
-                        "${config.application['namePrefix']}example-apps",
-                        "registry-push-user",
-                        "${config.registry['pushUsername']}",
-                        "${config.registry['pushPassword']}",
-                        'credentials for accessing the docker-registry that contains images built on jenkins')
-            } else {
-                jobManger.createCredential(
-                        "${config.application['namePrefix']}example-apps",
-                        "registry-user",
-                        "${config.registry['username']}",
-                        "${config.registry['password']}",
-                        'credentials for accessing the docker-registry')
+
             }
             // Once everything is set up, start the jobs.
             jobManger.startJob('example-apps')

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
@@ -38,8 +38,7 @@ class ApplicationConfiguratorTest {
             ],
             registry   : [
                     url         : EXPECTED_REGISTRY_URL,
-                    pullUrl: "pull-$EXPECTED_REGISTRY_URL",
-                    pushUrl: "push-$EXPECTED_REGISTRY_URL",
+                    proxyUrl: "proxy-$EXPECTED_REGISTRY_URL",
                     internalPort: EXPECTED_REGISTRY_INTERNAL_PORT,
                     path        : null
             ],
@@ -389,8 +388,7 @@ images:
     @Test
     void "Registry: Sets to internal when no URL set"() {
         testConfig.registry['url'] = null
-        testConfig.registry['pullUrl'] = null
-        testConfig.registry['pushUrl'] = null
+        testConfig.registry['proxyUrl'] = null
         
         Map actualConfig = applicationConfigurator.setConfig(testConfig)
         
@@ -400,44 +398,21 @@ images:
     }
     
     @Test
-    void "Registry: Sets to external when single URL set"() {
-        testConfig.registry['pullUrl'] = null
-        testConfig.registry['pushUrl'] = null
-        
+    void "Registry: Sets to external when only registry URL set"() {
+        testConfig.registry['proxyUrl'] = null
+
         Map actualConfig = applicationConfigurator.setConfig(testConfig)
         
         assertThat(actualConfig['registry']['internal']).isEqualTo(false)
     }
     
     @Test
-    void "Registry: Sets to external when pull and push URL set"() {
+    void "Registry: Sets to internal when only proxy Url is set"() {
         testConfig.registry['url'] = null
-        
+
         Map actualConfig = applicationConfigurator.setConfig(testConfig)
         
-        assertThat(actualConfig['registry']['internal']).isEqualTo(false)
-    }
-    
-    @Test
-    void "Registry: Fails when pushUrl is set but not pullUrl"() {
-        testConfig.registry['pullUrl'] = null
-
-        def exception = shouldFail(RuntimeException) {
-            applicationConfigurator.setConfig(testConfig)
-        }
-        assertThat(exception.message)
-                .isEqualTo("Always set pull AND push URL. pullUrl=, pushUrl=push-${EXPECTED_REGISTRY_URL}".toString())
-    }
-    
-    @Test
-    void "Registry: Fails when pullUrl is set but not pushUrl"() {
-        testConfig.registry['pushUrl'] = null
-
-        def exception = shouldFail(RuntimeException) {
-            applicationConfigurator.setConfig(testConfig)
-        }
-        assertThat(exception.message)
-                .isEqualTo("Always set pull AND push URL. pullUrl=pull-${EXPECTED_REGISTRY_URL}, pushUrl=".toString())
+        assertThat(actualConfig['registry']['internal']).isEqualTo(true)
     }
     
     List<String> getAllFieldNames(Class clazz, String parentField = '', List<String> fieldNames = []) {

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
@@ -39,6 +39,8 @@ class ApplicationConfiguratorTest {
             registry   : [
                     url         : EXPECTED_REGISTRY_URL,
                     proxyUrl: "proxy-$EXPECTED_REGISTRY_URL",
+                    proxyUsername: "proxy-user",
+                    proxyPassword: "proxy-pw",
                     internalPort: EXPECTED_REGISTRY_INTERNAL_PORT,
                     path        : null
             ],
@@ -413,6 +415,30 @@ images:
         Map actualConfig = applicationConfigurator.setConfig(testConfig)
         
         assertThat(actualConfig['registry']['internal']).isEqualTo(true)
+    }
+    
+    @Test
+    void "Registry: Fails when proxy but no username and password set"() {
+        def expectedException = 'Proxy URL needs to be used with proxy-username and proxy-password'
+        
+        testConfig.registry['proxyUsername'] = null
+        def exception = shouldFail(RuntimeException) {
+            applicationConfigurator.setConfig(testConfig)
+        }
+        assertThat(exception.message).isEqualTo(expectedException)
+        
+        testConfig.registry['proxyUsername'] = 'something'
+        testConfig.registry['proxyPassword'] = null
+        exception = shouldFail(RuntimeException) {
+            applicationConfigurator.setConfig(testConfig)
+        }
+        assertThat(exception.message).isEqualTo(expectedException)
+        
+        testConfig.registry['proxyUsername'] = null
+        exception = shouldFail(RuntimeException) {
+            applicationConfigurator.setConfig(testConfig)
+        }
+        assertThat(exception.message).isEqualTo(expectedException)
     }
     
     List<String> getAllFieldNames(Class clazz, String parentField = '', List<String> fieldNames = []) {

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -17,13 +17,9 @@ class ConfigToConfigFileConverterTest {
                         path        : 'path',
                         username    : 'username',
                         password    : 'password',
-                        pullUrl         : 'pullUrl',
-                        pullUsername    : 'pullUsername',
-                        pullPassword    : 'pullPassword',
-                        pushUrl         : 'pushUrl',
-                        pushPath        : 'pushPath',
-                        pushUsername    : 'pushUsername',
-                        pushPassword    : 'pushPassword',
+                        proxyUrl         : 'proxyUrl',
+                        proxyUsername    : 'proxyUsername',
+                        proxyPassword    : 'proxyPassword',
                         helm  : [
                                 chart  : 'docker-registry',
                                 repoURL: 'https://charts.helm.sh/stable',
@@ -182,13 +178,9 @@ registry:
   path: "path"
   username: "username"
   password: "password"
-  pullUrl: "pullUrl"
-  pullUsername: "pullUsername"
-  pullPassword: "pullPassword"
-  pushUrl: "pushUrl"
-  pushPath: "pushPath"
-  pushUsername: "pushUsername"
-  pushPassword: "pushPassword"
+  proxyUrl: "proxyUrl"
+  proxyUsername: "proxyUsername"
+  proxyPassword: "proxyPassword"
   helm:
     chart: "docker-registry"
     repoURL: "https://charts.helm.sh/stable"

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -47,13 +47,9 @@ class JenkinsTest {
                     username: 'reg-usr',
                     password: 'reg-pw',
                     twoRegistries: false,
-                    pullUrl: 'reg-pull-url',
-                    pullUsername    : 'reg-pull-usr',
-                    pullPassword    : 'reg-pull-pw',
-                    pushUrl: 'reg-push-url',
-                    pushPath: 'reg-push-path',
-                    pushUsername    : 'reg-push-usr',
-                    pushPassword    : 'reg-push-pw',
+                    proxyUrl: 'reg-proxy-url',
+                    proxyUsername    : 'reg-proxy-usr',
+                    proxyPassword    : 'reg-proxy-pw',
             ],
             scmm       : [
                     url     : 'http://scmm',
@@ -104,12 +100,10 @@ class JenkinsTest {
 
         verify(globalPropertyManager).setGlobalProperty('SCMM_URL', 'http://scmm')
         verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_K8S_VERSION', ApplicationConfigurator.K8S_VERSION)
-        
+
         verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_URL', 'reg-url')
         verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PATH', 'reg-path')
-        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PULL_URL'), anyString())
-        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PUSH_URL'), anyString())
-        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PUSH_PATH'), anyString())
+        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PROXY_URL'), anyString())
         verify(globalPropertyManager, never()).setGlobalProperty(eq('MAVEN_CENTRAL_MIRROR'), anyString())
 
         verify(userManager).createUser('metrics-usr', 'metrics-pw')
@@ -121,12 +115,12 @@ class JenkinsTest {
                 'my-prefix-gitops', 'scmm-pw', 'credentials for accessing scm-manager')
 
         verify(jobManger).startJob('example-apps')
-        
+
         verify(jobManger).createCredential('my-prefix-example-apps', 'registry-user', 
                 'reg-usr', 'reg-pw', 'credentials for accessing the docker-registry')
-        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-pull-user'),
+        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-proxy-user'),
                 anyString(), anyString(), anyString())
-        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-push-user'),
+        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-proxy-user'),
                 anyString(), anyString(), anyString())
     }
 
@@ -136,21 +130,17 @@ class JenkinsTest {
         
         createJenkins().install()
         
-        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PULL_URL', 'reg-pull-url')
-        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PUSH_URL', 'reg-push-url')
-        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PUSH_PATH', 'reg-push-path')
+        verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_REGISTRY_PROXY_URL', 'reg-proxy-url')
 
-        verify(jobManger).createCredential('my-prefix-example-apps', 'registry-pull-user',
-                'reg-pull-usr', 'reg-pull-pw', 
+        verify(globalPropertyManager).setGlobalProperty(eq('MY_PREFIX_REGISTRY_URL'), anyString())
+        verify(globalPropertyManager).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PATH'), anyString())
+
+        verify(jobManger).createCredential('my-prefix-example-apps', 'registry-user',
+                'reg-usr', 'reg-pw',
+                'credentials for accessing the docker-registry')
+        verify(jobManger).createCredential('my-prefix-example-apps', 'registry-proxy-user',
+                'reg-proxy-usr', 'reg-proxy-pw',
                 'credentials for accessing the docker-registry that contains 3rd party or base images')
-        verify(jobManger).createCredential('my-prefix-example-apps', 'registry-push-user',
-                'reg-push-usr', 'reg-push-pw', 
-                'credentials for accessing the docker-registry that contains images built on jenkins')
-
-        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_URL'), anyString())
-        verify(globalPropertyManager, never()).setGlobalProperty(eq('MY_PREFIX_REGISTRY_PATH'), anyString())
-        verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-user'), 
-                anyString(), anyString(), anyString())
     }
     
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -117,7 +117,7 @@ class JenkinsTest {
         verify(jobManger).startJob('example-apps')
 
         verify(jobManger).createCredential('my-prefix-example-apps', 'registry-user', 
-                'reg-usr', 'reg-pw', 'credentials for accessing the docker-registry')
+                'reg-usr', 'reg-pw', 'credentials for accessing the docker-registry for writing images built on jenkins')
         verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-proxy-user'),
                 anyString(), anyString(), anyString())
         verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-proxy-user'),
@@ -137,7 +137,7 @@ class JenkinsTest {
 
         verify(jobManger).createCredential('my-prefix-example-apps', 'registry-user',
                 'reg-usr', 'reg-pw',
-                'credentials for accessing the docker-registry')
+                'credentials for accessing the docker-registry for writing images built on jenkins')
         verify(jobManger).createCredential('my-prefix-example-apps', 'registry-proxy-user',
                 'reg-proxy-usr', 'reg-proxy-pw',
                 'credentials for accessing the docker-registry that contains 3rd party or base images')

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -819,13 +819,13 @@ class ArgoCDTest {
     }
 
     private void assertJenkinsEnvironmentVariablesPrefixes(String prefix) {
-        List singleRegistryEnvVars = ["env.${prefix}REGISTRY_URL", "env.${prefix}REGISTRY_PATH"]
+        List defaultRegistryEnvVars = ["env.${prefix}REGISTRY_URL", "env.${prefix}REGISTRY_PATH"]
         List twoRegistriesEnvVars = ["env.${prefix}REGISTRY_PROXY_URL"]
 
         assertThat(new File(nginxHelmJenkinsRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains("env.${prefix}K8S_VERSION")
 
         for (def petclinicRepo : petClinicRepos) {
-            singleRegistryEnvVars.each { expectedEnvVar ->
+            defaultRegistryEnvVars.each { expectedEnvVar ->
                 assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(expectedEnvVar)
             }
 

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -43,7 +43,7 @@ class ArgoCDTest {
                     gitEmail            : 'hello@cloudogu.com',
                     urlSeparatorHyphen  : false,
                     mirrorRepos         : false,
-                    skipCrds: false
+                    skipCrds            : false
             ],
             jenkins     : [
                     mavenCentralMirror: '',
@@ -55,8 +55,8 @@ class ArgoCDTest {
                     username: '',
                     password: ''
             ],
-            images      : buildImages + [ petclinic  : 'petclinic-value' ],
-            registry: [
+            images      : buildImages + [petclinic: 'petclinic-value'],
+            registry    : [
                     twoRegistries: false,
             ],
             repositories: [
@@ -76,37 +76,37 @@ class ArgoCDTest {
                     ]
             ],
             features    : [
-                    argocd     : [
+                    argocd      : [
                             active      : true,
                             configOnly  : true,
                             emailFrom   : 'argocd@example.org',
                             emailToUser : 'app-team@example.org',
                             emailToAdmin: 'infra@example.org'
                     ],
-                    mail       : [
+                    mail        : [
                             mailhog     : true,
                             smtpAddress : '',
                             smtpPort    : '',
                             smtpUser    : '',
                             smtpPassword: ''
                     ],
-                    monitoring : [
+                    monitoring  : [
                             active: true,
                             helm  : [
-                                    chart: 'kube-prometheus-stack',
+                                    chart  : 'kube-prometheus-stack',
                                     version: '42.0.3'
-                                    ]
+                            ]
                     ],
-                    ingressNginx : [
-                            active     : true
+                    ingressNginx: [
+                            active: true
                     ],
-                    secrets    : [
+                    secrets     : [
                             active: true,
                             vault : [
                                     url: ''
                             ]
                     ],
-                    exampleApps: [
+                    exampleApps : [
                             petclinic: [
                                     baseDomain: ''
                             ],
@@ -230,18 +230,18 @@ class ArgoCDTest {
     @Test
     void 'When monitoring disabled: Does not push path monitoring to cluster resources'() {
         config.features['monitoring']['active'] = false
-        
+
         createArgoCD().install()
-        
-        assertThat(new File(clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + ArgoCD.MONITORING_RESOURCES_PATH )).doesNotExist()
+
+        assertThat(new File(clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + ArgoCD.MONITORING_RESOURCES_PATH)).doesNotExist()
     }
 
     @Test
     void 'When monitoring enabled: Does push path monitoring to cluster resources'() {
         config.features['monitoring']['active'] = true
-        
+
         createArgoCD().install()
-        
+
         assertThat(new File(clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + ArgoCD.MONITORING_RESOURCES_PATH)).exists()
 
         assertValidDashboards()
@@ -264,13 +264,13 @@ class ArgoCDTest {
             }.as("Invalid JSON in ${path.fileName}").doesNotThrowAnyException()
         }
     }
-    
+
     @Test
     void 'When ingressNginx disabled: Does not push monitoring dashboard resources'() {
         config.features['monitoring']['active'] = true
         config.features['ingressNginx']['active'] = false
         createArgoCD().install()
-        assertThat(new File(clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + ArgoCD.MONITORING_RESOURCES_PATH )).exists()
+        assertThat(new File(clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + ArgoCD.MONITORING_RESOURCES_PATH)).exists()
         assertThat(new File(clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + "/misc/ingress-nginx-dashboard.yaml")).doesNotExist()
         assertThat(new File(clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + "/misc/ingress-nginx-dashboard-requests-handling.yaml")).doesNotExist()
     }
@@ -389,7 +389,7 @@ class ArgoCDTest {
                 parseActualYaml(actualHelmValuesFile)['argo-cd']['notifications']['notifiers']['service.email'] as String)
 
         k8sCommands.assertNotExecuted('kubectl create secret generic argocd-notifications-secret')
-        
+
         assertThat(serviceEmail['host']).isEqualTo("smtp.example.com")
         assertThat(serviceEmail as Map).doesNotContainKey('port')
         assertThat(serviceEmail as Map).doesNotContainKey('username')
@@ -457,19 +457,19 @@ class ArgoCDTest {
         assertThat(parseActualYaml(new File(nginxHelmJenkinsRepo.getAbsoluteLocalRepoTmpDir()), 'k8s/values-production.yaml')).doesNotContainKey('ingress')
         assertThat(parseActualYaml(new File(nginxHelmJenkinsRepo.getAbsoluteLocalRepoTmpDir()), 'k8s/values-staging.yaml')).doesNotContainKey('ingress')
         assertThat(valuesYaml).doesNotContainKey('resources')
-        
+
         valuesYaml = parseActualYaml(new File(exampleAppsRepo.getAbsoluteLocalRepoTmpDir()), 'apps/nginx-helm-umbrella/values.yaml')
         assertThat(valuesYaml['nginx']['service']['type']).isEqualTo('NodePort')
         assertThat(valuesYaml['nginx'] as Map).doesNotContainKey('ingress')
         assertThat(valuesYaml['nginx'] as Map).doesNotContainKey('resources')
-        
+
         assertThat((parseActualYaml(brokenApplicationRepo.absoluteLocalRepoTmpDir + '/broken-application.yaml')[1]['spec']['type']))
                 .isEqualTo('NodePort')
         assertThat((parseActualYaml(brokenApplicationRepo.absoluteLocalRepoTmpDir + '/broken-application.yaml')[0]['spec']['template']['spec']['containers'] as List)[0]['resources'])
                 .isNull()
 
         assertThat(new File(nginxValidationRepo.absoluteLocalRepoTmpDir, '/k8s/values-shared.yaml').text).doesNotContain('resources:')
-        
+
         // Assert Petclinic repo cloned
         verify(gitCloneMock).setURI('https://github.com/cloudogu/spring-petclinic.git')
         verify(setUriMock).setDirectory(remotePetClinicRepoTmpDir)
@@ -566,7 +566,7 @@ class ArgoCDTest {
 
         assertThat((parseActualYaml(brokenApplicationRepo.absoluteLocalRepoTmpDir + '/broken-application.yaml')[2]['spec']['rules'] as List)[0]['host'])
                 .isEqualTo('broken-application-nginx-local')
-        
+
         assertPetClinicRepos('LoadBalancer', 'NodePort', 'petclinic-local')
     }
 
@@ -618,7 +618,7 @@ class ArgoCDTest {
         assertArgoCdYamlPrefixes(ArgoCD.SCMM_URL_INTERNAL, '')
         assertJenkinsEnvironmentVariablesPrefixes('')
     }
-    
+
     @Test
     void 'Creates Jenkinsfiles for two registries'() {
         config.registry['twoRegistries'] = true
@@ -686,9 +686,9 @@ class ArgoCDTest {
         createArgoCD().install()
 
         for (def petclinicRepo : petClinicRepos) {
-                assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(
-                        'mvn.useMirrors([name: \'maven-central-mirror\', mirrorOf: \'central\', url:  env.MAVEN_CENTRAL_MIRROR])'
-                )
+            assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(
+                    'mvn.useMirrors([name: \'maven-central-mirror\', mirrorOf: \'central\', url:  env.MAVEN_CENTRAL_MIRROR])'
+            )
         }
     }
 
@@ -708,7 +708,7 @@ class ArgoCDTest {
 
         assertThat((parseActualYaml(brokenApplicationRepo.absoluteLocalRepoTmpDir + '/broken-application.yaml')[0]['spec']['template']['spec']['containers'] as List)[0]['resources'] as Map)
                 .containsKeys('limits', 'requests')
-        
+
         assertPetClinicRepos('NodePort', 'LoadBalancer', '')
     }
 
@@ -819,24 +819,21 @@ class ArgoCDTest {
     }
 
     private void assertJenkinsEnvironmentVariablesPrefixes(String prefix) {
-        List singleRegistryEnvVars = ["env.${prefix}REGISTRY_URL", "env.${prefix}REGISTRY_URL"]
-        List twoRegistriesEnvVars = ["env.${prefix}REGISTRY_PULL_URL", 
-                                     "env.${prefix}REGISTRY_PUSH_URL", "env.${prefix}REGISTRY_PUSH_PATH" ]
-        
+        List singleRegistryEnvVars = ["env.${prefix}REGISTRY_URL", "env.${prefix}REGISTRY_PATH"]
+        List twoRegistriesEnvVars = ["env.${prefix}REGISTRY_PROXY_URL"]
+
         assertThat(new File(nginxHelmJenkinsRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains("env.${prefix}K8S_VERSION")
-        
+
         for (def petclinicRepo : petClinicRepos) {
+            singleRegistryEnvVars.each { expectedEnvVar ->
+                assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(expectedEnvVar)
+            }
+
             if (config.registry['twoRegistries']) {
                 twoRegistriesEnvVars.each { expectedEnvVar ->
                     assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(expectedEnvVar)
                 }
-                singleRegistryEnvVars.each { expectedEnvVar ->
-                    assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).doesNotContain(expectedEnvVar)
-                }
             } else {
-                singleRegistryEnvVars.each { expectedEnvVar ->
-                    assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).contains(expectedEnvVar)
-                }
                 twoRegistriesEnvVars.each { expectedEnvVar ->
                     assertThat(new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text).doesNotContain(expectedEnvVar)
                 }
@@ -898,8 +895,8 @@ class ArgoCDTest {
 
     void assertPetClinicRepos(String expectedServiceType, String unexpectedServiceType, String ingressUrl) {
         boolean separatorHyphen = config.application['urlSeparatorHyphen']
-        boolean podResources = config.application['podResources'] 
-                
+        boolean podResources = config.application['podResources']
+
         for (ScmmRepo repo : petClinicRepos) {
 
             def tmpDir = repo.absoluteLocalRepoTmpDir
@@ -909,15 +906,15 @@ class ArgoCDTest {
 
             if (repo.scmmRepoTarget == 'argocd/petclinic-plain') {
                 assertBuildImagesInJenkinsfileReplaced(jenkinsfile)
-                
+
                 assertThat(new File(tmpDir, 'Dockerfile').text).startsWith('FROM petclinic-value')
-                
+
                 assertThat(new File(tmpDir, 'k8s/production/service.yaml').text).contains("type: ${expectedServiceType}")
                 assertThat(new File(tmpDir, 'k8s/staging/service.yaml').text).contains("type: ${expectedServiceType}")
 
                 assertThat(new File(tmpDir, 'k8s/production/service.yaml').text).doesNotContain("type: ${unexpectedServiceType}")
                 assertThat(new File(tmpDir, 'k8s/staging/service.yaml').text).doesNotContain("type: ${unexpectedServiceType}")
-                
+
                 if (podResources) {
                     assertThat((parseActualYaml(tmpDir + '/k8s/production/deployment.yaml')['spec']['template']['spec']['containers'] as List)[0]['resources'] as Map)
                             .containsKeys('limits', 'requests')
@@ -928,7 +925,7 @@ class ArgoCDTest {
                             .doesNotContainKey('resources')
                     assertThat((parseActualYaml(tmpDir + '/k8s/staging/deployment.yaml')['spec']['template']['spec']['containers'] as List)[0] as Map)
                             .doesNotContainKey('resources')
-                } 
+                }
 
                 if (!ingressUrl) {
                     assertThat(new File(tmpDir, 'k8s/staging/ingress.yaml')).doesNotExist()
@@ -984,7 +981,7 @@ class ArgoCDTest {
                 } else {
                     assertThat(parseActualYaml(tmpDir + '/k8s/values-shared.yaml')['resources']).isNull()
                 }
-                
+
                 if (!ingressUrl) {
                     assertThat(parseActualYaml(tmpDir + '/k8s/values-shared.yaml')['ingress']['enabled']).isEqualTo(false)
                     assertThat(parseActualYaml(tmpDir + '/k8s/values-production.yaml')).doesNotContainKey('ingress')
@@ -1009,30 +1006,25 @@ class ArgoCDTest {
     }
 
     void assertJenkinsfileRegistryCredentials() {
-        List singleRegistryExpectedLines = [
-                'docker.withRegistry("http://${dockerRegistryBaseUrl}", dockerRegistryCredentials) {',
+        List defaultRegistryExpectedLines = [
                 'String pathPrefix = !dockerRegistryPath?.trim() ? "" : "${dockerRegistryPath}/"',
                 'imageName = "${dockerRegistryBaseUrl}/${pathPrefix}${application}:${imageTag}"'
         ]
-        List twoRegistriesExpectedLines = [ 
-                'String pathPrefix = !dockerRegistryPushPath?.trim() ? "" : "${dockerRegistryPushPath}/"',
-                'imageName = "${dockerRegistryPushBaseUrl}/${pathPrefix}${application}:${imageTag}"',
-                'docker.withRegistry("http://${dockerRegistryPullBaseUrl}", dockerRegistryPullCredentials) {',
-                'docker.withRegistry("http://${dockerRegistryPushBaseUrl}", dockerRegistryPushCredentials) {' ]
-        
+        List twoRegistriesExpectedLines = [
+                'docker.withRegistry("http://${dockerRegistryProxyBaseUrl}", dockerRegistryProxyCredentials) {']
+
         for (def petclinicRepo : petClinicRepos) {
             String jenkinsfile = new File(petclinicRepo.absoluteLocalRepoTmpDir, 'Jenkinsfile').text
+
+            defaultRegistryExpectedLines.each { expectedEnvVar ->
+                assertThat(jenkinsfile).contains(expectedEnvVar)
+            }
+
             if (config.registry['twoRegistries']) {
                 twoRegistriesExpectedLines.each { expectedEnvVar ->
                     assertThat(jenkinsfile).contains(expectedEnvVar)
                 }
-                singleRegistryExpectedLines.each { expectedEnvVar ->
-                    assertThat(jenkinsfile).doesNotContain(expectedEnvVar)
-                }
             } else {
-                singleRegistryExpectedLines.each { expectedEnvVar ->
-                    assertThat(jenkinsfile).contains(expectedEnvVar)
-                }
                 twoRegistriesExpectedLines.each { expectedEnvVar ->
                     assertThat(jenkinsfile).doesNotContain(expectedEnvVar)
                 }


### PR DESCRIPTION
to decrease the number of parameters to improve user experience.

Migration:

* `registry-push-*` -> `registry-*`
* `registry-pull-*` -> `registry-proxy*`, `proxy-path` not in use right now.