### PR TITLE
upgrading kube-prometheus-stack to 66.2.1

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -518,18 +518,22 @@ skopeo copy docker://ghcr.io/external-secrets/external-secrets:v0.9.16 --dest-cr
 skopeo copy docker://hashicorp/vault:1.14.0 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  docker://localhost:30000/proxy/vault
 skopeo copy docker://bitnami/nginx:1.23.3-debian-11-r8 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  docker://localhost:30000/proxy/nginx
 skopeo copy docker://registry.k8s.io/ingress-nginx/controller:v1.9.6 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/ingress-nginx
-skopeo copy docker://quay.io/prometheus-operator/prometheus-operator:v0.73.2 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/prometheus-operator
+
+# Monitoring
 # Using latest will lead to failure with
 # k describe prometheus -n monitoring
 #  Message:               initializing PrometheusRules failed: failed to parse version: Invalid character(s) found in major number "0latest"
-skopeo copy docker://quay.io/prometheus/prometheus:v2.51.2 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/prometheus:v2.51.2
-skopeo copy docker://quay.io/prometheus-operator/prometheus-config-reloader:v0.73.2 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/prometheus-config-reloader
-skopeo copy docker://grafana/grafana:10.4.1 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/grafana
-skopeo copy docker://quay.io/kiwigrid/k8s-sidecar:1.27.4 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/k8s-sidecar
+skopeo copy docker://quay.io/prometheus/prometheus:v2.55.1 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/prometheus:v2.55.1
+skopeo copy docker://quay.io/prometheus-operator/prometheus-operator:v0.78.1 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/prometheus-operator
+skopeo copy docker://quay.io/prometheus-operator/prometheus-config-reloader:v0.78.1 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/prometheus-config-reloader
+skopeo copy docker://docker.io/grafana/grafana:11.3.0 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/grafana
+skopeo copy docker://quay.io/kiwigrid/k8s-sidecar:1.28.0 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/k8s-sidecar
+
 # Cert Manager images
 skopeo copy docker://quay.io/jetstack/cert-manager-controller:v1.16.1 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/cert-manager-controller
 skopeo copy docker://quay.io/jetstack/cert-manager-cainjector:v1.16.1 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/cert-manager-cainjector
 skopeo copy docker://quay.io/jetstack/cert-manager-webhook:v1.16.1 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false docker://localhost:30000/proxy/cert-manager-webhook
+
 # Needed for the builds to work with proxy-registry
 skopeo copy docker://bitnami/kubectl:1.29 --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  docker://localhost:30000/proxy/bitnami/kubectl:1.29
 skopeo copy docker://eclipse-temurin:11-jre-alpine --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  docker://localhost:30000/proxy/eclipse-temurin:11-jre-alpine
@@ -570,7 +574,7 @@ docker run --rm -t -u $(id -u) \
     --cert-manager-image=localhost:30000/proxy/cert-manager-controller:latest \
     --cert-manager-webhook-image=localhost:30000/proxy/cert-manager-webhook:latest \
     --cert-manager-cainjector-image=localhost:30000/proxy/cert-manager-cainjector:latest \
-    --prometheus-image=localhost:30000/proxy/prometheus:v2.51.2 \
+    --prometheus-image=localhost:30000/proxy/prometheus:v2.55.1 \
     --prometheus-operator-image=localhost:30000/proxy/prometheus-operator:latest \
     --prometheus-config-reloader-image=localhost:30000/proxy/prometheus-config-reloader:latest \
     --grafana-image=localhost:30000/proxy/grafana:latest \

--- a/scripts/downloadHelmCharts.sh
+++ b/scripts/downloadHelmCharts.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#execute from root folder
 set -o errexit -o nounset -o pipefail
 charts=( 'kube-prometheus-stack' 'external-secrets' 'vault' 'mailhog' 'ingress-nginx' 'cert-manager')
 CONFIG="${1:-src/main/groovy/com/cloudogu/gitops/config/Config.groovy}"

--- a/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
@@ -540,7 +540,7 @@ class Config {
                 chart: 'kube-prometheus-stack',
                 repoURL: 'https://prometheus-community.github.io/helm-charts',
                 /* When updating this make sure to also test if air-gapped mode still works */
-                version: '58.2.1',
+                version: '66.2.1',
                 values: [:] // Otherwise values is null 🤷‍♂️
         )
         static class MonitoringHelmSchema extends HelmConfigWithValues {


### PR DESCRIPTION
Updating the 'kube-prometheus-stack' from 58.2.1 to 66.2.1.

local testing for reviewer:
1. run ./scripts/downloadHelmCharts.sh and
2. run ./init-cluster.sh. 
3. run gop with params: 
--yes
--ingress-nginx
--argocd
--base-url=http://localhost
--monitoring
--cert-manager
-x
4. check if kubernetes runs the new chart with the new version:
 kubectl get pods -l chart=kube-prometheus-stack-66.2.1 -n monitoring 
 should output a running  kube-prometheus-stack-operator pod.
5. check if grafana is able to get data from prometheus. Visit Grafana and check metric logs.
6. deploy in airgapped mode and repeat step 4.
7.  execute
kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" \
  | tr -s '[[:space:]]' '\n' | sort | uniq \
  | grep -v 'harbor\|jenkins\|scmm\|rancher\|argo\|redis\|dex'

check if promt shows:
localhost:30000/proxy/grafana:latest
localhost:30000/proxy/k8s-sidecar:latest
localhost:30000/proxy/prometheus-config-reloader:latest
localhost:30000/proxy/prometheus-operator:latest
localhost:30000/proxy/prometheus:v2.55.1
8. kubectl  get pods -n monitoring should give this promt: 

NAME                                              READY   STATUS    RESTARTS   AGE
kube-prometheus-stack-grafana-6d846855f7-hb6pd    3/3     Running   0          7m12s
kube-prometheus-stack-operator-7b749fc5fb-c68x6   1/1     Running   0          7m14s
prometheus-kube-prometheus-stack-prometheus-0     2/2     Running   0          6m30s

