### PR TITLE
Update to kubernetes 1.29.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ RUN apk add curl grep
 # * also update in init-cluster.sh. vars.tf, ApplicationConfigurator.groovy and apply.sh
 # When upgrading to 1.26 we can verify the kubectl signature with cosign!
 # https://kubernetes.io/blog/2022/12/12/kubernetes-release-artifact-signing/
-ARG K8S_VERSION=1.29.1
-ARG KUBECTL_CHECKSUM=69ab3a931e826bf7ac14d38ba7ca637d66a6fcb1ca0e3333a2cafdf15482af9f
+ARG K8S_VERSION=1.29.8
+ARG KUBECTL_CHECKSUM=038454e0d79748aab41668f44ca6e4ac8affd1895a94f592b9739a0ae2a5f06a
 # When updating, also upgrade helm image in ApplicationConfigurator
 ARG HELM_VERSION=3.15.4
 # bash curl unzip required for Jenkins downloader

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 import com.cloudogu.ces.cesbuildlib.*
 
 String getDockerRegistryBaseUrl() { 'ghcr.io' }
-
 String getDockerImageName() { 'cloudogu/gitops-playground' }
+String getTrivyVersion() { '0.55.0'}
 
 properties([
         // Dont keep builds forever to preserve space
@@ -207,7 +207,8 @@ def scanForCriticalVulns(String imageName, String fileName){
     trivyConfig = [
             imageName      : imageName,
             severity       : ['CRITICAL'],
-            additionalFlags: '--ignore-unfixed'
+            additionalFlags: '--ignore-unfixed',
+            trivyVersion: trivyVersion
     ]
 
     def vulns = findVulnerabilitiesWithTrivy(trivyConfig)
@@ -221,7 +222,8 @@ def scanForCriticalVulns(String imageName, String fileName){
 
 def scanForAllVulns(String imageName, String fileName){
     trivyConfig = [
-            imageName      : imageName
+            imageName      : imageName,
+            trivyVersion: trivyVersion
     ]
 
     def vulns = findVulnerabilitiesWithTrivy(trivyConfig)

--- a/docs/k3d.md
+++ b/docs/k3d.md
@@ -114,7 +114,7 @@ k3d cluster create gitops-playground \
   # Mount port for ingress
   -p 80:80@server:0:direct \
   # Pin image for reproducibility
-  --image=rancher/k3s:v1.29.1-k3s2 \
+  --image=rancher/k3s:v1.29.8-k3s2 \
   # Disable built-in ingress controller, because we want to use the same one locally and in prod
   --k3s-arg=--disable=traefik@server:0 \
   # Allow node ports < 30000

--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -4,8 +4,8 @@
 # This variable is also read in Jenkinsfile
 K3D_VERSION=5.6.0
 # When updating please also adapt in Dockerfile, vars.tf and ApplicationConfigurator.groovy
-K8S_VERSION=1.29.1
-K3S_VERSION="rancher/k3s:v${K8S_VERSION}-k3s2"
+K8S_VERSION=1.29.8
+K3S_VERSION="rancher/k3s:v${K8S_VERSION}-k3s1"
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
Fixes CVE-2024-24790 in kubectl.

Also update trivy in our build pipeline to make sure we find issues like these earlier.

I tested if the trivy update finds the CVE on a different branch (f1bc3c1e9c90a03f4a10d70e26e386a4908085a9) and later extracted this as a separate PR.
![image](https://github.com/user-attachments/assets/594d945d-4625-40e9-9b7e-7c15304451ba)
