### PR TITLE
Upgrade k3d to 5.7.4

### DIFF
--- a/scripts/init-cluster.sh
+++ b/scripts/init-cluster.sh
@@ -2,7 +2,7 @@
 
 # See https://github.com/rancher/k3d/releases
 # This variable is also read in Jenkinsfile
-K3D_VERSION=5.6.0
+K3D_VERSION=5.7.4
 # When updating please also adapt in Dockerfile, vars.tf and ApplicationConfigurator.groovy
 K8S_VERSION=1.29.8
 K3S_VERSION="rancher/k3s:v${K8S_VERSION}-k3s1"
@@ -142,7 +142,7 @@ EOF
 
   echo "Creating cluster '${CLUSTER_NAME}'"
   #k3d cluster create ${CLUSTER_NAME} ${K3D_ARGS[*]} >/dev/null
-  cat <<EOF | k3d cluster create ${CLUSTER_NAME} ${K3D_ARGS[*]} --config - > /dev/null
+  cat <<EOF | k3d cluster create ${CLUSTER_NAME} ${K3D_ARGS[*]}  --no-rollback --config - > /dev/null
   apiVersion: k3d.io/v1alpha5
   kind: Simple
   kubeAPI:


### PR DESCRIPTION
This resolves errors like this:

```
ERRO[0001] Failed Cluster Start: Failed to start server k3d-gitops-playground-server-0: Node k3d-gitops-playground-server-0 failed to get ready: error waiting for log line k3s is up and running from node 'k3d-gitops-playground-server-0': stopped returning log lines: node k3d-gitops-playground-server-0 is running=true in status=restarting 
ERRO[0001] Failed to create cluster >>> Rolling Back    
FATA[0002] Cluster creation FAILED, all changes have been rolled back! 
```

that have started to appear on 23 September 2024 🤷‍♂️