### PR TITLE
Increased livenessProbe initialDelaySeconds value to handle pipeline issues 

### DIFF
--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -11,24 +11,6 @@
       },
       "additionalProperties" : false
     },
-    "HelmConfig-nullable" : {
-      "type" : [ "object", "null" ],
-      "properties" : {
-        "chart" : {
-          "type" : [ "string", "null" ],
-          "description" : "Name of the Helm chart"
-        },
-        "repoURL" : {
-          "type" : [ "string", "null" ],
-          "description" : "Repository url from which the Helm chart should be obtained"
-        },
-        "version" : {
-          "type" : [ "string", "null" ],
-          "description" : "The version of the Helm chart to be installed"
-        }
-      },
-      "additionalProperties" : false
-    },
     "Map(String,Object)-nullable" : {
       "type" : [ "object", "null" ]
     },
@@ -583,7 +565,22 @@
           "description" : "Create image pull secrets for registry and proxy-registry for all GOP namespaces and helm charts. Uses proxy-username, read-only-username or registry-username (in this order).  Use this if your cluster is not auto-provisioned with credentials for your private registries or if you configure individual helm images to be pulled from the proxy-registry that requires authentication."
         },
         "helm" : {
-          "$ref" : "#/$defs/HelmConfig-nullable",
+          "type" : [ "object", "null" ],
+          "properties" : {
+            "chart" : {
+              "type" : [ "string", "null" ],
+              "description" : "Name of the Helm chart"
+            },
+            "repoURL" : {
+              "type" : [ "string", "null" ],
+              "description" : "Repository url from which the Helm chart should be obtained"
+            },
+            "version" : {
+              "type" : [ "string", "null" ],
+              "description" : "The version of the Helm chart to be installed"
+            }
+          },
+          "additionalProperties" : false,
           "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors."
         },
         "internalPort" : {
@@ -657,7 +654,26 @@
       "type" : [ "object", "null" ],
       "properties" : {
         "helm" : {
-          "$ref" : "#/$defs/HelmConfig-nullable",
+          "type" : [ "object", "null" ],
+          "properties" : {
+            "chart" : {
+              "type" : [ "string", "null" ],
+              "description" : "Name of the Helm chart"
+            },
+            "repoURL" : {
+              "type" : [ "string", "null" ],
+              "description" : "Repository url from which the Helm chart should be obtained"
+            },
+            "values" : {
+              "$ref" : "#/$defs/Map(String,Object)-nullable",
+              "description" : "Helm values of the chart, allows overriding defaults and setting values that are not exposed as explicit configuration"
+            },
+            "version" : {
+              "type" : [ "string", "null" ],
+              "description" : "The version of the Helm chart to be installed"
+            }
+          },
+          "additionalProperties" : false,
           "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors."
         },
         "password" : {

--- a/scm-manager/values.ftl.yaml
+++ b/scm-manager/values.ftl.yaml
@@ -1,6 +1,11 @@
 persistence:
   size: 1Gi
 
+<#if helm.values['initialDelaySeconds']??>
+livenessProbe:
+  initialDelaySeconds: ${helm.values.initialDelaySeconds}
+</#if>
+
 extraEnv: |
     - name: SCM_WEBAPP_INITIALUSER
       value: "${username}"
@@ -12,7 +17,7 @@ service:
   nodePort: 9091
   type: NodePort
 </#if>
-  
+ 
 <#if host?has_content>
 ingress:
   enabled: true
@@ -20,3 +25,4 @@ ingress:
   hosts:
     - ${host}
 </#if>
+  

--- a/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
@@ -237,10 +237,13 @@ class Config {
         String password = DEFAULT_ADMIN_PW
 
         @JsonPropertyDescription(HELM_CONFIG_DESCRIPTION)
-        HelmConfig helm = new HelmConfig(
+        HelmConfigWithValues helm = new HelmConfigWithValues(
                 chart: 'scm-manager',
                 repoURL: 'https://packages.scm-manager.org/repository/helm-v2-releases/',
-                version: '3.2.1')
+                version: '3.2.1',
+                values: [
+                        initialDelaySeconds: 120
+                ])
     }
 
     static class ApplicationSchema {

--- a/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
@@ -52,7 +52,8 @@ class ScmManager extends Feature {
                     host  : config.scmm.ingress,
                     remote: config.application.remote,
                     username:  config.scmm.username,
-                    password: config.scmm.password
+                    password: config.scmm.password,
+                    helm: config.scmm.helm
             ]).toPath()
 
             deployer.deployFeature(

--- a/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
@@ -33,10 +33,11 @@ class ScmManagerTest {
                     password: 'scmm-pw',
                     gitOpsUsername: 'foo-gitops',
                     urlForJenkins : 'http://scmm4jenkins',
-                    helm  : new Config.HelmConfig(
+                    helm  : new Config.HelmConfigWithValues(
                             chart  : 'scm-manager-chart',
                             version: '2.47.0',
                             repoURL: 'https://packages.scm-manager.org/repository/helm-v2-releases/',
+                            values: [:]
                     )
             ),
             jenkins: new Config.JenkinsSchema(
@@ -126,6 +127,16 @@ class ScmManagerTest {
         createScmManager().install()
 
         assertThat(temporaryYamlFile).isNull()
+    }
+
+    @Test
+    void 'initialDelaySeconds is set properly'() {
+        config.scmm.helm.values = [
+                initialDelaySeconds: 140
+        ]
+
+        createScmManager().install()
+        assertThat(parseActualYaml()['livenessProbe'] as String).contains('initialDelaySeconds:140')
     }
 
     protected Map<String, String> getEnvAsMap() {


### PR DESCRIPTION
This change hopefully fixes the flaky integration tests found by https://github.com/cloudogu/gitops-playground/pull/237.
Allowing the SCMM more time to come alive could work out. If not additional measures are needed.

How to test locally:
1. rerun GOP
2. set a custom value for initialDelaySeconds in Config.groovy  under HelmConfigWithValues
3. run 'helm get manifest scmm | grep -A 10 livenessProbe'
4. the custom value should be displayed under livenessProbe 