### PR TITLE
Implement pull secrets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ node('high-cpu') {
                                         .inside("-e KUBECONFIG=${env.WORKSPACE}/.kube/config " +
                                                 " --network=host --entrypoint=''") {
                                             sh "/app/apply-ng --yes --trace --internal-registry-port=${registryPort} " +
-                                                    "--argocd --monitoring --vault=dev --ingress-nginx --mailhog"
+                                                    "--argocd --monitoring --vault=dev --ingress-nginx --mailhog --base-url=http://localhost"
                                         }
                             }
                         }

--- a/applications/argocd/nginx/helm-jenkins/k8s/values-shared.ftl.yaml
+++ b/applications/argocd/nginx/helm-jenkins/k8s/values-shared.ftl.yaml
@@ -4,6 +4,12 @@ image:
   repository: ${nginxImage.repository}
   tag: ${nginxImage.tag}
 </#if>
+<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+
+global:
+  imagePullSecrets:
+    - proxy-registry
+</#if>
 service:
   ports:
     http: 80

--- a/applications/argocd/nginx/helm-jenkins/k8s/values-shared.ftl.yaml
+++ b/applications/argocd/nginx/helm-jenkins/k8s/values-shared.ftl.yaml
@@ -4,7 +4,7 @@ image:
   repository: ${nginxImage.repository}
   tag: ${nginxImage.tag}
 </#if>
-<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+<#if config.registry.createImagePullSecrets == true>
 
 global:
   imagePullSecrets:

--- a/applications/argocd/nginx/helm-umbrella/values.ftl.yaml
+++ b/applications/argocd/nginx/helm-umbrella/values.ftl.yaml
@@ -1,4 +1,16 @@
 nginx:
+<#if nginxImage??>
+  image:
+    registry: ${nginxImage.registry}
+    repository: ${nginxImage.repository}
+    tag: ${nginxImage.tag}
+</#if>
+  <#if config.registry.createImagePullSecrets == true>
+
+  global:
+    imagePullSecrets:
+    - proxy-registry
+  </#if>
   service:
     ports:
       http: 80

--- a/applications/cluster-resources/ingress-nginx-helm-values.ftl.yaml
+++ b/applications/cluster-resources/ingress-nginx-helm-values.ftl.yaml
@@ -1,5 +1,5 @@
 <#assign DockerImageParser=statics['com.cloudogu.gitops.utils.DockerImageParser']>
-<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+<#if config.registry.createImagePullSecrets == true>
 imagePullSecrets:
   - name: proxy-registry
 

--- a/applications/cluster-resources/ingress-nginx-helm-values.ftl.yaml
+++ b/applications/cluster-resources/ingress-nginx-helm-values.ftl.yaml
@@ -1,4 +1,19 @@
+<#assign DockerImageParser=statics['com.cloudogu.gitops.utils.DockerImageParser']>
+<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+imagePullSecrets:
+  - name: proxy-registry
+
+</#if>
 controller:
+<#if config.features.ingressNginx.helm.image?has_content>
+  <#assign imageObject = DockerImageParser.parse(config.features.ingressNginx.helm.image)>
+  image:
+    repository: ${imageObject.registryAndRepositoryAsString}
+    tag: ${imageObject.tag}
+    # Changing the image will change digest, so don't use the default.
+    # A digest can also be appended to the tag
+    digest: null 
+</#if>
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
   watchIngressWithoutClass: true
@@ -14,7 +29,8 @@ controller:
     # https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     externalTrafficPolicy: Local
   replicaCount: 2
-<#if podResources == true>
+<#if config.application.podResources == true>
+
   resources:
     # Be generous to our Single Point of failure
     limits:
@@ -42,10 +58,10 @@ controller:
     # customize access log format to include requested hostname ($host)
     # https://github.com/kubernetes/ingress-nginx/blob/controller-v1.2.1/docs/user-guide/nginx-configuration/log-format.md
     log-format-upstream: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$host" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id'
-<#if monitoring.active == true>
+<#if config.features.monitoring.active == true>
   metrics:
     enabled: true
     serviceMonitor:
       enabled: true
-      namespace: ${namePrefix}monitoring
+      namespace: ${config.application.namePrefix}monitoring
 </#if>

--- a/applications/cluster-resources/mailhog-helm-values.ftl.yaml
+++ b/applications/cluster-resources/mailhog-helm-values.ftl.yaml
@@ -1,9 +1,14 @@
-<#if image?has_content>
+<#assign DockerImageParser=statics['com.cloudogu.gitops.utils.DockerImageParser']>
+<#if config.features.mail.helm.image?has_content>
+<#assign imageObject = DockerImageParser.parse(config.features.mail.helm.image)>
 image:
-  repository: ${image?split(":")[0]}
-  <#if image?contains(":")>
-  tag: ${image?split(":")[1]}
-  </#if>
+  repository: ${imageObject.registryAndRepositoryAsString}
+<#if imageObject.tag?has_content>  tag: ${imageObject.tag}</#if>
+</#if>
+
+<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+imagePullSecrets: 
+ - name: proxy-registry
 </#if>
 
 service:

--- a/applications/cluster-resources/mailhog-helm-values.ftl.yaml
+++ b/applications/cluster-resources/mailhog-helm-values.ftl.yaml
@@ -5,12 +5,11 @@ image:
   repository: ${imageObject.registryAndRepositoryAsString}
 <#if imageObject.tag?has_content>  tag: ${imageObject.tag}</#if>
 </#if>
-
 <#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+
 imagePullSecrets: 
  - name: proxy-registry
 </#if>
-
 service:
   type: <#if isRemote>LoadBalancer<#else>NodePort</#if>
   port:

--- a/applications/cluster-resources/mailhog-helm-values.ftl.yaml
+++ b/applications/cluster-resources/mailhog-helm-values.ftl.yaml
@@ -5,7 +5,7 @@ image:
   repository: ${imageObject.registryAndRepositoryAsString}
 <#if imageObject.tag?has_content>  tag: ${imageObject.tag}</#if>
 </#if>
-<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+<#if config.registry.createImagePullSecrets == true>
 
 imagePullSecrets: 
  - name: proxy-registry

--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -4,14 +4,21 @@ crds:
   enabled: false
 </#if>
 
-<#if namespaceIsolation == true>
+<#if namespaceIsolation == true || config.registry.createImagePullSecrets == true>
 global:
+  <#if config.registry.createImagePullSecrets == true>
+  imagePullSecrets:
+    - name: proxy-registry
+  </#if>
+<#if namespaceIsolation == true>
+
   rbac:
     # Avoids creation of ClusterRole, which do not need here
     create: false
 kubeApiServer:
   # Don't scrape ApiServer to avoid 403 in prometheus targets due to lacking RBAC in isolated mode
   enabled: false
+</#if>
 </#if>
 
 # Note that many things are disabled here, because we want to start small, especially in airgapped envs where each image

--- a/applications/cluster-resources/secrets/external-secrets/values.ftl.yaml
+++ b/applications/cluster-resources/secrets/external-secrets/values.ftl.yaml
@@ -29,7 +29,7 @@ resources:
     memory: 40Mi
     cpu: 50m
 </#if>
-<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+<#if config.registry.createImagePullSecrets  == true>
 imagePullSecrets:
   - name: proxy-registry
 </#if>
@@ -45,7 +45,7 @@ certController:
   image:
     repository: ${certControllerimageObject.registryAndRepositoryAsString}
     tag: ${certControllerimageObject.tag}
-  <#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+  <#if config.registry.createImagePullSecrets == true>
   imagePullSecrets:
     - name: proxy-registry
   </#if>
@@ -56,7 +56,7 @@ webhook:
   image:
     repository: ${webhookImageObject.registryAndRepositoryAsString}
     tag: ${webhookImageObject.tag}
-  <#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+  <#if config.registry.createImagePullSecrets == true>
   imagePullSecrets:
     - name: proxy-registry
   </#if>

--- a/applications/cluster-resources/secrets/external-secrets/values.ftl.yaml
+++ b/applications/cluster-resources/secrets/external-secrets/values.ftl.yaml
@@ -1,8 +1,8 @@
-<#if skipCrds == true>
+<#assign DockerImageParser=statics['com.cloudogu.gitops.utils.DockerImageParser']>
+<#if config.application.skipCrds == true>
 installCRDs: false
 </#if>
