### PR TITLE
Migrate Jenkins.createJob from bash to groovy

### DIFF
--- a/jenkins/namespaceJobTemplate.xml.ftl
+++ b/jenkins/namespaceJobTemplate.xml.ftl
@@ -1,11 +1,11 @@
-<?xml version="1.1" encoding="UTF-8"?>
-<jenkins.branch.OrganizationFolder plugin="branch-api@2.6.2">
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.branch.OrganizationFolder plugin="branch-api@2.1178.v969d9eb_c728e">
     <actions/>
     <description></description>
     <properties>
         <jenkins.branch.OrganizationChildHealthMetricsProperty>
             <templates>
-                <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric plugin="cloudbees-folder@6.15">
+                <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric plugin="cloudbees-folder@6.942.vb_43318a_156b_2">
                     <nonRecursive>false</nonRecursive>
                 </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
             </templates>
@@ -15,7 +15,7 @@
         </jenkins.branch.OrganizationChildOrphanedItemsProperty>
         <jenkins.branch.OrganizationChildTriggersProperty>
             <templates>
-                <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.15">
+                <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.942.vb_43318a_156b_2">
                     <spec>H H/4 * * *</spec>
                     <interval>86400000</interval>
                 </com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger>
@@ -23,10 +23,11 @@
         </jenkins.branch.OrganizationChildTriggersProperty>
         <org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig plugin="docker-workflow@1.25">
             <dockerLabel></dockerLabel>
-            <registry plugin="docker-commons@1.17"/>
+            <registry plugin="docker-commons@443.v921729d5611d"/>
         </org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig>
         <jenkins.branch.NoTriggerOrganizationFolderProperty>
             <branches>.*</branches>
+            <strategy>NONE</strategy>
         </jenkins.branch.NoTriggerOrganizationFolderProperty>
     </properties>
     <folderViews class="jenkins.branch.OrganizationFolderViewHolder">
@@ -36,13 +37,14 @@
     <icon class="jenkins.branch.MetadataActionFolderIcon">
         <owner class="jenkins.branch.OrganizationFolder" reference="../.."/>
     </icon>
-    <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@6.15">
+    <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@6.942.vb_43318a_156b_2">
         <pruneDeadBranches>true</pruneDeadBranches>
         <daysToKeep>-1</daysToKeep>
         <numToKeep>-1</numToKeep>
+        <abortBuilds>false</abortBuilds>
     </orphanedItemStrategy>
     <triggers>
-        <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.15">
+        <com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@6.942.vb_43318a_156b_2">
             <spec>H H/4 * * *</spec>
             <interval>86400000</interval>
         </com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger>
@@ -53,12 +55,12 @@
             <serverUrl>${SCMM_NAMESPACE_JOB_SERVER_URL}</serverUrl>
             <namespace>${SCMM_NAMESPACE_JOB_NAMESPACE}</namespace>
             <credentialsId>${SCMM_NAMESPACE_JOB_CREDENTIALS_ID}</credentialsId>
-            <dependencyChecker class="com.cloudogu.scmmanager.scm.ScmManagerNavigator$$Lambda$267/0x0000000100a46c40"/>
+            <dependencyChecker class="null"/>
             <traits>
-                <com.cloudogu.scmmanager.scm.BranchDiscoveryTrait/>
                 <com.cloudogu.scmmanager.scm.PullRequestDiscoveryTrait>
                     <excludeBranchesWithPRs>false</excludeBranchesWithPRs>
                 </com.cloudogu.scmmanager.scm.PullRequestDiscoveryTrait>
+                <com.cloudogu.scmmanager.scm.ScmManagerBranchDiscoveryTrait/>
             </traits>
             <apiFactory>
                 <credentialsLookup/>
@@ -66,7 +68,7 @@
         </com.cloudogu.scmmanager.scm.ScmManagerNavigator>
     </navigators>
     <projectFactories>
-        <org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory plugin="workflow-multibranch@2.22">
+        <org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory plugin="workflow-multibranch@795.ve0cb_1f45ca_9a_">
             <scriptPath>Jenkinsfile</scriptPath>
         </org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory>
     </projectFactories>

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -134,10 +134,6 @@ function configureJenkins() {
   # Since safeRestart can take time until it really restarts jenkins, we will sleep here before querying jenkins status.
   sleep 5
   waitForJenkins
-  
-    if [[ $INSTALL_ARGOCD == true ]]; then
-      createJob "${NAME_PREFIX}example-apps" "${SCMM_URL}" "${NAME_PREFIX}argocd" "scmm-user"
-    fi
 }
 
 initJenkins "$@"

--- a/scripts/jenkins/jenkins-REST-client.sh
+++ b/scripts/jenkins/jenkins-REST-client.sh
@@ -7,36 +7,6 @@ function curlJenkins() {
     "$@"
 }
 
