### PR TITLE
Implement namespaceIsolation for PrometheusStack

### DIFF
--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -1,3 +1,4 @@
+<#assign DockerImageParser=statics['com.cloudogu.gitops.utils.DockerImageParser']>
 <#if skipCrds == true>
 crds:
   enabled: false
@@ -68,6 +69,21 @@ prometheusOperator:
       cpu: 20m
       memory: 40Mi
 </#if>
+<#if config.features.monitoring.helm.prometheusOperatorImage?has_content>
+  <#assign operatorImageObject = DockerImageParser.parse(config.features.monitoring.helm.prometheusOperatorImage)>
+  image:
+    registry  : ${operatorImageObject.registry}
+    repository: ${operatorImageObject.repository}
+    tag       : ${operatorImageObject.tag}
+</#if>
+<#if config.features.monitoring.helm.prometheusConfigReloaderImage?has_content>
+<#assign reloaderImageObject = DockerImageParser.parse(config.features.monitoring.helm.prometheusConfigReloaderImage)>
+  prometheusConfigReloader:
+    image:
+        registry  : ${reloaderImageObject.registry}
+        repository: ${reloaderImageObject.repository}
+        tag       : ${reloaderImageObject.tag}
+</#if>
 kubelet:
   enabled: false
 kubeControllerManager:
@@ -86,15 +102,21 @@ alertmanager:
   enabled: false
 grafana:
   defaultDashboardsEnabled: false
-  adminUser: admin
-  adminPassword: admin
+  adminUser: ${config.application["username"]}
+  adminPassword: ${config.application["password"]}
   service:
-    type: NodePort
+    type: <#if remote>LoadBalancer<#else>NodePort</#if>
     nodePort: "9095"
 <#if monitoring.grafana.host?has_content>
   ingress:
     enabled: true
     hosts: [${monitoring.grafana.host}]
+</#if>
+<#if config.features.monitoring.helm.grafanaImage?has_content>
+<#assign grafanImageObject = DockerImageParser.parse(config.features.monitoring.helm.grafanaImage)>
+  image:
+    repository: ${grafanImageObject.registryAndRepositoryAsString}
+    tag       : ${grafanImageObject.tag}
 </#if>
   sidecar:
     dashboards:
@@ -109,6 +131,12 @@ grafana:
       requests:
         cpu: 35m
         memory: 65Mi
+</#if>
+<#if config.features.monitoring.helm.grafanaSidecarImage?has_content>
+<#assign sidecarImageObject = DockerImageParser.parse(config.features.monitoring.helm.grafanaSidecarImage)>
+    image:
+      repository: ${sidecarImageObject.registryAndRepositoryAsString}
+      tag       : ${sidecarImageObject.tag}
 </#if>
 <#if mail.active??>
   notifiers:
@@ -197,6 +225,13 @@ prometheus:
       requests:
         cpu: 50m
         memory: 450Mi
+</#if>
+<#if config.features.monitoring.helm.prometheusImage?has_content>
+<#assign prometheusImageObject = DockerImageParser.parse(config.features.monitoring.helm.prometheusImage)>
+    image:
+      registry  : ${prometheusImageObject.registry}
+      repository: ${prometheusImageObject.repository}
+      tag       : ${prometheusImageObject.tag}
 </#if>
     secrets:
       - prometheus-metrics-creds-scmm

--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -7,16 +7,23 @@ crds:
 <#if namespaceIsolation == true>
 global:
   rbac:
+    # Avoids creation of ClusterRole, which do not need here
     create: false
+kubeApiServer:
+  # Don't scrape ApiServer to avoid 403 in prometheus targets due to lacking RBAC in isolated mode
+  enabled: false
 </#if>
 
 # Note that many things are disabled here, because we want to start small, especially in airgapped envs where each image
 # has to be replicated individually
 defaultRules:
   rules:
-    alertmanager: true
-    etcd: false
     general: true
+    prometheus: true
+    prometheusOperator: true
+    kubePrometheusGeneral: true
+    alertmanager: false
+    etcd: false
     k8sContainerCpuUsageSecondsTotal: false
     k8sContainerMemoryCache: false
     k8sContainerMemoryRss: false
@@ -30,7 +37,6 @@ defaultRules:
     kubeApiserverHistogram: false
     kubeApiserverSlos: false
     kubelet: false
-    kubePrometheusGeneral: true
     kubePrometheusNodeRecording: false
     kubernetesAbsent: false
     kubernetesApps: false
@@ -44,8 +50,6 @@ defaultRules:
     node: false
     nodeExporterAlerting: false
     nodeExporterRecording: false
-    prometheus: true
-    prometheusOperator: true
     windows: false
 kubeStateMetrics:
   enabled: false
@@ -54,12 +58,28 @@ nodeExporter:
 prometheusOperator:
   enabled: true
   admissionWebhooks:
+    # Avoids warning in operator log: remote error: tls: bad certificate
     enabled: false
   tls:
-    # Once admissionWebhooks is disabled, the operator fails with
-    # MountVolume.SetUp failed for volume "tls-secret" : secret "...-kube-prometh-admission" not found
-    # This can be worked around by disabling tls altogether
+    # Avoids warning in operator log: server TLS client verification disabled
     enabled: false
+<#if config.application.openshift == true>
+  securityContext: 
+    fsGroup: null
+    runAsGroup: null
+    runAsUser: null
+</#if>
+<#if namespaceIsolation == true>
+  kubeletService:
+    enabled: false
+  namespaces:
+    releaseNamespace: false
+    additional:
+    <#-- Note that the quotes in the final YAML here are created by groovy, not Freemarker-->
+    <#list namespaces as namespace>
+      - ${namespace}
+    </#list>
+</#if>
 <#if podResources == true>
   resources:
     limits:
@@ -76,13 +96,24 @@ prometheusOperator:
     repository: ${operatorImageObject.repository}
     tag       : ${operatorImageObject.tag}
 </#if>
-<#if config.features.monitoring.helm.prometheusConfigReloaderImage?has_content>
-<#assign reloaderImageObject = DockerImageParser.parse(config.features.monitoring.helm.prometheusConfigReloaderImage)>
+<#if config.features.monitoring.helm.prometheusConfigReloaderImage?has_content || podResources == true>
   prometheusConfigReloader:
+  <#if config.features.monitoring.helm.prometheusConfigReloaderImage?has_content>
+  <#assign reloaderImageObject = DockerImageParser.parse(config.features.monitoring.helm.prometheusConfigReloaderImage)>
     image:
         registry  : ${reloaderImageObject.registry}
         repository: ${reloaderImageObject.repository}
         tag       : ${reloaderImageObject.tag}
+  </#if>
+  <#if podResources == true>
+    resources:
+      requests:
+        cpu: 200m
+        memory: 50Mi
+      limits:
+        cpu: 200m
+        memory: 50Mi
+  </#if>
 </#if>
 kubelet:
   enabled: false
@@ -101,12 +132,32 @@ kubeProxy:
 alertmanager:
   enabled: false
 grafana:
+  grafana.ini:
+    analytics:
+      check_for_updates: false
+<#if config.application.openshift == true>
+  securityContext:
+      # Null is ignored on rendering resulting in default 472, which results in error: .containers[0].runAsUser: Invalid value: 472: must be in the ranges: [1000740000, 1000749999]
+      # So set some arbitrary but valid UID/GID
+      fsGroup: 1000740000
+      runAsGroup: 1000740000
+      runAsUser: 1000740000
+</#if>
+<#if namespaceIsolation == true>
+  # For now, Grafana will only search for configMaps in its own namespace.
+  # In the future, we could deploy a least-privilege RBAC roleBindings for Grafana's SA, similar to prometheus.
+  # Then we would also add a list of NS to sidecar.dashboards.searchNamespace
+  rbac:
+    namespaced: true
+</#if>
   defaultDashboardsEnabled: false
   adminUser: ${config.application["username"]}
   adminPassword: ${config.application["password"]}
   service:
     type: <#if remote>LoadBalancer<#else>NodePort</#if>
+    <#if !remote>
     nodePort: "9095"
+    </#if>
 <#if monitoring.grafana.host?has_content>
   ingress:
     enabled: true
@@ -115,14 +166,19 @@ grafana:
 <#if config.features.monitoring.helm.grafanaImage?has_content>
 <#assign grafanImageObject = DockerImageParser.parse(config.features.monitoring.helm.grafanaImage)>
   image:
-    repository: ${grafanImageObject.registryAndRepositoryAsString}
-    tag       : ${grafanImageObject.tag}
+    registry: ${grafanImageObject.registry}
+    repository: ${grafanImageObject.repository}
+    tag: ${grafanImageObject.tag}
 </#if>
   sidecar:
     dashboards:
-      #this needs to be added so that the label will become 'label: grafana_dashboards: "1"'
+      # This needs to be added so that the label will become 'label: grafana_dashboards: "1"'
       labelValue: 1
+<#if namespaceIsolation == true>
+      searchNamespace: "${namePrefix}monitoring"
+<#else>
       searchNamespace: "ALL"
+</#if>
 <#if podResources == true>
     resources:
       limits:
@@ -135,8 +191,9 @@ grafana:
 <#if config.features.monitoring.helm.grafanaSidecarImage?has_content>
 <#assign sidecarImageObject = DockerImageParser.parse(config.features.monitoring.helm.grafanaSidecarImage)>
     image:
-      repository: ${sidecarImageObject.registryAndRepositoryAsString}
-      tag       : ${sidecarImageObject.tag}
+      registry: ${sidecarImageObject.registry}
+      repository: ${sidecarImageObject.repository}
+      tag: ${sidecarImageObject.tag}
 </#if>
 <#if mail.active??>
   notifiers:
@@ -201,6 +258,12 @@ grafana:
 
 prometheus:
   prometheusSpec:
+    <#if config.application.openshift == true>
+    securityContext: 
+      fsGroup: null
+      runAsGroup: null
+      runAsUser: null
+    </#if>
     # Find podMonitors, serviceMonitor, etc. in all namespaces
     serviceMonitorNamespaceSelector:
       matchLabels: {}
@@ -216,8 +279,7 @@ prometheus:
     probeNamespaceSelector:
       matchLabels: {}
     probeSelectorNilUsesHelmValues: false
-      
-<#if podResources == true>
+  <#if podResources == true>
     resources:
       limits:
         cpu: 500m
@@ -232,7 +294,7 @@ prometheus:
       registry  : ${prometheusImageObject.registry}
       repository: ${prometheusImageObject.repository}
       tag       : ${prometheusImageObject.tag}
-</#if>
+  </#if>
     secrets:
       - prometheus-metrics-creds-scmm
       - prometheus-metrics-creds-jenkins

--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -3,6 +3,12 @@ crds:
   enabled: false
 </#if>
 
+<#if namespaceIsolation == true>
+global:
+  rbac:
+    create: false
+</#if>
+
 # Note that many things are disabled here, because we want to start small, especially in airgapped envs where each image
 # has to be replicated individually
 defaultRules:

--- a/applications/cluster-resources/monitoring/rbac/namespace-isolation-rbac.ftl.yaml
+++ b/applications/cluster-resources/monitoring/rbac/namespace-isolation-rbac.ftl.yaml
@@ -1,0 +1,167 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-prometheus-stack-prometheus
+  namespace: ${namespace}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+<#-- These options taken from the cluster role are not valid inside the role:
+      Role.rbac.authorization.k8s.io "kube-prometheus-stack-prometheus" is invalid: rules[2].nonResourceURLs: Invalid value: []string{"/metrics", "/metrics/cadvisor"}: namespaced rules cannot apply to non-resource URLs
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+    verbs:
+      - get
+-->
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-prometheus-stack-operator
+  namespace: ${namespace}
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - alertmanagers/finalizers
+      - alertmanagers/status
+      - alertmanagerconfigs
+      - prometheuses
+      - prometheuses/finalizers
+      - prometheuses/status
+      - prometheusagents
+      - prometheusagents/finalizers
+      - prometheusagents/status
+      - thanosrulers
+      - thanosrulers/finalizers
+      - thanosrulers/status
+      - scrapeconfigs
+      - servicemonitors
+      - podmonitors
+      - probes
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - services/finalizers
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - patch
+      - create
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-prometheus-stack-operator
+  namespace: ${namespace}
+subjects:
+  - kind: ServiceAccount
+    name: kube-prometheus-stack-operator
+    namespace: ${namePrefix}monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-prometheus-stack-operator
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-prometheus-stack-prometheus
+  namespace: ${namespace}
+subjects:
+  - kind: ServiceAccount
+    name: kube-prometheus-stack-prometheus
+    namespace: ${namePrefix}monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-prometheus-stack-prometheus

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -30,6 +30,9 @@
       "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors.",
       "additionalProperties" : false
     },