-
-<#if podResources == true>
+<#if config.application.podResources == true>
 certController:
   resources:
     limits:
@@ -20,7 +20,7 @@ webhook:
     requests:
       memory: 25Mi
       cpu: 50m
-
+      
 resources:
   limits:
     memory: 80Mi
@@ -28,4 +28,36 @@ resources:
   requests:
     memory: 40Mi
     cpu: 50m
+</#if>
+<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+imagePullSecrets:
+  - name: proxy-registry
+</#if>
+<#if config.features.secrets.externalSecrets.helm.image?has_content>
+<#assign imageObject = DockerImageParser.parse(config.features.secrets.externalSecrets.helm.image)>
+image:
+  repository: ${imageObject.registryAndRepositoryAsString}
+  tag: ${imageObject.tag}
+</#if>
+<#if config.features.secrets.externalSecrets.helm.certControllerImage?has_content>
+<#assign certControllerimageObject = DockerImageParser.parse(config.features.secrets.externalSecrets.helm.certControllerImage)>
+certController:
+  image:
+    repository: ${certControllerimageObject.registryAndRepositoryAsString}
+    tag: ${certControllerimageObject.tag}
+  <#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+  imagePullSecrets:
+    - name: proxy-registry
+  </#if>
+</#if>
+<#if config.features.secrets.externalSecrets.helm.webhookImage?has_content>
+<#assign webhookImageObject = DockerImageParser.parse(config.features.secrets.externalSecrets.helm.webhookImage)>
+webhook:
+  image:
+    repository: ${webhookImageObject.registryAndRepositoryAsString}
+    tag: ${webhookImageObject.tag}
+  <#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+  imagePullSecrets:
+    - name: proxy-registry
+  </#if>
 </#if>

--- a/applications/cluster-resources/secrets/vault/values.ftl.yaml
+++ b/applications/cluster-resources/secrets/vault/values.ftl.yaml
@@ -10,7 +10,7 @@ ui:
 </#if>
 injector: 
   enabled: false
-<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+<#if config.registry.createImagePullSecrets == true>
 global:
   imagePullSecrets:
   - name: proxy-registry
@@ -26,11 +26,11 @@ server:
       repository: ${imageObject.registryAndRepositoryAsString}
       tag: ${imageObject.tag}
 </#if>
-<#if url?has_content>
+<#if host?has_content>
   ingress:
     enabled: true
     hosts:
-      - host: ${url.host}
+      - host: ${host}
 </#if>
 
 <#if config.application.podResources == true>

--- a/applications/cluster-resources/secrets/vault/values.ftl.yaml
+++ b/applications/cluster-resources/secrets/vault/values.ftl.yaml
@@ -1,0 +1,44 @@
+<#assign DockerImageParser=statics['com.cloudogu.gitops.utils.DockerImageParser']>
+ui: 
+  enabled: true
+  externalPort: 80
+<#if config.application.remote>
+  serviceType: "LoadBalancer"
+<#else>
+  serviceType: NodePort
+  serviceNodePort: 8200
+</#if>
+injector: 
+  enabled: false
+<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+global:
+  imagePullSecrets:
+  - name: proxy-registry
+</#if>
+<#if config.features.secrets.vault.helm.image?has_content 
+  || url?has_content 
+  || config.application.podResources == true>
+server:
+</#if>
+<#if config.features.secrets.vault.helm.image?has_content>
+<#assign imageObject = DockerImageParser.parse(config.features.secrets.vault.helm.image)>
+  image:
+      repository: ${imageObject.registryAndRepositoryAsString}
+      tag: ${imageObject.tag}
+</#if>
+<#if url?has_content>
+  ingress:
+    enabled: true
+    hosts:
+      - host: ${url.host}
+</#if>
+
+<#if config.application.podResources == true>
+  resources:
+      limits:
+        memory: 200Mi
+        cpu: 500m
+      requests:
+        memory: 100Mi
+        cpu: 50m
+</#if>

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -198,6 +198,10 @@
                   "type" : "string",
                   "description" : "Name of the Helm chart"
                 },
+                "image" : {
+                  "type" : "string",
+                  "description" : "The image of the Helm chart to be installed"
+                },
                 "repoURL" : {
                   "type" : "string",
                   "description" : "Repository url from which the Helm chart should be obtained"
@@ -211,8 +215,8 @@
                   "description" : "The version of the Helm chart to be installed"
                 }
               },
-              "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors.",
-              "additionalProperties" : false
+              "additionalProperties" : false,
+              "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors."
             }
           },
           "additionalProperties" : false,
@@ -507,7 +511,7 @@
       "properties" : {
         "createImagePullSecrets" : {
           "type" : "boolean",
-          "description" : "Create image pull secrets for registry and proxy-registry for all GOP namespaces and helm charts. Use this if your cluster is not auto-provisioned with credentials for your private registries or if you configure individual helm images to be pulled from the proxy-registry that requires authentication."
+          "description" : "Create image pull secrets for registry and proxy-registry for all GOP namespaces and helm charts. Uses proxy-username, read-only-username or registry-username (in this order).  Use this if your cluster is not auto-provisioned with credentials for your private registries or if you configure individual helm images to be pulled from the proxy-registry that requires authentication."
         },
         "helm" : {
           "$ref" : "#/$defs/HelmConfig"

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -270,7 +270,7 @@
             }
           },
           "additionalProperties" : false,