-function createJob() {
-  JOB_NAME=${1}
-
-  # shellcheck disable=SC2016
-  # we don't want to expand these variables in single quotes
-  JOB_CONFIG=$(env -i \
-               SCMM_NAMESPACE_JOB_SERVER_URL="${2}" \
-               SCMM_NAMESPACE_JOB_NAMESPACE="${3}" \
-               SCMM_NAMESPACE_JOB_CREDENTIALS_ID="${4}" \
-               envsubst '${SCMM_NAMESPACE_JOB_SERVER_URL},
-                         ${SCMM_NAMESPACE_JOB_NAMESPACE},
-                         ${SCMM_NAMESPACE_JOB_CREDENTIALS_ID}' \
-               < scripts/jenkins/namespaceJobTemplate.xml)
-
-  printf 'Creating job %s ... ' "${JOB_NAME}"
-
-  # Don't add --fail here, because if the job already exists we get a return code of 400
-  STATUS=$(curlJenkins -L -o /dev/null --write-out '%{http_code}' \
-           -X POST "${JENKINS_URL}/createItem?name=${JOB_NAME}" \
-           -H "Content-Type:text/xml" \
-           --data "${JOB_CONFIG}" ) && EXIT_STATUS=$? || EXIT_STATUS=$?
-  if [ $EXIT_STATUS != 0 ]
-    then
-      echo "Creating Job failed with exit code: curl: ${EXIT_STATUS}, HTTP Status: ${STATUS}"
-      exit $EXIT_STATUS
-  fi
-  
-  printStatus "${STATUS}"
-}
-
 function crumb() {
     
   RESPONSE=$(curl -s --cookie-jar /tmp/cookies \

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -99,15 +99,24 @@ class Jenkins extends Feature {
         prometheusConfigurator.enableAuthentication()
 
         if (config.features['argocd']['active']) {
+
+            String jobName = "${config.application['namePrefix']}example-apps"
+            def credentialId = "scmm-user"
+            
+            jobManger.createJob(jobName, 
+                    config.scmm['urlForJenkins'] as String,
+                    "${config.application['namePrefix']}argocd",
+                    credentialId)
+
             jobManger.createCredential(
-                    "${config.application['namePrefix']}example-apps",
-                    "scmm-user",
+                    jobName,
+                    credentialId,
                     "${config.application['namePrefix']}gitops",
                     "${config.scmm['password']}",
                     'credentials for accessing scm-manager')
 
             jobManger.createCredential(
-                    "${config.application['namePrefix']}example-apps",
+                    jobName,
                     "registry-user",
                     "${config.registry['username']}",
                     "${config.registry['password']}",
@@ -123,7 +132,7 @@ class Jenkins extends Feature {
 
             }
             // Once everything is set up, start the jobs.
-            jobManger.startJob('example-apps')
+            jobManger.startJob(jobName)
         }
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -114,7 +114,9 @@ class JenkinsTest {
         verify(jobManger).createCredential('my-prefix-example-apps', 'scmm-user', 
                 'my-prefix-gitops', 'scmm-pw', 'credentials for accessing scm-manager')
 
-        verify(jobManger).startJob('example-apps')
+        verify(jobManger).startJob('my-prefix-example-apps')
+        verify(jobManger).createJob('my-prefix-example-apps', 'http://scmm-scm-manager/scm',
+                "my-prefix-argocd",'scmm-user')
 
         verify(jobManger).createCredential('my-prefix-example-apps', 'registry-user', 
                 'reg-usr', 'reg-pw', 'credentials for accessing the docker-registry for writing images built on jenkins')


### PR DESCRIPTION
This also fixes namePrefix issues, when starting the job and
updates from the legacy to the current `ScmManagerBranchDiscoveryTrait`.

The main reason is that this avoids the following error occurring in production
with Cloudogu Ecosystem:

```
++++ curl -s --cookie-jar /tmp/cookies --retry 3 --retry-delay 1 ... ++++ jq -rsc '(.[1] | .http_code|tostring), (.[0] | .crumb)' jq: parse error: Invalid numeric literal at line 4, column 14 +++ RESPONSE=
+++ EXIT_STATUS=5
+++ mapfile -t RESPONSE
+++ '[' 5 '!=' 0 ']'
+++ echo 'Creating Credentials failed with exit code: curl: 5, HTTP Status: ' +++ exit 5
++ curl -s -H 'Jenkins-Crumb:Creating Credentials failed with exit code: curl: 5, HTTP Status: ' --cookie /tmp/cookie ...-H Content-Type:text/xml --data '<?xml version="1.1" encoding="UTF-8"?>
```
-> status code: 403
