### PR TITLE
adding custom maven image and registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Note that you can get a free CES demo instance set up with a Kubernetes Cluster 
 --registry-password="$( cat account.json | sed 's/"/\\"/g' )" 
 ```
 
-##### Override default images 
+##### Override default images
 
 ###### gitops-build-lib
 
@@ -486,6 +486,7 @@ Images used by various tools and exercises can be configured using the following
 * `--external-secrets-webhook-image someRegistry/someImage:1.0.0`
 * `--vault-image someRegistry/someImage:1.0.0`
 * `--nginx-image someRegistry/someImage:1.0.0`
+* `--maven-image someRegistry/someImage:1.0.0`
 
 Note that specifying a tag is mandatory.  
   

--- a/applications/argocd/petclinic/helm/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/helm/Jenkinsfile.ftl
@@ -38,8 +38,17 @@ properties([
 
 node {
 
-    mvn = cesBuildLib.MavenWrapper.new(this)
 </#noparse>
+<#if images.maven?has_content>
+  <#if registry.twoRegistries>
+      mvn = cesBuildLib.MavenInDocker.new(this, '${images.maven}', dockerRegistryProxyCredentials)
+  <#else>
+      mvn = cesBuildLib.MavenInDocker.new(this, '${images.maven}')
+  </#if>
+<#else>
+    mvn = cesBuildLib.MavenWrapper.new(this)
+</#if>
+
 <#if jenkins.mavenCentralMirror?has_content>
     mvn.useMirrors([name: 'maven-central-mirror', mirrorOf: 'central', url:  env.${namePrefixForEnvVars}MAVEN_CENTRAL_MIRROR])
 </#if>

--- a/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
@@ -29,8 +29,18 @@ properties([
 
 node {
 
-    mvn = cesBuildLib.MavenWrapper.new(this)
 </#noparse>
+
+<#if images.maven?has_content>
+    <#if registry.twoRegistries>
+        mvn = cesBuildLib.MavenInDocker.new(this, '${images.maven}', dockerRegistryProxyCredentials)
+    <#else>
+        mvn = cesBuildLib.MavenInDocker.new(this, '${images.maven}')
+    </#if>
+<#else>
+    mvn = cesBuildLib.MavenWrapper.new(this)
+</#if>
+
 <#if jenkins.mavenCentralMirror?has_content>
     mvn.useMirrors([name: 'maven-central-mirror', mirrorOf: 'central', url:  env.${namePrefixForEnvVars}MAVEN_CENTRAL_MIRROR])
 </#if>

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -444,6 +444,10 @@
           "type" : "string",
           "description" : "Sets image for kubeval"
         },
+        "maven" : {
+          "type" : "string",
+          "description" : "Sets image for maven"
+        },
         "nginx" : {
           "type" : "string",
           "description" : "Sets image for nginx used in various applications"

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -101,6 +101,8 @@ class GitopsPlaygroundCli  implements Runnable {
     private String helmKubevalImage
     @Option(names = ['--yamllint-image'], description = YAMLLINT_IMAGE_DESCRIPTION)
     private String yamllintImage
+    @Option(names = ['--maven-image'], description = MAVEN_IMAGE_DESCRIPTION)
+    private String mavenImage
     @Option(names = ['--grafana-image'], description = GRAFANA_IMAGE_DESCRIPTION)
     private String grafanaImage
     @Option(names = ['--grafana-sidecar-image'], description = GRAFANA_SIDECAR_IMAGE_DESCRIPTION)
@@ -433,6 +435,7 @@ class GitopsPlaygroundCli  implements Runnable {
                         yamllint   : yamllintImage,
                         nginx      : nginxImage,
                         petclinic  : petClinicImage,
+                        maven      : mavenImage
                 ],
                 features    : [
                         argocd : [

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -132,7 +132,8 @@ class ApplicationConfigurator {
                     helmKubeval: HELM_IMAGE,
                     yamllint   : "cytopia/yamllint:1.25-0.7",
                     nginx      : null,
-                    petclinic   : 'eclipse-temurin:11-jre-alpine'
+                    petclinic  : 'eclipse-temurin:11-jre-alpine',
+                    maven      : null
             ],
             repositories : [
                     springBootHelmChart: [

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -53,6 +53,7 @@ interface ConfigConstants {
     String KUBEVAL_IMAGE_DESCRIPTION = 'Sets image for kubeval'
     String HELMKUBEVAL_IMAGE_DESCRIPTION = 'Sets image for helmkubeval'
     String YAMLLINT_IMAGE_DESCRIPTION = 'Sets image for yamllint'
+    String MAVEN_IMAGE_DESCRIPTION = 'Sets image for maven'
     String GRAFANA_IMAGE_DESCRIPTION = 'Sets image for grafana'
     String GRAFANA_SIDECAR_IMAGE_DESCRIPTION = 'Sets image for grafana\'s sidecar'
     String PROMETHEUS_IMAGE_DESCRIPTION = 'Sets image for prometheus'

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/Schema.groovy
@@ -190,6 +190,8 @@ class Schema {
         String nginx = ""
         @JsonPropertyDescription(PETCLINIC_IMAGE_DESCRIPTION)
         String petclinic = ""
+        @JsonPropertyDescription(MAVEN_IMAGE_DESCRIPTION)
+        String maven = ""
     }
 
     static class RepositoriesSchema {

--- a/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/ConfigToConfigFileConverterTest.groovy
@@ -76,7 +76,8 @@ class ConfigToConfigFileConverterTest {
                         helmKubeval: 'helmKubeval-value',
                         yamllint   : 'yamllint-value',
                         nginx: 'nginx-value',
-                        petclinic : 'petclinic-value'
+                        petclinic  : 'petclinic-value',
+                        maven      : 'maven-value'
                 ],
                 repositories : [
                         springBootHelmChart: [
@@ -236,6 +237,7 @@ images:
   yamllint: "yamllint-value"
   nginx: "nginx-value"
   petclinic: "petclinic-value"
+  maven: "maven-value"
 repositories:
   springBootHelmChart:
     url: "springboot-url"


### PR DESCRIPTION
Allowing passing down a custom maven build image. Additionally using the proxy registry if set. 


locally tested using :
--registry-proxy-url="localhost:9919"
--registry-proxy-username="test"
--registry-proxy-password="test"
--maven-image="maven:latest"

result: 
jenkinsfile displays proper values in SCMM for petclinic. 