-          "description" : "Config parameters for the internal Mail Server"
+          "description" : "Config parameters for mail servers"
         },
         "monitoring" : {
           "type" : "object",
@@ -505,6 +505,10 @@
     "registry" : {
       "type" : "object",
       "properties" : {
+        "createImagePullSecrets" : {
+          "type" : "boolean",
+          "description" : "Create image pull secrets for registry and proxy-registry for all GOP namespaces and helm charts. Use this if your cluster is not auto-provisioned with credentials for your private registries or if you configure individual helm images to be pulled from the proxy-registry that requires authentication."
+        },
         "helm" : {
           "$ref" : "#/$defs/HelmConfig"
         },
@@ -522,19 +526,27 @@
         },
         "proxyPassword" : {
           "type" : "string",
-          "description" : "Use with registry-proxy-url, added to Jenkins as credentials."
+          "description" : "Use with registry-proxy-url, added to Jenkins as credentials and created as pull secrets, when create-image-pull-secrets is set."
         },
         "proxyUrl" : {
           "type" : "string",
-          "description" : "The url of your proxy-registry. Used in pipelines to authorize pull base images. Use in conjunction with petclinic base image."
+          "description" : "The url of your proxy-registry. Used in pipelines to authorize pull base images. Use in conjunction with petclinic base image. Used in helm charts when create-image-pull-secrets is set. Use in conjunction with helm.*image fields."
         },
         "proxyUsername" : {
           "type" : "string",
-          "description" : "Use with registry-proxy-url, added to Jenkins as credentials."
+          "description" : "Use with registry-proxy-url, added to Jenkins as credentials and created as pull secrets, when create-image-pull-secrets is set."
+        },
+        "readOnlyPassword" : {
+          "type" : "string",
+          "description" : "Optional alternative password for registry-url with read-only permissions that is used when create-image-pull-secrets is set."
+        },
+        "readOnlyUsername" : {
+          "type" : "string",
+          "description" : "Optional alternative username for registry-url with read-only permissions that is used when create-image-pull-secrets is set."
         },
         "url" : {
           "type" : "string",
-          "description" : "The url of your external registry"
+          "description" : "The url of your external registry, used for pushing images"
         },
         "username" : {
           "type" : "string",

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -487,7 +487,7 @@ skopeo copy docker://quay.io/kiwigrid/k8s-sidecar:1.27.4 --dest-creds Proxy:Prox
 docker run --rm -t -u $(id -u)  \
    -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config  \
     --net=host  \
-    gitops-playground:dev \
+    gitops-playground:dev -x \
     --yes --argocd --ingress-nginx --base-url=http://localhost \
     --vault=dev --monitoring --mailhog \
     --create-image-pull-secrets \

--- a/exercises/broken-application/broken-application.ftl.yaml
+++ b/exercises/broken-application/broken-application.ftl.yaml
@@ -7,6 +7,10 @@ spec:
   selector:
     matchLabels:
       app: broken-application
+<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+  imagePullSecrets:
+    - name: proxy-registry
+</#if>
   template:
     metadata:
       labels:

--- a/exercises/broken-application/broken-application.ftl.yaml
+++ b/exercises/broken-application/broken-application.ftl.yaml
@@ -7,7 +7,7 @@ spec:
   selector:
     matchLabels:
       app: broken-application
-<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+<#if config.registry.createImagePullSecrets == true>
   imagePullSecrets:
     - name: proxy-registry
 </#if>

--- a/exercises/nginx-validation/k8s/values-shared.ftl.yaml
+++ b/exercises/nginx-validation/k8s/values-shared.ftl.yaml
@@ -4,7 +4,7 @@ image:
   repository: ${nginxImage.repository}
   tag: ${nginxImage.tag}
 </#if>
-<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+<#if config.registry.createImagePullSecrets == true>
 global:
   imagePullSecrets:
     - proxy-registry

--- a/exercises/nginx-validation/k8s/values-shared.ftl.yaml
+++ b/exercises/nginx-validation/k8s/values-shared.ftl.yaml
@@ -4,6 +4,11 @@ image:
   repository: ${nginxImage.repository}
   tag: ${nginxImage.tag}
 </#if>
+<#if config.registry.createImagePullSecrets?has_content && config.registry.twoRegistries?has_content>
+global:
+  imagePullSecrets:
+    - proxy-registry
+</#if>
 service:
   ports:
     http: 80

--- a/src/main/groovy/com/cloudogu/gitops/Feature.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/Feature.groovy
@@ -8,6 +8,11 @@ abstract class Feature {
     boolean install() {
         if (isEnabled()) {
             log.info("Installing Feature ${getClass().getSimpleName()}")
+            
+            if (this instanceof FeatureWithImage) {
+                (this as FeatureWithImage).createImagePullSecret()
+            }
+
             enable()
             return true
         } else {

--- a/src/main/groovy/com/cloudogu/gitops/FeatureWithImage.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/FeatureWithImage.groovy
@@ -12,12 +12,14 @@ trait FeatureWithImage {
     final Logger log = LoggerFactory.getLogger(this.class)
     
     void createImagePullSecret() {
-        if (config.registry['createImagePullSecrets'] && config.registry['twoRegistries']) {
+        if (config.registry['createImagePullSecrets']) {
             log.trace("Creating image pull secret 'proxy-registry' in namespace ${namespace}" as String)
+            String url = config.registry['proxyUrl'] ?: config.registry['url']
+            String user = config.registry['proxyUsername'] ?: config.registry['readOnlyUsername'] ?: config.registry['username']
+            String password = config.registry['proxyPassword'] ?: config.registry['readOnlyPassword'] ?: config.registry['password']
+            
             k8sClient.createNamespace(namespace)
-            k8sClient.createImagePullSecret('proxy-registry', namespace, config.registry['proxyUrl'] as String,
-                    config.registry['proxyUsername'] as String,
-                    config.registry['proxyPassword'] as String)
+            k8sClient.createImagePullSecret('proxy-registry', namespace, url, user, password)
         }
     }
     

--- a/src/main/groovy/com/cloudogu/gitops/FeatureWithImage.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/FeatureWithImage.groovy
@@ -1,0 +1,27 @@
+package com.cloudogu.gitops
+
+import com.cloudogu.gitops.utils.K8sClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * A feature that relies on container images running inside the kubernetes cluster.
+ */
+trait FeatureWithImage {
+
+    final Logger log = LoggerFactory.getLogger(this.class)
+    
+    void createImagePullSecret() {
+        if (config.registry['createImagePullSecrets'] && config.registry['twoRegistries']) {
+            log.trace("Creating image pull secret 'proxy-registry' in namespace ${namespace}" as String)
+            k8sClient.createNamespace(namespace)
+            k8sClient.createImagePullSecret('proxy-registry', namespace, config.registry['proxyUrl'] as String,
+                    config.registry['proxyUsername'] as String,
+                    config.registry['proxyPassword'] as String)
+        }
+    }
+    
+    abstract String getNamespace()
+    abstract K8sClient getK8sClient()
+    abstract Map getConfig()
+}

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -45,15 +45,19 @@ class GitopsPlaygroundCli  implements Runnable {
     private String registryUsername
     @Option(names = ['--registry-password'], description = REGISTRY_PASSWORD_DESCRIPTION)
     private String registryPassword
-    @Option(names = ['--registry-proxy-url'], description = 'The url of your external proxy-registry. Make sure to always use this with --registry-proxy-url')
+    @Option(names = ['--registry-proxy-url'], description = REGISTRY_PROXY_URL_DESCRIPTION)
     private String registryProxyUrl
-    @Option(names = ['--registry-proxy-path'], description = 'Optional when --registry-proxy-url is set')
-    private String registryProxyPath
-    @Option(names = ['--registry-proxy-username'], description = 'Optional when --registry-proxy-url is set')
+    @Option(names = ['--registry-proxy-username'], description = REGISTRY_PROXY_USERNAME_DESCRIPTION)
     private String registryProxyUsername
-    @Option(names = ['--registry-proxy-password'], description = 'Optional when --registry-proxy-url is set')
+    @Option(names = ['--registry-proxy-password'], description = REGISTRY_PROXY_PASSWORD_DESCRIPTION)
     private String registryProxyPassword
-
+    @Option(names = ['--registry-username-read-only'], description = REGISTRY_USERNAME_RO_DESCRIPTION)
+    private String registryUsernameReadOnly
+    @Option(names = ['--registry-password-read-only'], description = REGISTRY_PASSWORD_RO_DESCRIPTION)
+    private String registryPasswordReadOnly
+    @Option(names = ['--create-image-pull-secrets'], description = REGISTRY_CREATE_IMAGE_PULL_SECRETS_DESCRIPTION)
+    private Boolean createImagePullSecrets
+    
     // args group jenkins
     @Option(names = ['--jenkins-url'], description = JENKINS_URL_DESCRIPTION)
     private String jenkinsUrl
@@ -155,6 +159,8 @@ class GitopsPlaygroundCli  implements Runnable {
     private String mailhogUrl
     @Option(names = ['--mailhog', '--mail'], description = MAILHOG_ENABLE_DESCRIPTION, scope = CommandLine.ScopeType.INHERIT)
     private Boolean mailhog
+    @Option(names = ['--mailhog-image'], description = HELM_CONFIG_IMAGE_DESCRIPTION)
+    private String mailhogImage
 
     // condition check dependent parameters of external Mailserver
     @Option(names = ['--smtp-address'], description = SMTP_ADDRESS_DESCRIPTION)
@@ -384,9 +390,11 @@ class GitopsPlaygroundCli  implements Runnable {
                         username    : registryUsername,
                         password    : registryPassword,
                         proxyUrl         : registryProxyUrl,
-                        proxyPath        : registryProxyPath,
                         proxyUsername    : registryProxyUsername,
                         proxyPassword    : registryProxyPassword,
+                        readOnlyUsername    : registryUsernameReadOnly,
+                        readOnlyPassword    : registryPasswordReadOnly,
+                        createImagePullSecrets: createImagePullSecrets
                 ],
                 jenkins    : [
                         url     : jenkinsUrl,
@@ -445,7 +453,10 @@ class GitopsPlaygroundCli  implements Runnable {
                                 smtpAddress : smtpAddress,
                                 smtpPort : smtpPort,
                                 smtpUser : smtpUser,
-                                smtpPassword : smtpPassword
+                                smtpPassword : smtpPassword,
+                                helm      : [
+                                        image: mailhogImage
+                                        ]
                         ],
                         exampleApps: [
                                 petclinic: [

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -224,7 +224,8 @@ class GitopsPlaygroundCli  implements Runnable {
     // args Ingress-Class
     @Option(names = ['--ingress-nginx'], description = INGRESS_NGINX_ENABLE_DESCRIPTION)
     private Boolean ingressNginx
-
+    @Option(names = ['--ingress-nginx-image'], description = HELM_CONFIG_IMAGE_DESCRIPTION)
+    private String ingressNginxImage
 
     @Override
     void run() {
@@ -497,6 +498,9 @@ class GitopsPlaygroundCli  implements Runnable {
                         ],
                         ingressNginx: [
                                active: ingressNginx,
+                               helm      : [
+                                       image: ingressNginxImage
+                               ]
                         ],
 
                 ]

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScripted.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScripted.groovy
@@ -113,6 +113,7 @@ class GitopsPlaygroundCliMainScripted {
                         new Jenkins(config, executor, fileSystemUtils, new GlobalPropertyManager(jenkinsApiClient),
                                 new JobManager(jenkinsApiClient), new UserManager(jenkinsApiClient),
                                 new PrometheusConfigurator(jenkinsApiClient)),
+                        new Content(config,k8sClient),
                         new ArgoCD(config, k8sClient, helmClient, fileSystemUtils, scmmRepoProvider),
                         new IngressNginx(config, fileSystemUtils, deployer, k8sClient, airGappedUtils),
                         new Mailhog(config, fileSystemUtils, deployer, k8sClient, airGappedUtils),

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -222,7 +222,8 @@ class ApplicationConfigurator {
                             helm  : [
                                     chart: 'ingress-nginx',
                                     repoURL: 'https://kubernetes.github.io/ingress-nginx',
-                                    version: '4.9.1',
+                                    version: '4.11.2',
+                                    image: '',
                                     values: [:]
                              ],
                     ],

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -43,6 +43,9 @@ class ApplicationConfigurator {
                     proxyUrl         : '',
                     proxyUsername    : '',
                     proxyPassword    : '',
+                    readOnlyUsername : '',
+                    readOnlyPassword : '',
+                    createImagePullSecrets: false,
                     helm  : [
                             chart  : 'docker-registry',
                             repoURL: 'https://helm.twun.io',
@@ -314,6 +317,14 @@ class ApplicationConfigurator {
                Allow overriding the port, in case multiple playground instance run on a single host in different 
                k3d clusters. */
             newConfig.registry['url'] = "localhost:${newConfig.registry['internalPort']}"
+        }
+        
+        if (newConfig.registry['createImagePullSecrets']) {
+            String username = newConfig.registry['readOnlyUsername'] ?: newConfig.registry['username']
+            String password = newConfig.registry['readOnlyPassword'] ?: newConfig.registry['password']
+            if (!username || !password) {
+                throw new RuntimeException("createImagePullSecrets needs to be used with either registry username and password or the readOnly variants")
+            }
         }
     }
 

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -9,14 +9,18 @@ interface ConfigConstants {
     // group registry
     String REGISTRY_DESCRIPTION = 'Config parameters for Registry'
     String REGISTRY_INTERNAL_PORT_DESCRIPTION = 'Port of registry registry. Ignored when a registry*url params are set'
-    String REGISTRY_URL_DESCRIPTION = 'The url of your external registry'
+    String REGISTRY_URL_DESCRIPTION = 'The url of your external registry, used for pushing images'
     String REGISTRY_PATH_DESCRIPTION = 'Optional when registry-url is set'
     String REGISTRY_USERNAME_DESCRIPTION = 'Optional when registry-url is set'
     String REGISTRY_PASSWORD_DESCRIPTION = 'Optional when registry-url is set'
 
-    String REGISTRY_PROXY_URL_DESCRIPTION = 'The url of your proxy-registry. Used in pipelines to authorize pull base images. Use in conjunction with petclinic base image.'
-    String REGISTRY_PROXY_USERNAME_DESCRIPTION = 'Use with registry-proxy-url, added to Jenkins as credentials.'
-    String REGISTRY_PROXY_PASSWORD_DESCRIPTION = 'Use with registry-proxy-url, added to Jenkins as credentials.'
+    String REGISTRY_PROXY_URL_DESCRIPTION = 'The url of your proxy-registry. Used in pipelines to authorize pull base images. Use in conjunction with petclinic base image. Used in helm charts when create-image-pull-secrets is set. Use in conjunction with helm.*image fields.'
+    String REGISTRY_PROXY_USERNAME_DESCRIPTION = 'Use with registry-proxy-url, added to Jenkins as credentials and created as pull secrets, when create-image-pull-secrets is set.'
+    String REGISTRY_PROXY_PASSWORD_DESCRIPTION = 'Use with registry-proxy-url, added to Jenkins as credentials and created as pull secrets, when create-image-pull-secrets is set.'
+    
+    String REGISTRY_USERNAME_RO_DESCRIPTION = 'Optional alternative username for registry-url with read-only permissions that is used when create-image-pull-secrets is set.'
+    String REGISTRY_PASSWORD_RO_DESCRIPTION = 'Optional alternative password for registry-url with read-only permissions that is used when create-image-pull-secrets is set.'
+    String REGISTRY_CREATE_IMAGE_PULL_SECRETS_DESCRIPTION = 'Create image pull secrets for registry and proxy-registry for all GOP namespaces and helm charts. Uses proxy-username, read-only-username or registry-username (in this order).  Use this if your cluster is not auto-provisioned with credentials for your private registries or if you configure individual helm images to be pulled from the proxy-registry that requires authentication.'
 
     String FEATURES_DESCRIPTION = 'Config parameters for features or tools'
     
@@ -90,7 +94,7 @@ interface ConfigConstants {
     String VAULT_ENABLE_DESCRIPTION = "Installs Hashicorp vault and the external secrets operator. Possible values: dev, prod."
     String VAULT_URL_DESCRIPTION = 'Sets url for vault ui'
 
-    String MAILHOG_DESCRIPTION = 'Config parameters for the internal Mail Server'
+    String MAIL_DESCRIPTION = 'Config parameters for mail servers'
     String MAILHOG_URL_DESCRIPTION = 'Sets url for MailHog'
     String MAILHOG_ENABLE_DESCRIPTION = 'Installs MailHog as Mail server.'
 

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -334,7 +334,12 @@ class Schema {
         @JsonPropertyDescription(INGRESS_NGINX_ENABLE_DESCRIPTION)
         boolean active = false
 
-        HelmConfigWithValues helm
+        @JsonPropertyDescription(HELM_CONFIG_DESCRIPTION)
+        IngressNginxHelmSchema helm
+        static class IngressNginxHelmSchema extends HelmConfigWithValues {
+            @JsonPropertyDescription(HELM_CONFIG_IMAGE_DESCRIPTION)
+            String image = ""
+        }
     }
 
     static class ExampleAppsSchema {

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -1,11 +1,10 @@
 //file:noinspection unused
-package com.cloudogu.gitops.config.schema 
+package com.cloudogu.gitops.config.schema
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 
-import static com.cloudogu.gitops.config.ConfigConstants.*
-
+import static com.cloudogu.gitops.config.ConfigConstants.* 
 /**
  * The schema for the configuration file.
  * It is used to validate the passed yaml file.
@@ -70,6 +69,13 @@ class Schema {
         String proxyUsername = ""
         @JsonPropertyDescription(REGISTRY_PROXY_PASSWORD_DESCRIPTION)
         String proxyPassword = ""
+        // Alternative set of credentials for url, used only for image pull secrets
+        @JsonPropertyDescription(REGISTRY_USERNAME_RO_DESCRIPTION)
+        String readOnlyUsername
+        @JsonPropertyDescription(REGISTRY_PASSWORD_RO_DESCRIPTION)
+        String readOnlyPassword
+        @JsonPropertyDescription(REGISTRY_CREATE_IMAGE_PULL_SECRETS_DESCRIPTION)
+        Boolean createImagePullSecrets
 
         HelmConfig helm
     }
@@ -215,7 +221,7 @@ class Schema {
     static class FeaturesSchema {
         @JsonPropertyDescription(ARGOCD_DESCRIPTION)
         ArgoCDSchema argocd
-        @JsonPropertyDescription(MAILHOG_DESCRIPTION)
+        @JsonPropertyDescription(MAIL_DESCRIPTION)
         MailSchema mail
         @JsonPropertyDescription(MONITORING_DESCRIPTION)
         MonitoringSchema monitoring

--- a/src/main/groovy/com/cloudogu/gitops/features/Content.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Content.groovy
@@ -1,0 +1,61 @@
+package com.cloudogu.gitops.features
+
+import com.cloudogu.gitops.Feature
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.utils.K8sClient
+import groovy.util.logging.Slf4j
+import io.micronaut.core.annotation.Order
+import jakarta.inject.Singleton
+
+@Slf4j
+@Singleton
+@Order(80)
+class Content extends Feature {
+
+    Map config
+    K8sClient k8sClient
+    
+    Content(
+            Configuration config,
+            K8sClient k8sClient
+    ) {
+        this.config = config.getConfig()
+        this.k8sClient = k8sClient
+    }
+
+
+    @Override
+    boolean isEnabled() {
+        return true // for now always on. Once we refactor from Argo CD class we add a param to enable
+    }
+
+    @Override
+    void enable() {
+        if (config.registry['createImagePullSecrets']) {
+            String registryUsername = config.registry['readOnlyUsername'] ?: config.registry['username']
+            String registryPassword = config.registry['readOnlyPassword'] ?: config.registry['password']
+
+            // Name prefix is added by k8sClient
+            List exampleAppNamespaces = [ "example-apps-staging", "example-apps-production"]
+            exampleAppNamespaces.each {
+                def namespace = it as String
+                def registrySecretName = 'registry'
+
+                k8sClient.createNamespace(it)
+                        
+                k8sClient.createImagePullSecret(registrySecretName, namespace,
+                        config.registry['url'] as String /* Only domain matters, path would be ignored */,
+                        registryUsername, registryPassword)
+
+                k8sClient.patch('serviceaccount', 'default', namespace,
+                        [ imagePullSecrets: [ [name: registrySecretName] ]])
+
+                if (config.registry['twoRegistries']) {
+                    k8sClient.createImagePullSecret('proxy-registry', namespace,
+                            config.registry['proxyUrl'] as String, config.registry['proxyUsername'] as String,
+                            config.registry['proxyPassword'] as String)
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -15,7 +15,7 @@ import jakarta.inject.Singleton
 
 @Slf4j
 @Singleton
-@Order(90)
+@Order(70)
 class Jenkins extends Feature {
 
     private Map config

--- a/src/main/groovy/com/cloudogu/gitops/features/Registry.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Registry.groovy
@@ -45,34 +45,65 @@ class Registry extends Feature {
 
     @Override
     boolean isEnabled() {
-        return config.registry['internal']
+        return true // For now, we either deploy an internal or configure an external instance
     }
 
     @Override
     void enable() {
-
-        def helmConfig = config['registry']['helm']
         
+        if (config.registry['internal']) {
+            deployRegistry()
+        }
+        
+        if (config.registry['createImagePullSecrets']) {
+            String registryUsername = config.registry['readOnlyUsername'] ?: config.registry['username']
+            String registryPassword = config.registry['readOnlyPassword'] ?: config.registry['password']
+            
+            // Name prefix is added by k8sClient
+            List exampleAppNamespaces = [ "example-apps-staging", "example-apps-production"]
+            exampleAppNamespaces.each {
+                def namespace = it as String
+                def registrySecretName = 'registry'
+                k8sClient.createImagePullSecret(registrySecretName, namespace, 
+                        config.registry['url'] as String/* Only domain matters, path would be ignored */,
+                        registryUsername, registryPassword)
+                
+                k8sClient.patch('serviceaccount', 'default', namespace,
+                        [ imagePullSecrets: [ [name: registrySecretName] ]])
+
+                if (config.registry['twoRegistries']) {
+                    k8sClient.createImagePullSecret('proxy-registry', namespace,
+                            config.registry['proxyUrl'] as String, config.registry['proxyUsername'] as String,
+                            config.registry['proxyPassword'] as String)
+                }
+            }
+        }
+
+    }
+
+    private void deployRegistry() {
+        def helmConfig = config['registry']['helm']
+
         Map yaml = [
                 service: [
                         nodePort: ApplicationConfigurator.DEFAULT_REGISTRY_PORT,
-                        type: 'NodePort'
+                        type    : 'NodePort'
                 ]
         ]
         log.trace("Helm yaml to be applied: ${yaml}")
         fileSystemUtils.writeYaml(yaml, tmpHelmValues.toFile())
-        
+
         if (config['registry']['internalPort'] != ApplicationConfigurator.DEFAULT_REGISTRY_PORT) {
             /* Add additional node port
                30000 is needed as a static by docker via port mapping of k3d, e.g. 32769 -> 30000 on server-0 container
                See "-p 30000" in init-cluster.sh
                e.g 32769 is needed so the kubelet can access the image inside the server-0 container
              */
-            k8sClient.createServiceNodePort('docker-registry-internal-port', 
+            k8sClient.createServiceNodePort('docker-registry-internal-port',
                     CONTAINER_PORT, config['registry']['internalPort'] as String,
                     'default')
         }
-        
+
         deployer.deployFeature(
                 helmConfig['repoURL'] as String,
                 'registry',
@@ -82,6 +113,5 @@ class Registry extends Feature {
                 'docker-registry',
                 tmpHelmValues
         )
-
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/Registry.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Registry.groovy
@@ -15,7 +15,7 @@ import java.nio.file.Path
 
 @Slf4j
 @Singleton
-@Order(60)
+@Order(50)
 class Registry extends Feature {
 
     /**
@@ -45,65 +45,34 @@ class Registry extends Feature {
 
     @Override
     boolean isEnabled() {
-        return true // For now, we either deploy an internal or configure an external instance
+        return config.registry['internal']
     }
 
     @Override
     void enable() {
-        
-        if (config.registry['internal']) {
-            deployRegistry()
-        }
-        
-        if (config.registry['createImagePullSecrets']) {
-            String registryUsername = config.registry['readOnlyUsername'] ?: config.registry['username']
-            String registryPassword = config.registry['readOnlyPassword'] ?: config.registry['password']
-            
-            // Name prefix is added by k8sClient
-            List exampleAppNamespaces = [ "example-apps-staging", "example-apps-production"]
-            exampleAppNamespaces.each {
-                def namespace = it as String
-                def registrySecretName = 'registry'
-                k8sClient.createImagePullSecret(registrySecretName, namespace, 
-                        config.registry['url'] as String/* Only domain matters, path would be ignored */,
-                        registryUsername, registryPassword)
-                
-                k8sClient.patch('serviceaccount', 'default', namespace,
-                        [ imagePullSecrets: [ [name: registrySecretName] ]])
 
-                if (config.registry['twoRegistries']) {
-                    k8sClient.createImagePullSecret('proxy-registry', namespace,
-                            config.registry['proxyUrl'] as String, config.registry['proxyUsername'] as String,
-                            config.registry['proxyPassword'] as String)
-                }
-            }
-        }
-
-    }
-
-    private void deployRegistry() {
         def helmConfig = config['registry']['helm']
-
+        
         Map yaml = [
                 service: [
                         nodePort: ApplicationConfigurator.DEFAULT_REGISTRY_PORT,
-                        type    : 'NodePort'
+                        type: 'NodePort'
                 ]
         ]
         log.trace("Helm yaml to be applied: ${yaml}")
         fileSystemUtils.writeYaml(yaml, tmpHelmValues.toFile())
-
+        
         if (config['registry']['internalPort'] != ApplicationConfigurator.DEFAULT_REGISTRY_PORT) {
             /* Add additional node port
                30000 is needed as a static by docker via port mapping of k3d, e.g. 32769 -> 30000 on server-0 container
                See "-p 30000" in init-cluster.sh
                e.g 32769 is needed so the kubelet can access the image inside the server-0 container
              */
-            k8sClient.createServiceNodePort('docker-registry-internal-port',
+            k8sClient.createServiceNodePort('docker-registry-internal-port', 
                     CONTAINER_PORT, config['registry']['internalPort'] as String,
                     'default')
         }
-
+        
         deployer.deployFeature(
                 helmConfig['repoURL'] as String,
                 'registry',
@@ -113,5 +82,6 @@ class Registry extends Feature {
                 'docker-registry',
                 tmpHelmValues
         )
+
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
@@ -13,7 +13,7 @@ import jakarta.inject.Singleton
 
 @Slf4j
 @Singleton
-@Order(80)
+@Order(60)
 class ScmManager extends Feature {
 
     static final String HELM_VALUES_PATH = "scm-manager/values.ftl.yaml"

--- a/src/main/groovy/com/cloudogu/gitops/features/Vault.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Vault.groovy
@@ -57,7 +57,7 @@ class Vault extends Feature implements FeatureWithImage {
 
         def yaml =  new YamlSlurper().parseText(
                 new TemplatingEngine().template(new File(HELM_VALUES_PATH), [
-                url: config.features['secrets']['vault']['url'] ? new URL(config.features['secrets']['vault']['url'] as String) : null,
+                host: config.features['secrets']['vault']['url'] ? new URL(config.features['secrets']['vault']['url'] as String).host : "",
                 config: config,
                 // Allow for using static classes inside the templates
                 statics: new DefaultObjectWrapperBuilder(freemarker.template.Configuration.VERSION_2_3_32).build().getStaticModels()

--- a/src/main/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategy.groovy
@@ -7,6 +7,7 @@ import com.cloudogu.gitops.utils.FileSystemUtils
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import groovy.util.logging.Slf4j
+import groovy.yaml.YamlSlurper
 import jakarta.inject.Singleton
 
 import java.nio.file.Path
@@ -39,7 +40,7 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
         clusterResourcesRepo.cloneRepo()
 
         // Inline values from tmpHelmValues file into ArgoCD Application YAML
-        def inlineValues = helmValuesPath.toFile().text
+        def inlineValues = new YamlSlurper().parse(helmValuesPath.toFile())
 
         // Write chart, repoURL and version into a ArgoCD Application YAML
 
@@ -64,7 +65,7 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
                                         targetRevision                     : version,
                                         helm                               : [
                                                 releaseName: releaseName,
-                                                values: inlineValues
+                                                valuesObject: inlineValues
                                         ],
                                 ],
                         ],

--- a/src/main/groovy/com/cloudogu/gitops/utils/DockerImageParser.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/DockerImageParser.groovy
@@ -40,6 +40,8 @@ class DockerImageParser {
 
     static Image parse(String image) {
         if (!image.contains(":")) {
+            // Most helm charts expect an explicit image tag, otherwise they use the version set by the app.
+            // This will likely be unexpected so force using a tag
             throw new RuntimeException("Cannot set image '$image' due to missing tag. Must be the format '\$repository:\$tag'")
         }
 

--- a/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
@@ -76,7 +76,7 @@ class K8sClient {
 
         commandExecutor.execute(command1, APPLY_FROM_STDIN)
     }
-
+    
     /**
      * Idempotent create, i.e. overwrites if exists.
      */
@@ -87,6 +87,21 @@ class K8sClient {
                 .dryRunOutputYaml()
                 .build()
         
+        commandExecutor.execute(command1, APPLY_FROM_STDIN)
+    }
+
+    /**
+     * Idempotent create, i.e. overwrites if exists.
+     */
+    void createImagePullSecret(String name, String namespace = '', String host, String user, String password) {
+        def command1 = kubectl( 'create', 'secret', 'docker-registry', name)
+                .namespace(namespace)
+                .mandatory('--docker-server', host)
+                .mandatory('--docker-username', user)
+                .mandatory('--docker-password', password)
+                .dryRunOutputYaml()
+                .build()
+
         commandExecutor.execute(command1, APPLY_FROM_STDIN)
     }
     
@@ -134,6 +149,7 @@ class K8sClient {
         // We're using a patch file here, instead of a patch JSON (--patch), because of quoting issues
         // ERROR c.c.gitops.utils.CommandExecutor - Stderr: error: unable to parse "'{\"stringData\":": yaml: found unexpected end of stream
         File patchYaml = File.createTempFile('gitops-playground-patch-yaml', '')
+        log.trace("Writing patch YAML: ${yaml}")
         fileSystemUtils.writeYaml(yaml, patchYaml)
 
         //  kubectl patch secret argocd-secret -p '{"stringData": { "admin.password": "'"${bcryptArgoCDPassword}"'"}}' || true

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationConfiguratorTest.groovy
@@ -174,6 +174,15 @@ class ApplicationConfiguratorTest {
                 'Either run inside the official container image or setting env var LOCAL_HELM_CHART_FOLDER=\'charts\' ' +
                 'after running \'scripts/downloadHelmCharts.sh\' from the repo')
     }
+
+    @Test
+    void 'Fails if createImagePullSecrets is used without secrets'() {
+        testConfig['registry']['createImagePullSecrets'] = true
+        def exception = shouldFail(RuntimeException) {
+            applicationConfigurator.setConfig(testConfig)
+        }
+        assertThat(exception.message).isEqualTo('createImagePullSecrets needs to be used with either registry username and password or the readOnly variants')
+    }
     
     @Test
     void 'Ignores empty localHemlChartFolder, if mirrorRepos is not set'() {

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
@@ -26,6 +26,6 @@ class ApplicationTest {
                 .getBean(Application)
         def features = application.features.collect { it.class.simpleName }
 
-        assertThat(features).isEqualTo(["Registry", "ScmManager", "Jenkins", "ArgoCD", "IngressNginx", "Mailhog", "PrometheusStack", "ExternalSecretsOperator", "Vault"])
+        assertThat(features).isEqualTo(["Registry", "ScmManager", "Jenkins", "Content", "ArgoCD", "IngressNginx", "Mailhog", "PrometheusStack", "ExternalSecretsOperator", "Vault"])
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/FeatureTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/FeatureTest.groovy
@@ -1,0 +1,49 @@
+package com.cloudogu.gitops
+
+import com.cloudogu.gitops.utils.K8sClient
+import com.cloudogu.gitops.utils.K8sClientForTest
+import org.junit.jupiter.api.Test 
+
+class FeatureTest {
+    Map config = [
+            registry: [
+                    createImagePullSecrets: false
+            ],
+            application: [
+                    namePrefix: "foo-"
+            ]
+    ]
+    K8sClientForTest k8sClient = new K8sClientForTest(config)
+
+    @Test
+    void 'Image pull secrets are create automatically'() {
+        config['registry']['createImagePullSecrets'] = true
+        config['registry']['twoRegistries'] = true
+        config['registry']['proxyUrl'] = 'proxy-url'
+        config['registry']['proxyUsername'] = 'proxy-user'
+        config['registry']['proxyPassword'] = 'proxy-pw'
+
+        Feature feature = new FeatureWithImageForTest()
+        feature.config = config
+        feature.k8sClient = k8sClient
+        feature.namespace = 'my-ns'
+
+        feature.install()
+        
+        k8sClient.commandExecutorForTest.assertExecuted(
+                'kubectl create secret docker-registry proxy-registry -n foo-my-ns' +
+                        ' --docker-server proxy-url --docker-username proxy-user --docker-password proxy-pw')
+    }
+
+    class FeatureWithImageForTest extends Feature implements FeatureWithImage {
+
+        String namespace
+        Map config
+        K8sClient k8sClient
+
+        @Override
+        boolean isEnabled() {
+            return true
+        }
+    }
+}

--- a/src/test/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScriptedTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScriptedTest.groovy
@@ -83,7 +83,7 @@ class GitopsPlaygroundCliMainScriptedTest {
                 .enableAnnotationInfo()
                 .scan().withCloseable { scanResult ->
             scanResult.getAllClasses().each { ClassInfo classInfo ->
-                if (classInfo.name.endsWith("Test")) {
+                if (classInfo.name.endsWith("Test") || classInfo.isAbstract()) {
                     return
                 }
 

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -307,6 +307,7 @@ features:
       version: "4.9.1"
       values:
         a: "b"
+      image: ""
   exampleApps:
     petclinic:
       baseDomain: "base-domain"

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -20,6 +20,9 @@ class ConfigToConfigFileConverterTest {
                         proxyUrl         : 'proxyUrl',
                         proxyUsername    : 'proxyUsername',
                         proxyPassword    : 'proxyPassword',
+                        readOnlyUsername: 'roUser',
+                        readOnlyPassword: 'roPw',
+                        createImagePullSecrets: true,
                         helm  : [
                                 chart  : 'docker-registry',
                                 repoURL: 'https://charts.helm.sh/stable',
@@ -183,6 +186,9 @@ registry:
   proxyUrl: "proxyUrl"
   proxyUsername: "proxyUsername"
   proxyPassword: "proxyPassword"
+  readOnlyUsername: "roUser"
+  readOnlyPassword: "roPw"
+  createImagePullSecrets: true
   helm:
     chart: "docker-registry"
     repoURL: "https://charts.helm.sh/stable"

--- a/src/test/groovy/com/cloudogu/gitops/features/ContentTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ContentTest.groovy
@@ -45,7 +45,7 @@ class ContentTest {
     }
 
     @Test
-    void 'deploys image pull secrets for proxy registry'() {
+    void 'deploys additional image pull secrets for proxy registry'() {
         config['registry']['createImagePullSecrets'] = true
         config['registry']['twoRegistries'] = true
         config['registry']['proxyUrl'] = 'proxy-url'

--- a/src/test/groovy/com/cloudogu/gitops/features/ContentTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ContentTest.groovy
@@ -1,0 +1,95 @@
+package com.cloudogu.gitops.features
+
+import com.cloudogu.gitops.config.Configuration
+import com.cloudogu.gitops.utils.K8sClientForTest
+import groovy.yaml.YamlSlurper
+import org.junit.jupiter.api.Test
+
+import static org.assertj.core.api.Assertions.assertThat 
+
+class ContentTest {
+
+    Map config = [
+            registry   : [
+                    url                   : 'reg-url',
+                    path                  : 'reg-path',
+                    username              : 'reg-user',
+                    password              : 'reg-pw',
+                    createImagePullSecrets: false,
+            ],
+            application: [
+                    namePrefix: "foo-",
+            ],
+    ]
+    K8sClientForTest k8sClient = new K8sClientForTest(config)
+
+
+    @Test
+    void 'deploys image pull secrets'() {
+        config['registry']['createImagePullSecrets'] = true
+
+        createContent().install()
+
+        assertRegistrySecrets('reg-user', 'reg-pw')
+    }
+
+    @Test
+    void 'deploys image pull secrets from read-only vars'() {
+        config['registry']['createImagePullSecrets'] = true
+        config['registry']['readOnlyUsername'] = 'other-user'
+        config['registry']['readOnlyPassword'] = 'other-pw'
+
+        createContent().install()
+
+        assertRegistrySecrets('other-user', 'other-pw')
+    }
+
+    @Test
+    void 'deploys image pull secrets for proxy registry'() {
+        config['registry']['createImagePullSecrets'] = true
+        config['registry']['twoRegistries'] = true
+        config['registry']['proxyUrl'] = 'proxy-url'
+        config['registry']['proxyUsername'] = 'proxy-user'
+        config['registry']['proxyPassword'] = 'proxy-pw'
+
+        createContent().install()
+
+        assertRegistrySecrets('reg-user', 'reg-pw')
+
+        k8sClient.commandExecutorForTest.assertExecuted('kubectl create namespace foo-example-apps-staging')
+        k8sClient.commandExecutorForTest.assertExecuted('kubectl create namespace foo-example-apps-production')
+        k8sClient.commandExecutorForTest.assertExecuted(
+                'kubectl create secret docker-registry proxy-registry -n foo-example-apps-staging' +
+                        ' --docker-server proxy-url --docker-username proxy-user --docker-password proxy-pw')
+        k8sClient.commandExecutorForTest.assertExecuted(
+                'kubectl create secret docker-registry proxy-registry -n foo-example-apps-production' +
+                        ' --docker-server proxy-url --docker-username proxy-user --docker-password proxy-pw')
+
+    }
+
+    private void assertRegistrySecrets(String regUser, String regPw) {
+        List expectedNamespaces = ["foo-example-apps-staging", "foo-example-apps-production"]
+        expectedNamespaces.each {
+
+            k8sClient.commandExecutorForTest.assertExecuted(
+                    "kubectl create secret docker-registry registry -n ${it}" +
+                            " --docker-server reg-url --docker-username $regUser --docker-password ${regPw}" +
+                            ' --dry-run=client -oyaml | kubectl apply -f-')
+
+            def patchCommand = k8sClient.commandExecutorForTest.assertExecuted(
+                    "kubectl patch serviceaccount default -n ${it}")
+            String patchFile = (patchCommand =~ /--patch-file=([\S]+)/)?.findResult { (it as List)[1] }
+            assertThat(parseActualYaml(new File(patchFile))['imagePullSecrets'] as List).hasSize(1)
+            assertThat((parseActualYaml(new File(patchFile))['imagePullSecrets'] as List)[0] as Map).containsEntry('name', 'registry')
+        }
+    }
+
+    private Content createContent() {
+        new Content(new Configuration(config), k8sClient)
+    }
+
+    private parseActualYaml(File pathToYamlFile) {
+        def ys = new YamlSlurper()
+        return ys.parse(pathToYamlFile)
+    }
+}

--- a/src/test/groovy/com/cloudogu/gitops/features/ExternalSecretsOperatorTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ExternalSecretsOperatorTest.groovy
@@ -159,7 +159,6 @@ class ExternalSecretsOperatorTest {
     @Test
     void 'deploys image pull secrets for proxy registry'() {
         config['registry']['createImagePullSecrets'] = true
-        config['registry']['twoRegistries'] = true
         config['registry']['proxyUrl'] = 'proxy-url'
         config['registry']['proxyUsername'] = 'proxy-user'
         config['registry']['proxyPassword'] = 'proxy-pw'

--- a/src/test/groovy/com/cloudogu/gitops/features/IngressNginxTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/IngressNginxTest.groovy
@@ -3,7 +3,6 @@ package com.cloudogu.gitops.features
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.features.deployment.DeploymentStrategy
 import com.cloudogu.gitops.utils.AirGappedUtils
-import com.cloudogu.gitops.utils.CommandExecutorForTest
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.cloudogu.gitops.utils.K8sClientForTest
 import groovy.yaml.YamlSlurper
@@ -52,7 +51,6 @@ class IngressNginxTest {
             ],
     ]
 
-    CommandExecutorForTest k8sCommandExecutor = new CommandExecutorForTest()
     Path temporaryYamlFile
     FileSystemUtils fileSystemUtils = new FileSystemUtils()
     DeploymentStrategy deploymentStrategy = mock(DeploymentStrategy)
@@ -169,7 +167,6 @@ class IngressNginxTest {
     @Test
     void 'deploys image pull secrets for proxy registry'() {
         config['registry']['createImagePullSecrets'] = true
-        config['registry']['twoRegistries'] = true
         config['registry']['proxyUrl'] = 'proxy-url'
         config['registry']['proxyUsername'] = 'proxy-user'
         config['registry']['proxyPassword'] = 'proxy-pw'

--- a/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
@@ -3,7 +3,6 @@ package com.cloudogu.gitops.features
 import com.cloudogu.gitops.config.Configuration
 import com.cloudogu.gitops.features.deployment.DeploymentStrategy
 import com.cloudogu.gitops.utils.AirGappedUtils
-import com.cloudogu.gitops.utils.CommandExecutorForTest
 import com.cloudogu.gitops.utils.FileSystemUtils
 import com.cloudogu.gitops.utils.K8sClientForTest
 import groovy.yaml.YamlSlurper
@@ -22,8 +21,7 @@ class MailhogTest {
 
     Map config = [
             registry   : [
-                    createImagePullSecret: false,
-                    twoRegistries        : false
+                    createImagePullSecrets: false,
             ],
             application: [
                     username    : 'abc',
@@ -53,7 +51,6 @@ class MailhogTest {
     DeploymentStrategy deploymentStrategy = mock(DeploymentStrategy)
     AirGappedUtils airGappedUtils = mock(AirGappedUtils)
     Path temporaryYamlFile = null
-    CommandExecutorForTest k8sCommandExecutor = new CommandExecutorForTest()
     FileSystemUtils fileSystemUtils = new FileSystemUtils()
     K8sClientForTest k8sClient = new K8sClientForTest(config)
 
@@ -200,7 +197,6 @@ class MailhogTest {
     @Test
     void 'deploys image pull secrets for proxy registry'() {
         config['registry']['createImagePullSecrets'] = true
-        config['registry']['twoRegistries'] = true
         config['registry']['proxyUrl'] = 'proxy-url'
         config['registry']['proxyUsername'] = 'proxy-user'
         config['registry']['proxyPassword'] = 'proxy-pw'

--- a/src/test/groovy/com/cloudogu/gitops/features/RegistryTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/RegistryTest.groovy
@@ -18,13 +18,14 @@ class RegistryTest {
 
     Map config = [
             registry   : [
-                    internal    : true,
-                    url         : '',
-                    path        : '',
-                    username    : '',
-                    password    : '',
-                    internalPort: ApplicationConfigurator.DEFAULT_REGISTRY_PORT,
-                    helm        : [
+                    internal              : true,
+                    url                   : 'reg-url',
+                    path                  : 'reg-path',
+                    username              : 'reg-user',
+                    password              : 'reg-pw',
+                    internalPort          : ApplicationConfigurator.DEFAULT_REGISTRY_PORT,
+                    createImagePullSecrets: false,
+                    helm                  : [
                             chart  : 'docker-registry',
                             repoURL: 'https://charts.helm.sh/stable',
                             version: '1.9.4'
@@ -40,7 +41,7 @@ class RegistryTest {
     File temporaryYamlFile
 
     @Test
-    void 'is disabled when external registry is configured'() {
+    void 'does not deploy internal registry, when external registry is configured'() {
         config.registry['internal'] = false
 
         createRegistry().install()
@@ -74,7 +75,66 @@ class RegistryTest {
 
         assertThat(k8sClient.commandExecutorForTest.actualCommands[0]).contains("--node-port $expectedNodePort")
     }
-    
+
+    @Test
+    void 'deploys image pull secrets'() {
+        config['registry']['createImagePullSecrets'] = true
+
+        createRegistry().install()
+
+        assertRegistrySecrets('reg-user', 'reg-pw')
+    }
+
+    @Test
+    void 'deploys image pull secrets from read-only vars'() {
+        config['registry']['createImagePullSecrets'] = true
+        config['registry']['readOnlyUsername'] = 'other-user'
+        config['registry']['readOnlyPassword'] = 'other-pw'
+
+        createRegistry().install()
+
+        assertRegistrySecrets('other-user', 'other-pw')
+
+    }
+
+    @Test
+    void 'deploys image pull secrets for proxy registry'() {
+        config['registry']['createImagePullSecrets'] = true
+        config['registry']['twoRegistries'] = true
+        config['registry']['proxyUrl'] = 'proxy-url'
+        config['registry']['proxyUsername'] = 'proxy-user'
+        config['registry']['proxyPassword'] = 'proxy-pw'
+
+        createRegistry().install()
+
+        assertRegistrySecrets('reg-user', 'reg-pw')
+
+        k8sClient.commandExecutorForTest.assertExecuted(
+                'kubectl create secret docker-registry proxy-registry -n foo-example-apps-staging' +
+                        ' --docker-server proxy-url --docker-username proxy-user --docker-password proxy-pw')
+        k8sClient.commandExecutorForTest.assertExecuted(
+                'kubectl create secret docker-registry proxy-registry -n foo-example-apps-production' +
+                        ' --docker-server proxy-url --docker-username proxy-user --docker-password proxy-pw')
+
+    }
+
+    private void assertRegistrySecrets(String regUser, String regPw) {
+        List expectedNamespaces = ["foo-example-apps-staging", "foo-example-apps-production"]
+        expectedNamespaces.each {
+
+            k8sClient.commandExecutorForTest.assertExecuted(
+                    "kubectl create secret docker-registry registry -n ${it}" +
+                            " --docker-server reg-url --docker-username $regUser --docker-password ${regPw}" +
+                            ' --dry-run=client -oyaml | kubectl apply -f-')
+
+            def patchCommand = k8sClient.commandExecutorForTest.assertExecuted(
+                    "kubectl patch serviceaccount default -n ${it}")
+            String patchFile = (patchCommand =~ /--patch-file=([\S]+)/)?.findResult { (it as List)[1] }
+            assertThat(parseActualYaml(new File(patchFile))['imagePullSecrets'] as List).hasSize(1)
+            assertThat((parseActualYaml(new File(patchFile))['imagePullSecrets'] as List)[0] as Map).containsEntry('name', 'registry')
+        }
+    }
+
     private Registry createRegistry() {
         // We use the real FileSystemUtils and not a mock to make sure file editing works as expected
 
@@ -89,8 +149,8 @@ class RegistryTest {
         }, k8sClient, new HelmStrategy(new Configuration(config), helmClient))
     }
 
-    private parseActualYaml() {
+    private parseActualYaml(File pathToYamlFile = temporaryYamlFile) {
         def ys = new YamlSlurper()
-        return ys.parse(temporaryYamlFile)
+        return ys.parse(pathToYamlFile)
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/features/VaultTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/VaultTest.groovy
@@ -232,7 +232,6 @@ class VaultTest {
     @Test
     void 'deploys image pull secrets for proxy registry'() {
         config['registry']['createImagePullSecrets'] = true
-        config['registry']['twoRegistries'] = true
         config['registry']['proxyUrl'] = 'proxy-url'
         config['registry']['proxyUsername'] = 'proxy-user'
         config['registry']['proxyPassword'] = 'proxy-pw'

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -59,7 +59,7 @@ class ArgoCDTest {
             images      : buildImages + [petclinic: 'petclinic-value'],
             registry    : [
                     twoRegistries: false,
-                    createImagePullSecrets : false
+                    createImagePullSecrets: false
             ],
             repositories: [
                     springBootHelmChart: [

--- a/src/test/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategyTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/deployment/ArgoCdApplicationStrategyTest.groovy
@@ -41,10 +41,9 @@ spec:
     targetRevision: "version"
     helm:
       releaseName: "releaseName"
-      values: |2
-
-        param1: value1
-        param2: value2
+      valuesObject:
+        param1: "value1"
+        param2: "value2"
   syncPolicy:
     automated:
       prune: true

--- a/src/test/groovy/com/cloudogu/gitops/utils/CommandExecutorForTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/CommandExecutorForTest.groovy
@@ -42,7 +42,8 @@ class CommandExecutorForTest extends CommandExecutor {
         def actualCommand = actualCommands.find {
             it.startsWith(commandStartsWith)
         }
-        assertThat(actualCommand).as("Expected command to have been executed, but was not: ${commandStartsWith}")
+        assertThat(actualCommand).as("Expected command to have been executed, but was not:\n${commandStartsWith}.\n" +
+                "Actual commands:\n${actualCommands.join('\n')}")
                 .isNotNull()
         return actualCommand
     }

--- a/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
@@ -74,6 +74,26 @@ class K8sClientTest {
                 "kubectl create secret generic my-secret --from-literal key1=value1 --dry-run=client -oyaml" +
                         " | kubectl apply -f-")
     }
+    
+    @Test
+    void 'Creates imagePullSecret without namespace'() {
+        k8sClient.createImagePullSecret('my-reg', 'host', 'user', 'pw')
+
+        assertThat(commandExecutor.actualCommands[0]).isEqualTo(
+                'kubectl create secret docker-registry my-reg' +
+                ' --docker-server host --docker-username user --docker-password pw' +
+                ' --dry-run=client -oyaml | kubectl apply -f-')
+    }
+    
+    @Test
+    void 'Creates imagePullSecret'() {
+        k8sClient.createImagePullSecret('my-reg', 'ns', 'host', 'user', 'pw')
+
+        assertThat(commandExecutor.actualCommands[0]).isEqualTo(
+                'kubectl create secret docker-registry my-reg -n foo-ns' +
+                ' --docker-server host --docker-username user --docker-password pw' +
+                ' --dry-run=client -oyaml | kubectl apply -f-')
+    }
 
     @Test
     void 'Creates no secret when literals are missing'() {


### PR DESCRIPTION
For all pods except Jenkins, SCMM, Registry, ArgoCD

We have different options for using them in airGapped envs: Cloudogu
Ecosystem and Argo CD Operator (WIP) and an external registry.

### Introduces new config/ CLI:
* `--create-image-pull-secrets`
* `--registry-username-read-only` and `--registry-password-read-only'`:  least privilege: if you don't want to use `--registry-username` and `-password` as pull secrets, that allow for *writing* to the registry. The cluster only needs to read.

### More or less unrelated changes:
* Introduces `Content` class, which we already know will in future hold example apps and exercises so they can be switched on and off separately. Also will improve maintenance of the huge ArgoCd.groovy monolith.
* missing image params and config options
* migrates some properties from pre-templating times from groovy to values (in Mailhog, Vault, External Secrets Operator)
* Changes Argo CD applications to use `valuesObject` instead of `values` (String). This improves visualization and simplifies debugging.

### How to test

See https://github.com/cloudogu/gitops-playground/blob/58fdd0/docs/developers.md#proper-test

After everything it built and deployed there should be 
* no degraded app in argocd
* no failing pods returned by `k get pods -A` 
* and this should only return `localhost:30000` pods:
```bash
$  kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" \
  | tr -s '[[:space:]]' '\n' | sort | uniq \
  | grep -v 'harbor\|jenkins\|scmm\|rancher\|argo\|redis\|dex'

localhost:30000/proxy/eso:latest
localhost:30000/proxy/grafana:latest
localhost:30000/proxy/ingress-nginx:latest
localhost:30000/proxy/k8s-sidecar:latest
localhost:30000/proxy/mailhog:latest
localhost:30000/proxy/nginx:latest
localhost:30000/proxy/prometheus-operator:latest
localhost:30000/proxy/vault:latest
```