+    "Map(String,Object)" : {
+      "type" : "object"
+    },
     "RepositorySchema" : {
       "type" : "object",
       "properties" : {
@@ -192,7 +195,7 @@
                   "description" : "Repository url from which the Helm chart should be obtained"
                 },
                 "values" : {
-                  "type" : "object",
+                  "$ref" : "#/$defs/Map(String,Object)",
                   "description" : "Helm values of the chart, allows overriding defaults and setting values that are not exposed as explicit configuration"
                 },
                 "version" : {
@@ -200,8 +203,8 @@
                   "description" : "The version of the Helm chart to be installed"
                 }
               },
-              "additionalProperties" : false,
-              "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors."
+              "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors.",
+              "additionalProperties" : false
             }
           },
           "additionalProperties" : false,
@@ -310,6 +313,10 @@
                 "repoURL" : {
                   "type" : "string",
                   "description" : "Repository url from which the Helm chart should be obtained"
+                },
+                "values" : {
+                  "$ref" : "#/$defs/Map(String,Object)",
+                  "description" : "Helm values of the chart, allows overriding defaults and setting values that are not exposed as explicit configuration"
                 },
                 "version" : {
                   "type" : "string",

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -92,6 +92,10 @@
           "type" : "string",
           "description" : "Set name-prefix for repos, jobs, namespaces"
         },
+        "namespaceIsolation" : {
+          "type" : "boolean",
+          "description" : "Configure tools to explicitly work with the given namespaces only, and not cluster-wide. This way GOP can be installed without having cluster-admin permissions."
+        },
         "password" : {
           "type" : "string",
           "description" : "Set initial admin passwords"

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -99,6 +99,10 @@
           "type" : "boolean",
           "description" : "Configure tools to explicitly work with the given namespaces only, and not cluster-wide. This way GOP can be installed without having cluster-admin permissions."
         },
