### PR TITLE
Namespace isolation: Specify Prometheus NamespaceSelectors

### DIFF
--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -83,9 +83,11 @@ prometheusOperator:
     releaseNamespace: false
     additional:
     <#-- Note that the quotes in the final YAML here are created by groovy, not Freemarker-->
+    <#if namespaces?has_content>
     <#list namespaces as namespace>
-      - ${namespace}
+    - ${namespace}
     </#list>
+    </#if>
 </#if>
 <#if podResources == true>
   resources:
@@ -272,8 +274,17 @@ prometheus:
     </#if>
     # Find podMonitors, serviceMonitor, etc. in all namespaces
     serviceMonitorNamespaceSelector:
-      matchLabels: {}
-    # With this, we don't need the label "release: kube-prometheus-stack" on the service monitor
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          <#if namespaces?has_content>
+            <#list namespaces as namespace>
+            - ${namespace}
+            </#list>
+            <#else>
+            {}
+          </#if>
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorNamespaceSelector:
       matchLabels: {}

--- a/src/main/groovy/com/cloudogu/gitops/Application.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/Application.groovy
@@ -1,6 +1,6 @@
 package com.cloudogu.gitops
 
-
+import com.cloudogu.gitops.config.Config
 import groovy.util.logging.Slf4j
 import jakarta.inject.Singleton
 