+        "openshift" : {
+          "type" : "boolean",
+          "description" : "Install with openshift compatibility"
+        },
         "password" : {
           "type" : "string",
           "description" : "Set initial admin passwords"

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -88,6 +88,8 @@ class GitopsPlaygroundCli  implements Runnable {
     private Boolean remote
     @Option(names = ['--insecure'], description = INSECURE_DESCRIPTION)
     private Boolean insecure
+    @Option(names = ['--openshift'], description = OPENSHIFT_DESCRIPTION)
+    private Boolean openshift
 
     // args group tool configuration
     @Option(names = ['--git-name'], description = GIT_NAME_DESCRIPTION)
@@ -383,6 +385,7 @@ class GitopsPlaygroundCli  implements Runnable {
                         password: scmmPassword
                 ],
                 application: [
+                        openshift     : openshift,
                         remote        : remote,
                         mirrorRepos     : mirrorRepos, 
                         destroy : destroy,

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -134,6 +134,8 @@ class GitopsPlaygroundCli  implements Runnable {
     private Boolean mirrorRepos
     @Option(names = ['--skip-crds'], description = SKIP_CRDS_DESCRIPTION)
     private Boolean skipCrds
+    @Option(names = ['--namespace-isolation'], description = NAMESPACE_ISOLATION_DESCRIPTION)
+    private Boolean namespaceIsolation
 
     // args group metrics
     @Option(names = ['--metrics', '--monitoring'], description = MONITORING_ENABLE_DESCRIPTION)
@@ -396,7 +398,8 @@ class GitopsPlaygroundCli  implements Runnable {
                         gitName: gitName,
                         gitEmail: gitEmail,
                         urlSeparatorHyphen : urlSeparatorHyphen,
-                        skipCrds : skipCrds
+                        skipCrds : skipCrds,
+                        namespaceIsolation: namespaceIsolation
                 ],
                 images     : [
                         kubectl    : kubectlImage,

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScripted.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScripted.groovy
@@ -116,7 +116,7 @@ class GitopsPlaygroundCliMainScripted {
                         new ArgoCD(config, k8sClient, helmClient, fileSystemUtils, scmmRepoProvider),
                         new IngressNginx(config, fileSystemUtils, deployer, k8sClient, airGappedUtils),
                         new Mailhog(config, fileSystemUtils, deployer, k8sClient, airGappedUtils),
-                        new PrometheusStack(config, fileSystemUtils, deployer, k8sClient, airGappedUtils),
+                        new PrometheusStack(config, fileSystemUtils, deployer, k8sClient, airGappedUtils, scmmRepoProvider),
                         new ExternalSecretsOperator(config, fileSystemUtils, deployer, k8sClient, airGappedUtils),
                         new Vault(config, fileSystemUtils, k8sClient, deployer, airGappedUtils)
                 ]))

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -124,6 +124,7 @@ class ApplicationConfigurator {
                     gitEmail: 'hello@cloudogu.com',
                     urlSeparatorHyphen: false,
                     skipCrds : false,
+                    namespaceIsolation : false
             ],
             images     : [
                     kubectl    : "bitnami/kubectl:$K8S_VERSION",

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -112,6 +112,7 @@ class ApplicationConfigurator {
                     // Take from env because the Dockerfile provides a local copy of the repo for air-gapped mode
                     localHelmChartFolder: System.getenv('LOCAL_HELM_CHART_FOLDER'),
                     insecure      : false,
+                    openshift     : false,
                     username      : DEFAULT_ADMIN_USER,
                     password      : DEFAULT_ADMIN_PW,
                     yes           : false,

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -191,6 +191,7 @@ class ApplicationConfigurator {
                                     prometheusImage: '',
                                     prometheusOperatorImage: '',
                                     prometheusConfigReloaderImage: '',
+                                    values: [:]
                             ]
                     ],
                     secrets   : [

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -38,6 +38,7 @@ interface ConfigConstants {
     // group remote
     String REMOTE_DESCRIPTION = 'Expose services as LoadBalancers'
     String INSECURE_DESCRIPTION = 'Sets insecure-mode in cURL which skips cert validation'
+    String OPENSHIFT_DESCRIPTION = 'Install with openshift compatibility'
     String LOCAL_HELM_CHART_FOLDER_DESCRIPTION = 'A local folder (within the GOP image mostly) where the local mirrors of all helm charts are loaded from when mirror-Repos is active. This is mostly needed for development.'
 
     // group tool configuration

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -63,6 +63,7 @@ interface ConfigConstants {
     String BASE_URL_DESCRIPTION = 'the external base url (TLD) for all tools, e.g. https://example.com or http://localhost:8080. The individual -url params for argocd, grafana, vault and mailhog take precedence.'
     String URL_SEPARATOR_HYPHEN_DESCRIPTION = 'Use hyphens instead of dots to separate application name from base-url'
     String SKIP_CRDS_DESCRIPTION = 'Skip installation of CRDs. This requires prior installation of CRDs'
+    String NAMESPACE_ISOLATION_DESCRIPTION = 'Configure tools to explicitly work with the given namespaces only, and not cluster-wide. This way GOP can be installed without having cluster-admin permissions.'
     String MIRROR_REPOS_DESCRIPTION = 'Changes the sources of deployed tools so they are not pulled from the internet, but are pulled from git and work in air-gapped environments.'
     String SPRING_BOOT_HELM_CHART_DESCRIPTION = 'Repo to pull the generic Spring Boot Helm chart, used in examples and exercises'
     String SPRING_PETCLINIC_DESCRIPTION = 'Repo to pull the Spring Petclinic, used in examples and exercises'

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -169,6 +169,8 @@ class Schema {
         boolean mirrorRepos = false
         @JsonPropertyDescription(SKIP_CRDS_DESCRIPTION)
         boolean skipCrds = false
+        @JsonPropertyDescription(NAMESPACE_ISOLATION_DESCRIPTION)
+        boolean namespaceIsolation = false
     }
 
     static class ImagesSchema {

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -1,5 +1,5 @@
 //file:noinspection unused
-package com.cloudogu.gitops.config.schema
+package com.cloudogu.gitops.config.schema 
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
@@ -41,6 +41,12 @@ class Schema {
         String repoURL = ""
         @JsonPropertyDescription(HELM_CONFIG_VERSION_DESCRIPTION)
         String version = ""
+    }
+    
+    @JsonClassDescription(HELM_CONFIG_DESCRIPTION)
+    static class HelmConfigWithValues extends HelmConfig {
+        @JsonPropertyDescription(HELM_CONFIG_VALUES_DESCRIPTION)
+        Map<String, Object> values
     }
 
     static class RegistrySchema {
@@ -274,7 +280,7 @@ class Schema {
 
         @JsonPropertyDescription(HELM_CONFIG_DESCRIPTION)
         MonitoringHelmSchema helm
-        static class MonitoringHelmSchema extends HelmConfig {
+        static class MonitoringHelmSchema extends HelmConfigWithValues {
             @JsonPropertyDescription(GRAFANA_IMAGE_DESCRIPTION)
             String grafanaImage = ""
             @JsonPropertyDescription(GRAFANA_SIDECAR_IMAGE_DESCRIPTION)
@@ -327,12 +333,7 @@ class Schema {
         @JsonPropertyDescription(INGRESS_NGINX_ENABLE_DESCRIPTION)
         boolean active = false
 
-        @JsonPropertyDescription(HELM_CONFIG_DESCRIPTION)
-        IngressNginxHelmSchema helm
-        static class IngressNginxHelmSchema extends HelmConfig {
-            @JsonPropertyDescription(HELM_CONFIG_VALUES_DESCRIPTION)
-            Map<String, Object> values
-        }
+        HelmConfigWithValues helm
     }
 
     static class ExampleAppsSchema {

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -137,7 +137,9 @@ class Schema {
         boolean insecure = false
         @JsonPropertyDescription(LOCAL_HELM_CHART_FOLDER_DESCRIPTION)
         String localHelmChartFolder = ""
-
+        @JsonPropertyDescription(OPENSHIFT_DESCRIPTION)
+        boolean openshift = false
+        
         // args group configuration
         @JsonPropertyDescription(USERNAME_DESCRIPTION)
         String username = ""

--- a/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
@@ -6,6 +6,7 @@ import com.cloudogu.gitops.features.deployment.DeploymentStrategy
 import com.cloudogu.gitops.scmm.ScmmRepo
 import com.cloudogu.gitops.scmm.ScmmRepoProvider
 import com.cloudogu.gitops.utils.*
+import freemarker.template.DefaultObjectWrapperBuilder
 import groovy.util.logging.Slf4j
 import groovy.yaml.YamlSlurper
 import io.micronaut.core.annotation.Order
@@ -24,9 +25,6 @@ class PrometheusStack extends Feature {
     static final String RBAC_NAMESPACE_ISOLATION_TEMPLATE = 'applications/cluster-resources/monitoring/rbac/namespace-isolation-rbac.ftl.yaml'
     
     private Map config
-    private boolean remoteCluster
-    private String username
-    private String password
     private FileSystemUtils fileSystemUtils
     private DeploymentStrategy deployer
     private K8sClient k8sClient
@@ -43,9 +41,6 @@ class PrometheusStack extends Feature {
     ) {
         this.deployer = deployer
         this.config = config.getConfig()
-        this.username = this.config.application["username"]
-        this.password = this.config.application["password"]
-        this.remoteCluster = this.config.application["remote"]
         this.fileSystemUtils = fileSystemUtils
         this.k8sClient = k8sClient
         this.airGappedUtils = airGappedUtils
@@ -61,51 +56,43 @@ class PrometheusStack extends Feature {
     void enable() {
         def namePrefix = config.application['namePrefix']
 
-        def tmpHelmValues = new TemplatingEngine().replaceTemplate(fileSystemUtils.copyToTempDir(HELM_VALUES_PATH).toFile(), [
-                namePrefix: namePrefix,
-                podResources: config.application['podResources'],
-                monitoring: [
+        def template = new TemplatingEngine().template(new File(HELM_VALUES_PATH), [
+                namePrefix        : namePrefix,
+                podResources      : config.application['podResources'],
+                monitoring        : [
                         grafanaEmailFrom: config.features['monitoring']['grafanaEmailFrom'] as String,
-                        grafanaEmailTo: config.features['monitoring']['grafanaEmailTo'] as String,
-                        grafana: [
+                        grafanaEmailTo  : config.features['monitoring']['grafanaEmailTo'] as String,
+                        grafana         : [
                                 // Note that passing the URL object here leads to problems in Graal Native image, see Git history
                                 host: config.features['monitoring']['grafanaUrl'] ? new URL(config.features['monitoring']['grafanaUrl'] as String).host : ""
                         ]
                 ],
-                skipCrds : config.application['skipCrds'],
+                remote: config.application["remote"],
+                skipCrds          : config.application['skipCrds'],
                 namespaceIsolation: config.application['namespaceIsolation'],
-                mail: [
-                        active: config.features['mail']['active'],
+                namespaces        : namespaceList,
+                mail              : [
+                        active      : config.features['mail']['active'],
                         smtpAddress : config.features['mail']['smtpAddress'],
-                        smtpPort : config.features['mail']['smtpPort'],
-                        smtpUser : config.features['mail']['smtpUser'],
-                        smtpPassword : config.features['mail']['smtpPassword']
+                        smtpPort    : config.features['mail']['smtpPort'],
+                        smtpUser    : config.features['mail']['smtpUser'],
+                        smtpPassword: config.features['mail']['smtpPassword']
                 ],
-                scmm: getScmmConfiguration(),
-                jenkins: getJenkinsConfiguration()
-        ]).toPath()
-        Map helmValuesYaml = fileSystemUtils.readYaml(tmpHelmValues)
-
-        if (remoteCluster) {
-            log.debug("Setting grafana service.type to LoadBalancer since it is running in a remote cluster")
-            helmValuesYaml['grafana']['service']['type'] = 'LoadBalancer'
-        }
-
-        if (username != null && username != "admin") {
-            log.debug("Setting grafana username")
-            helmValuesYaml['grafana']['adminUser'] = username
-        }
-        if (password != null && password != "admin") {
-            log.debug("Setting grafana password")
-            helmValuesYaml['grafana']['adminPassword'] = password
-        }
+                scmm              : getScmmConfiguration(),
+                jenkins           : getJenkinsConfiguration(),
+                config: config,
+                // Allow for using static classes inside the templates
+                statics: new DefaultObjectWrapperBuilder(freemarker.template.Configuration.VERSION_2_3_32).build().getStaticModels()
+        ])
+        def helmValuesYaml = new YamlSlurper().parseText(
+                template) as Map
 
         // Create secret imperatively here instead of values.yaml, because we don't want it to show in git repo
         k8sClient.createSecret(
                 'generic',
                 'prometheus-metrics-creds-scmm',
                 'monitoring',
-                new Tuple2('password', password)
+                new Tuple2('password', config.application["password"])
         )
 
         k8sClient.createSecret(
@@ -139,11 +126,10 @@ class PrometheusStack extends Feature {
             clusterResourcesRepo.commitAndPush("Add namespace-isolated RBAC for PrometheusStack")
         }
 
-        def helmConfig = config['features']['monitoring']['helm']
-        setCustomImages(helmConfig, helmValuesYaml)
-
+        def tmpHelmValues = fileSystemUtils.createTempFile()
         fileSystemUtils.writeYaml(helmValuesYaml, tmpHelmValues.toFile())
 
+        def helmConfig = config['features']['monitoring']['helm']
         if (config.application['mirrorRepos']) {
             log.debug("Mirroring repos: Deploying prometheus from local git repo")
 
@@ -229,102 +215,5 @@ class PrometheusStack extends Feature {
                 host           : uri.authority,
                 path           : uri.path
         ]
-    }
-
-    private void setCustomImages(helmConfig, Map helmValuesYaml) {
-        setGrafanaImage(helmConfig, helmValuesYaml)
-        setGrafanaSidecarImage(helmConfig, helmValuesYaml)
-        setPrometheusImage(helmConfig, helmValuesYaml)
-        setPrometheusOperatorImage(helmConfig, helmValuesYaml)
-        setPrometheusConfigReloaderImage(helmConfig, helmValuesYaml)
-    }
-
-    private static void setPrometheusConfigReloaderImage(helmConfig, Map helmValuesYaml) {
-        String prometheusConfigReloaderImage = helmConfig['prometheusConfigReloaderImage']
-        if (prometheusConfigReloaderImage) {
-            log.debug("Setting custom prometheus-config-reloader image as requested for prometheus-stack")
-            def image = DockerImageParser.parse(prometheusConfigReloaderImage)
-            MapUtils.deepMerge([
-                    prometheusOperator: [
-                            prometheusConfigReloader: [
-                                    image: [
-                                            registry  : image.registry,
-                                            repository: image.repository,
-                                            tag       : image.tag
-                                    ]
-                            ]
-                    ]
-            ], helmValuesYaml)
-        }
-    }
-
-    private static void setPrometheusOperatorImage(helmConfig, Map helmValuesYaml) {
-        String prometheusOperatorImage = helmConfig['prometheusOperatorImage']
-        if (prometheusOperatorImage) {
-            log.debug("Setting custom prometheus-operator image as requested for prometheus-stack")
-            def image = DockerImageParser.parse(prometheusOperatorImage)
-            MapUtils.deepMerge([
-                    prometheusOperator: [
-                            image: [
-                                    registry: image.registry,
-                                    repository: image.repository,
-                                    tag       : image.tag
-                            ]
-                    ]
-            ], helmValuesYaml)
-        }
-    }
-
-    private static void setPrometheusImage(helmConfig, Map helmValuesYaml) {
-        String prometheusImage = helmConfig['prometheusImage']
-        if (prometheusImage) {
-            log.debug("Setting custom prometheus-operator image as requested for prometheus-stack")
-            def image = DockerImageParser.parse(prometheusImage)
-            MapUtils.deepMerge([
-                    prometheus: [
-                            prometheusSpec: [
-                                    image: [
-                                            registry: image.registry,
-                                            repository: image.repository,
-                                            tag       : image.tag
-                                    ]
-                            ]
-                    ]
-            ], helmValuesYaml)
-        }
-    }
-
-    private static void setGrafanaSidecarImage(helmConfig, Map helmValuesYaml) {
-        String grafanaSidecarImage = helmConfig['grafanaSidecarImage']
-        if (grafanaSidecarImage) {
-            log.debug("Setting custom grafana-sidecar image as requested for prometheus-stack")
-            def image = DockerImageParser.parse(grafanaSidecarImage)
-            MapUtils.deepMerge([
-                    grafana: [
-                            sidecar: [
-                                    image: [
-                                            repository: image.getRegistryAndRepositoryAsString(),
-                                            tag       : image.tag
-                                    ]
-                            ]
-                    ]
-            ], helmValuesYaml)
-        }
-    }
-
-    private static void setGrafanaImage(helmConfig, Map helmValuesYaml) {
-        String grafanaImage = helmConfig['grafanaImage']
-        if (grafanaImage) {
-            log.debug("Setting custom grafana image as requested for prometheus-stack")
-            def image = DockerImageParser.parse(grafanaImage)
-            MapUtils.deepMerge([
-                    grafana: [
-                            image: [
-                                    repository: image.getRegistryAndRepositoryAsString(),
-                                    tag       : image.tag
-                            ]
-                    ]
-            ], helmValuesYaml)
-        }
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -226,6 +226,7 @@ application:
   urlSeparatorHyphen: true
   mirrorRepos: true
   skipCrds: true
+  namespaceIsolation: false
 images:
   kubectl: "kubectl-value"
   helm: "helm-value"

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -274,6 +274,7 @@ features:
       chart: "kube-prometheus-stack"
       repoURL: "https://prometheus-community.github.io/helm-charts"
       version: "58.2.1"
+      values: null
       grafanaImage: "grafanaImage"
       grafanaSidecarImage: "grafanaSidecarImage"
       prometheusImage: "prometheusImage"

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -214,6 +214,7 @@ application:
   remote: true
   insecure: true
   localHelmChartFolder: "folder"
+  openshift: false
   username: "app-user"
   password: "app-pw"
   "yes": true

--- a/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/PrometheusStackTest.groovy
@@ -58,6 +58,7 @@ class PrometheusStackTest {
                                     chart  : 'kube-prometheus-stack',
                                     repoURL: 'https://prom',
                                     version: '19.2.2',
+                                    values : [:],
                                     grafanaImage: '',
                                     grafanaSidecarImage: '',
                                     prometheusImage: '',
@@ -100,14 +101,14 @@ class PrometheusStackTest {
     void 'When mailhog disabled: Does not include mail configurations into cluster resources'() {
         config.features['mail']['mailhog'] = false
         createStack().install()
-        assertThat(parseActualStackYaml()['grafana']['notifiers']).isNull()
+        assertThat(parseActualYaml()['grafana']['notifiers']).isNull()
     }
 
     @Test
     void 'When mailhog enabled: Includes mail configurations into cluster resources'() {
         config.features['mail']['active'] = true
         createStack().install()
-        assertThat(parseActualStackYaml()['grafana']['notifiers']).isNotNull()
+        assertThat(parseActualYaml()['grafana']['notifiers']).isNotNull()
     }
 
     @Test
@@ -117,9 +118,9 @@ class PrometheusStackTest {
         config.features['monitoring']['grafanaEmailTo'] = 'infra@example.com'
         createStack().install()
 
-        def notifiersYaml = parseActualStackYaml()['grafana']['notifiers']['notifiers.yaml']['notifiers']['settings'] as List
+        def notifiersYaml = parseActualYaml()['grafana']['notifiers']['notifiers.yaml']['notifiers']['settings'] as List
         assertThat(notifiersYaml[0]['addresses']).isEqualTo('infra@example.com')
-        assertThat(parseActualStackYaml()['grafana']['env']['GF_SMTP_FROM_ADDRESS']).isEqualTo('grafana@example.com')
+        assertThat(parseActualYaml()['grafana']['env']['GF_SMTP_FROM_ADDRESS']).isEqualTo('grafana@example.com')
     }
 
     @Test
@@ -127,9 +128,9 @@ class PrometheusStackTest {
         config.features['mail']['active'] = true
         createStack().install()
 
-        def notifiersYaml = parseActualStackYaml()['grafana']['notifiers']['notifiers.yaml']['notifiers']['settings'] as List
+        def notifiersYaml = parseActualYaml()['grafana']['notifiers']['notifiers.yaml']['notifiers']['settings'] as List
         assertThat(notifiersYaml[0]['addresses']).isEqualTo('infra@example.org')
-        assertThat(parseActualStackYaml()['grafana']['env']['GF_SMTP_FROM_ADDRESS']).isEqualTo('grafana@example.org')
+        assertThat(parseActualYaml()['grafana']['env']['GF_SMTP_FROM_ADDRESS']).isEqualTo('grafana@example.org')
     }
 
     @Test
@@ -140,7 +141,7 @@ class PrometheusStackTest {
         config.features['monitoring']['grafanaEmailTo'] = 'grafana@example.com'   // needed to check that yaml is inserted correctly
 
         createStack().install()
-        def contactPointsYaml = parseActualStackYaml()
+        def contactPointsYaml = parseActualYaml()
 
         assertThat(contactPointsYaml['grafana']['alerting']['contactpoints.yaml']).isEqualTo(new YamlSlurper().parseText(
 """
@@ -181,7 +182,7 @@ policies:
 
         createStack().install()
         
-        assertThat(parseActualStackYaml()['grafana']['smtp']['existingSecret']).isEqualTo('grafana-email-secret')
+        assertThat(parseActualYaml()['grafana']['smtp']['existingSecret']).isEqualTo('grafana-email-secret')
         k8sCommandExecutor.assertExecuted('kubectl create secret generic grafana-email-secret -n foo-monitoring --from-literal user=mailserver@example.com --from-literal password=')
     }
 
@@ -192,7 +193,7 @@ policies:
         config.features['mail']['smtpPassword'] = '1101ABCabc&/+*~'
 
         createStack().install()
-        assertThat(parseActualStackYaml()['grafana']['smtp']['existingSecret']).isEqualTo('grafana-email-secret')
+        assertThat(parseActualYaml()['grafana']['smtp']['existingSecret']).isEqualTo('grafana-email-secret')
         k8sCommandExecutor.assertExecuted('kubectl create secret generic grafana-email-secret -n foo-monitoring --from-literal user= --from-literal password=1101ABCabc&/+*~')
     }
 
@@ -203,8 +204,8 @@ policies:
 
         createStack().install()
 
-        assertThat(parseActualStackYaml()['grafana']['valuesFrom']).isNull()
-        assertThat(parseActualStackYaml()['grafana']['smtp']).isNull()
+        assertThat(parseActualYaml()['grafana']['valuesFrom']).isNull()
+        assertThat(parseActualYaml()['grafana']['smtp']).isNull()
         k8sCommandExecutor.assertNotExecuted('kubectl create secret generic grafana-email-secret')
     }
     
@@ -226,7 +227,7 @@ policies:
         config.features['mail']['smtpAddress'] = 'smtp.example.com'
 
         createStack().install()
-        def contactPointsYaml = parseActualStackYaml()
+        def contactPointsYaml = parseActualYaml()
         
         assertThat(contactPointsYaml['grafana']['env']['GF_SMTP_HOST']).isEqualTo('smtp.example.com')
     }
@@ -235,7 +236,7 @@ policies:
     void 'When external Mailserver is NOT set'() {
         config.features['mail']['mailhog'] = false
         createStack().install()
-        def contactPointsYaml = parseActualStackYaml()
+        def contactPointsYaml = parseActualYaml()
 
         assertThat(contactPointsYaml['grafana']['alerting']).isNull()
     }
@@ -245,7 +246,7 @@ policies:
         config['application']['remote'] = true
         createStack().install()
 
-        assertThat(parseActualStackYaml()['grafana']['service']['type']).isEqualTo('LoadBalancer')
+        assertThat(parseActualYaml()['grafana']['service']['type']).isEqualTo('LoadBalancer')
     }
 
     @Test
@@ -254,8 +255,8 @@ policies:
         config['application']['password'] = "hunter2"
         createStack().install()
 
-        assertThat(parseActualStackYaml()['grafana']['adminUser']).isEqualTo('my-user')
-        assertThat(parseActualStackYaml()['grafana']['adminPassword']).isEqualTo('hunter2')
+        assertThat(parseActualYaml()['grafana']['adminUser']).isEqualTo('my-user')
+        assertThat(parseActualYaml()['grafana']['adminPassword']).isEqualTo('hunter2')
     }
 
     @Test
@@ -263,7 +264,7 @@ policies:
         config['application']['remote'] = false
         createStack().install()
 
-        assertThat(parseActualStackYaml()['grafana']['service']['type']).isEqualTo('NodePort')
+        assertThat(parseActualYaml()['grafana']['service']['type']).isEqualTo('NodePort')
     }
 
     @Test
@@ -272,7 +273,7 @@ policies:
         createStack().install()
 
 
-        def ingressYaml = parseActualStackYaml()['grafana']['ingress']
+        def ingressYaml = parseActualYaml()['grafana']['ingress']
         assertThat(ingressYaml['enabled']).isEqualTo(true)
         assertThat((ingressYaml['hosts'] as List)[0]).isEqualTo('grafana.local')
     }
@@ -281,7 +282,7 @@ policies:
     void 'does not use ingress by default'() {
         createStack().install()
 
-        assertThat(parseActualStackYaml()['grafana'] as Map).doesNotContainKey('ingress')
+        assertThat(parseActualYaml()['grafana'] as Map).doesNotContainKey('ingress')
     }
 
     @Test
@@ -291,7 +292,7 @@ policies:
         createStack().install()
 
 
-        def additionalScrapeConfigs = parseActualStackYaml()['prometheus']['prometheusSpec']['additionalScrapeConfigs'] as List
+        def additionalScrapeConfigs = parseActualYaml()['prometheus']['prometheusSpec']['additionalScrapeConfigs'] as List
         assertThat(((additionalScrapeConfigs[0]['static_configs'] as List)[0]['targets'] as List)[0]).isEqualTo('localhost:9091')
         assertThat(additionalScrapeConfigs[0]['metrics_path']).isEqualTo('/prefix/scm/api/v2/metrics/prometheus')
         assertThat(additionalScrapeConfigs[0]['scheme']).isEqualTo('https')
@@ -309,7 +310,7 @@ policies:
         createStack().install()
 
 
-        def additionalScrapeConfigs = parseActualStackYaml()['prometheus']['prometheusSpec']['additionalScrapeConfigs'] as List
+        def additionalScrapeConfigs = parseActualYaml()['prometheus']['prometheusSpec']['additionalScrapeConfigs'] as List
         assertThat(((additionalScrapeConfigs[1]['static_configs'] as List)[0]['targets'] as List)[0]).isEqualTo('localhost:9090')
         assertThat(additionalScrapeConfigs[1]['metrics_path']).isEqualTo('/jenkins/prometheus')
         assertThat(additionalScrapeConfigs[1]['scheme']).isEqualTo('https')
@@ -327,7 +328,7 @@ policies:
         createStack().install()
 
         assertThat(k8sCommandExecutor.actualCommands[1]).isEqualTo("kubectl create secret generic prometheus-metrics-creds-jenkins -n foo-monitoring --from-literal password=hunter2 --dry-run=client -oyaml | kubectl apply -f-")
-        def additionalScrapeConfigs = parseActualStackYaml()['prometheus']['prometheusSpec']['additionalScrapeConfigs'] as List
+        def additionalScrapeConfigs = parseActualYaml()['prometheus']['prometheusSpec']['additionalScrapeConfigs'] as List
         assertThat(additionalScrapeConfigs[1]['basic_auth']['username']).isEqualTo('external-metrics-username')
     }
 
@@ -336,8 +337,8 @@ policies:
         config['features']['monitoring']['helm']['grafanaImage'] = "localhost:5000/grafana/grafana:the-tag"
         createStack().install()
 
-        assertThat(parseActualStackYaml()['grafana']['image']['repository']).isEqualTo('localhost:5000/grafana/grafana')
-        assertThat(parseActualStackYaml()['grafana']['image']['tag']).isEqualTo('the-tag')
+        assertThat(parseActualYaml()['grafana']['image']['repository']).isEqualTo('localhost:5000/grafana/grafana')
+        assertThat(parseActualYaml()['grafana']['image']['tag']).isEqualTo('the-tag')
     }
 
     @Test
@@ -345,8 +346,8 @@ policies:
         config['features']['monitoring']['helm']['grafanaSidecarImage'] = "localhost:5000/grafana/sidecar:the-tag"
         createStack().install()
 
-        assertThat(parseActualStackYaml()['grafana']['sidecar']['image']['repository']).isEqualTo('localhost:5000/grafana/sidecar')
-        assertThat(parseActualStackYaml()['grafana']['sidecar']['image']['tag']).isEqualTo('the-tag')
+        assertThat(parseActualYaml()['grafana']['sidecar']['image']['repository']).isEqualTo('localhost:5000/grafana/sidecar')
+        assertThat(parseActualYaml()['grafana']['sidecar']['image']['tag']).isEqualTo('the-tag')
     }
 
     @Test
@@ -357,7 +358,7 @@ policies:
         createStack().install()
 
 
-        def actualYaml = parseActualStackYaml()
+        def actualYaml = parseActualYaml()
         assertThat(actualYaml['prometheus']['prometheusSpec']['image']['registry']).isEqualTo('localhost:5000')
         assertThat(actualYaml['prometheus']['prometheusSpec']['image']['repository']).isEqualTo('prometheus/prometheus')
         assertThat(actualYaml['prometheus']['prometheusSpec']['image']['tag']).isEqualTo('v1')
@@ -384,7 +385,7 @@ policies:
                 'helm upgrade -i kube-prometheus-stack prometheusstack/kube-prometheus-stack --version 19.2.2' +
                         " --values ${temporaryYamlFile} --namespace foo-monitoring --create-namespace") */
 
-        def yaml = parseActualStackYaml()
+        def yaml = parseActualYaml()
         assertThat(yaml['grafana']['adminUser']).isEqualTo('abc')
         assertThat(yaml['grafana']['adminPassword']).isEqualTo(123)
         
@@ -403,7 +404,7 @@ policies:
 
         createStack().install()
 
-        assertThat(parseActualStackYaml()['crds']['enabled']).isEqualTo(false)
+        assertThat(parseActualYaml()['crds']['enabled']).isEqualTo(false)
     }
     
     @Test
@@ -412,7 +413,7 @@ policies:
 
         createStack().install()
 
-        def yaml = parseActualStackYaml()
+        def yaml = parseActualYaml()
         assertThat(yaml['prometheusOperator']['resources'] as Map).containsKeys('limits', 'requests')
         assertThat(yaml['grafana']['resources'] as Map)containsKeys('limits', 'requests')
         assertThat(yaml['grafana']['sidecar']['resources'] as Map)containsKeys('limits', 'requests')
@@ -426,7 +427,7 @@ policies:
         def prometheusStack = createStack()
         prometheusStack.install()
         
-        def yaml = parseActualStackYaml()
+        def yaml = parseActualYaml()
         assertThat(yaml['global']['rbac']['create']).isEqualTo(false)
 
         List<String> expectedNamespaces = [ "foo-default", "foo-argocd", "foo-monitoring", "foo-ingress-nginx", "foo-example-apps-staging", "foo-example-apps-production", "foo-secrets"]
@@ -466,6 +467,22 @@ policies:
                 'kube-prometheus-stack', temporaryYamlFilePrometheus, RepoType.GIT)
     }
 
+    @Test
+    void 'Merges additional helm values merged with default values'() {
+        config['features']['monitoring']['helm']['values'] = [
+                key: [
+                        some: 'thing',
+                        one: 1
+                ]
+        ]
+
+        createStack().install()
+        def actual = parseActualYaml()
+
+        assertThat(actual['key']['some']).isEqualTo('thing')
+        assertThat(actual['key']['one']).isEqualTo(1)
+    }
+
     private PrometheusStack createStack() {
         // We use the real FileSystemUtils and not a mock to make sure file editing works as expected
 
@@ -496,7 +513,7 @@ policies:
         }), airGappedUtils, repoProvider)
     }
 
-    private Map parseActualStackYaml() {
+    private Map parseActualYaml() {
         def ys = new YamlSlurper()
         return ys.parse(temporaryYamlFilePrometheus) as Map
     }


### PR DESCRIPTION
After building locally you can test this feature like so:

```
docker run --rm -t -u $(id -u)  \
    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
    --net=host \
 gitops-playground:dev --yes --argocd  --ingress-nginx --base-url=http://localhost --monitoring \
  --namespace-isolation --mirror-repos \
  --prometheus-config-reloader-image=quay.io/prometheus-operator/prometheus-config-reloader:v0.73.2 --prometheus-image=quay.io/prometheus/prometheus:v2.51.2 --prometheus-operator-image=quay.io/prometheus-operator/prometheus-operator:v0.73.2 --grafana-image=grafana/grafana:10.4.1  --grafana-sidecar-image=quay.io/kiwigrid/k8s-sidecar:1.26.1 \
  --openshift --pod-resources -x 
```

This pretty much create the config we need in an air-gapped, namespace-isolated, least-privilege OpenShift cluster 🤯.