@@ -9,16 +9,21 @@ import jakarta.inject.Singleton
 class Application {
 
     final List<Feature> features
+    final Config config
 
-    Application(
+    Application(Config config,
             List<Feature> features
     ) {
+        this.config=config
         // Order is important. Enforced by @Order-Annotation on the Singletons
         this.features = features
+
     }
 
     def start() {
         log.debug("Starting Application")
+
+        setNamespaceListToConfig(config)
         features.forEach(feature -> {
             feature.install()
         })
@@ -27,5 +32,32 @@ class Application {
 
     List<Feature> getFeatures() {
         return features
+    }
+
+    void setNamespaceListToConfig(Config config) {
+        List<String> namespaces = []
+        String namePrefix = config.application.namePrefix;
+
+        if(config.registry.internal || config.scmm.internal || config.jenkins.internal){
+            namespaces.add(namePrefix + "default")
+        }
+        
+        if (config.features.argocd.active) {
+            namespaces.addAll(Arrays.asList(
+                    namePrefix + "argocd",
+                    namePrefix + "example-apps-staging",
+                    namePrefix + "example-apps-production"
+            ))
+        }
+
+        //iterates over all FeatureWithImages and gets their namespaces
+        namespaces.addAll(this.features
+                .collect { it.activeNamespaceFromFeature }
+                .findAll { it }
+                .unique()
+                .collect { "${namePrefix}${it}".toString() })
+
+        log.debug("Active namespaces retrieved: {}", namespaces);
+        config.application.activeNamespaces = namespaces
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/Feature.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/Feature.groovy
@@ -46,7 +46,15 @@ abstract class Feature {
             return false
         }
     }
-    
+
+    String getActiveNamespaceFromFeature() {
+        //using reflection to get all subclasses implementing a own namespace
+        if (this.metaClass.hasProperty(this, 'namespace'))  {
+            return isEnabled() ? this.getProperty('namespace') : null
+        }
+        return null
+    }
+
     abstract boolean isEnabled()
     
     /*

--- a/src/main/groovy/com/cloudogu/gitops/FeatureWithImage.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/FeatureWithImage.groovy
@@ -24,7 +24,7 @@ trait FeatureWithImage {
             k8sClient.createImagePullSecret('proxy-registry', namespace, url, user, password)
         }
     }
-    
+
     abstract String getNamespace()
     abstract K8sClient getK8sClient()
     abstract Config getConfig()

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -17,6 +17,7 @@ import com.cloudogu.gitops.utils.K8sClient
 import groovy.util.logging.Slf4j
 import groovy.yaml.YamlSlurper
 import io.micronaut.context.ApplicationContext
+import jakarta.inject.Provider
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
 

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScripted.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliMainScripted.groovy
@@ -86,7 +86,7 @@ class GitopsPlaygroundCliMainScripted {
 
                 def airGappedUtils = new AirGappedUtils(config, scmmRepoProvider, repoApi, fileSystemUtils, helmClient)
 
-                context.registerSingleton(new Application([
+                context.registerSingleton(new Application(config,[
                         new Registry(config, fileSystemUtils, k8sClient, helmStrategy),
                         new ScmManager(config, executor, fileSystemUtils, helmStrategy),
                         new Jenkins(config, executor, fileSystemUtils, new GlobalPropertyManager(jenkinsApiClient),

--- a/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
@@ -249,6 +249,7 @@ class Config {
     static class ApplicationSchema {
         Boolean runningInsideK8s = false
         String namePrefixForEnvVars = ''
+        List<String> activeNamespaces = []
         String internalKubernetesApiUrl = ''
         String localHelmChartFolder = System.getenv('LOCAL_HELM_CHART_FOLDER')
 

--- a/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/PrometheusStack.groovy
@@ -97,14 +97,14 @@ class PrometheusStack extends Feature implements FeatureWithImage {
         k8sClient.createSecret(
                 'generic',
                 'prometheus-metrics-creds-scmm',
-                'monitoring',
+                namespace,
                 new Tuple2('password', config.application.password)
         )
 
         k8sClient.createSecret(
                 'generic',
                 'prometheus-metrics-creds-jenkins',
-                'monitoring',
+                namespace,
                 new Tuple2('password', config.jenkins.metricsPassword),
         )
 
@@ -112,7 +112,7 @@ class PrometheusStack extends Feature implements FeatureWithImage {
             k8sClient.createSecret(
                     'generic',
                     'grafana-email-secret',
-                    'monitoring',
+                    namespace,
                     new Tuple2('user', config.features.mail.smtpUser),
                     new Tuple2('password', config.features.mail.smtpPassword)
             )
@@ -159,7 +159,7 @@ class PrometheusStack extends Feature implements FeatureWithImage {
                     'prometheusstack',
                     '.',
                     prometheusVersion,
-                    'monitoring',
+                    namespace,
                     'kube-prometheus-stack',
                     tmpHelmValues, RepoType.GIT)
         } else {
@@ -169,7 +169,7 @@ class PrometheusStack extends Feature implements FeatureWithImage {
                     'prometheusstack',
                     helmConfig.chart,
                     helmConfig.version,
-                    'monitoring',
+                    namespace,
                     'kube-prometheus-stack',
                     tmpHelmValues)
         }

--- a/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
@@ -15,7 +15,7 @@ class K8sClient {
 
     private CommandExecutor commandExecutor
     private FileSystemUtils fileSystemUtils
-    public Provider<Config> configProvider
+    private Provider<Config> configProvider
 
     K8sClient(
             CommandExecutor commandExecutor,
@@ -410,14 +410,15 @@ class K8sClient {
 
     private class Kubectl {
         private List<String> command = ['kubectl']
-
+        private Provider<Config> configProvider
         Kubectl(String... args) {
+            configProvider=K8sClient.this.configProvider
             command.addAll(args)
         }
 
         Kubectl namespace(String namespace) {
             if (namespace) {
-                this.command += ['-n', configProvider.get().application.namePrefix + namespace]
+                this.command += ['-n', K8sClient.this.configProvider.get().application.namePrefix + namespace]
             }
             return this
         }

--- a/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
@@ -15,7 +15,7 @@ class K8sClient {
 
     private CommandExecutor commandExecutor
     private FileSystemUtils fileSystemUtils
-    private Provider<Config> configProvider
+    public Provider<Config> configProvider
 
     K8sClient(
             CommandExecutor commandExecutor,
@@ -24,7 +24,7 @@ class K8sClient {
     ) {
         this.fileSystemUtils = fileSystemUtils
         this.commandExecutor = commandExecutor
-        this.configProvider = configProvider;
+        this.configProvider = configProvider
     }
 
     String getInternalNodeIp() {

--- a/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/K8sClient.groovy
@@ -1,8 +1,8 @@
 package com.cloudogu.gitops.utils
 
+import com.cloudogu.gitops.config.Config
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
-import com.cloudogu.gitops.config.Config
 import groovy.transform.Immutable
 import groovy.util.logging.Slf4j
 import jakarta.inject.Provider
@@ -410,9 +410,8 @@ class K8sClient {
 
     private class Kubectl {
         private List<String> command = ['kubectl']
-        private Provider<Config> configProvider
+
         Kubectl(String... args) {
-            configProvider=K8sClient.this.configProvider
             command.addAll(args)
         }
 

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
@@ -1,6 +1,5 @@
 package com.cloudogu.gitops
 
-
 import com.cloudogu.gitops.config.Config
 import io.micronaut.context.ApplicationContext
 import org.junit.jupiter.api.Test
@@ -21,5 +20,26 @@ class ApplicationTest {
         def features = application.features.collect { it.class.simpleName }
 
         assertThat(features).isEqualTo(["Registry", "ScmManager", "Jenkins", "Content", "ArgoCD", "IngressNginx", "CertManager", "Mailhog", "PrometheusStack", "ExternalSecretsOperator", "Vault"])
+    }
+
+    @Test
+    void 'get active namespaces correctly'() {
+        config.features.monitoring.active = true
+        config.features.argocd.active = true
+        config.features.ingressNginx.active = true
+        config.application.namePrefix = 'test1-'
+        List<String> namespaceList = new ArrayList<>(Arrays.asList(
+                "test1-default",
+                "test1-argocd",
+                "test1-example-apps-staging",
+                "test1-example-apps-production",
+                "test1-ingress-nginx",
+                "test1-monitoring"
+        ))
+        def application = ApplicationContext.run()
+                .registerSingleton(config)
+                .getBean(Application)
+        application.setNamespaceListToConfig(config)
+        assertThat(config.application.getActiveNamespaces()).isEqualTo(namespaceList)
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/features/IngressNginxTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/IngressNginxTest.groovy
@@ -164,6 +164,13 @@ class IngressNginxTest {
         assertThat(yaml['controller']['image']['tag']).isEqualTo('v42')
         assertThat(yaml['controller']['image']['digest']).isNull()
     }
+
+    @Test
+    void 'get namespace from feature'() {
+        assertThat(createIngressNginx().getActiveNamespaceFromFeature()).isEqualTo('ingress-nginx')
+        config.features.ingressNginx.active = false
+        assertThat(createIngressNginx().getActiveNamespaceFromFeature()).isEqualTo(null)
+    }
     
     private IngressNginx createIngressNginx() {
         // We use the real FileSystemUtils and not a mock to make sure file editing works as expected

--- a/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
@@ -12,7 +12,7 @@ class K8sClientTest {
 
     Config config = new Config(application: new Config.ApplicationSchema(namePrefix: "foo-"))
 
-    K8sClientForTest k8sClient = new K8sClientForTest( config)
+    K8sClientForTest k8sClient = new K8sClientForTest(config)
     CommandExecutorForTest commandExecutor =  k8sClient.commandExecutorForTest
 
     @Test
@@ -100,7 +100,6 @@ class K8sClientTest {
                 "kubectl create secret generic very-secret --from-literal isnullbecomeempty= --dry-run=client -oyaml" +
                         " | kubectl apply -f-")
     }
-
 
     @Test
     void 'Creates configmap from file'() {


### PR DESCRIPTION
adding ServiceMonitorNamespaceSelectors to Prometheus.
removed duplicate getNamespace functions in Argo and Prometheus. Adding a Config param for active namespaces.
