### PR TITLE
BREAKING: Remove config options for Helm repo

### DIFF
--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -188,17 +188,9 @@
                   "type" : [ "string", "null" ],
                   "description" : "Sets cainjector Image for Cert Manager"
                 },
-                "chart" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Name of the Helm chart"
-                },
                 "image" : {
                   "type" : [ "string", "null" ],
                   "description" : "Sets image for Cert Manager"
-                },
-                "repoURL" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Repository url from which the Helm chart should be obtained"
                 },
                 "startupAPICheckImage" : {
                   "type" : [ "string", "null" ],
@@ -207,10 +199,6 @@
                 "values" : {
                   "$ref" : "#/$defs/Map(String,Object)-nullable",
                   "description" : "Helm values of the chart, allows overriding defaults and setting values that are not exposed as explicit configuration"
-                },
-                "version" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "The version of the Helm chart to be installed"
                 },
                 "webhookImage" : {
                   "type" : [ "string", "null" ],
@@ -249,25 +237,13 @@
             "helm" : {
               "type" : [ "object", "null" ],
               "properties" : {
-                "chart" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Name of the Helm chart"
-                },
                 "image" : {
                   "type" : [ "string", "null" ],
                   "description" : "The image of the Helm chart to be installed"
                 },
-                "repoURL" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Repository url from which the Helm chart should be obtained"
-                },
                 "values" : {
                   "$ref" : "#/$defs/Map(String,Object)-nullable",
                   "description" : "Helm values of the chart, allows overriding defaults and setting values that are not exposed as explicit configuration"
-                },
-                "version" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "The version of the Helm chart to be installed"
                 }
               },
               "additionalProperties" : false,
@@ -283,21 +259,9 @@
             "helm" : {
               "type" : [ "object", "null" ],
               "properties" : {
-                "chart" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Name of the Helm chart"
-                },
                 "image" : {
                   "type" : [ "string", "null" ],
                   "description" : "The image of the Helm chart to be installed"
-                },
-                "repoURL" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Repository url from which the Helm chart should be obtained"
-                },
-                "version" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "The version of the Helm chart to be installed"
                 }
               },
               "additionalProperties" : false,
@@ -353,10 +317,6 @@
             "helm" : {
               "type" : [ "object", "null" ],
               "properties" : {
-                "chart" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Name of the Helm chart"
-                },
                 "grafanaImage" : {
                   "type" : [ "string", "null" ],
                   "description" : "Sets image for grafana"
@@ -377,17 +337,9 @@
                   "type" : [ "string", "null" ],
                   "description" : "Sets image for prometheus-operator"
                 },
-                "repoURL" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "Repository url from which the Helm chart should be obtained"
-                },
                 "values" : {
                   "$ref" : "#/$defs/Map(String,Object)-nullable",
                   "description" : "Helm values of the chart, allows overriding defaults and setting values that are not exposed as explicit configuration"
-                },
-                "version" : {
-                  "type" : [ "string", "null" ],
-                  "description" : "The version of the Helm chart to be installed"
                 }
               },
               "additionalProperties" : false,
@@ -410,21 +362,9 @@
                       "type" : [ "string", "null" ],
                       "description" : "Sets image for external secrets operator's controller"
                     },
-                    "chart" : {
-                      "type" : [ "string", "null" ],
-                      "description" : "Name of the Helm chart"
-                    },
                     "image" : {
                       "type" : [ "string", "null" ],
                       "description" : "Sets image for external secrets operator"
-                    },
-                    "repoURL" : {
-                      "type" : [ "string", "null" ],
-                      "description" : "Repository url from which the Helm chart should be obtained"
-                    },
-                    "version" : {
-                      "type" : [ "string", "null" ],
-                      "description" : "The version of the Helm chart to be installed"
                     },
                     "webhookImage" : {
                       "type" : [ "string", "null" ],
@@ -444,21 +384,9 @@
                 "helm" : {
                   "type" : [ "object", "null" ],
                   "properties" : {
-                    "chart" : {
-                      "type" : [ "string", "null" ],
-                      "description" : "Name of the Helm chart"
-                    },
                     "image" : {
                       "type" : [ "string", "null" ],
                       "description" : "Sets image for vault"
-                    },
-                    "repoURL" : {
-                      "type" : [ "string", "null" ],
-                      "description" : "Repository url from which the Helm chart should be obtained"
-                    },
-                    "version" : {
-                      "type" : [ "string", "null" ],
-                      "description" : "The version of the Helm chart to be installed"
                     }
                   },
                   "additionalProperties" : false,
@@ -590,20 +518,6 @@
         },
         "helm" : {
           "type" : [ "object", "null" ],
-          "properties" : {
-            "chart" : {
-              "type" : [ "string", "null" ],
-              "description" : "Name of the Helm chart"
-            },
-            "repoURL" : {
-              "type" : [ "string", "null" ],
-              "description" : "Repository url from which the Helm chart should be obtained"
-            },
-            "version" : {
-              "type" : [ "string", "null" ],
-              "description" : "The version of the Helm chart to be installed"
-            }
-          },
           "additionalProperties" : false,
           "description" : "Common Config parameters for the Helm package manager: Name of Chart (chart), URl of Helm-Repository (repoURL) and Chart Version (version). Note: These config is intended to obtain the chart from a different source (e.g. in air-gapped envs), not to use a different version of a helm chart. Using a different helm chart or version to the one used in the GOP version will likely cause errors."
         },
@@ -680,21 +594,9 @@
         "helm" : {
           "type" : [ "object", "null" ],
           "properties" : {
-            "chart" : {
-              "type" : [ "string", "null" ],
-              "description" : "Name of the Helm chart"
-            },
-            "repoURL" : {
-              "type" : [ "string", "null" ],
-              "description" : "Repository url from which the Helm chart should be obtained"
-            },
             "values" : {
               "$ref" : "#/$defs/Map(String,Object)-nullable",
               "description" : "Helm values of the chart, allows overriding defaults and setting values that are not exposed as explicit configuration"
-            },
-            "version" : {
-              "type" : [ "string", "null" ],
-              "description" : "The version of the Helm chart to be installed"
             }
           },
           "additionalProperties" : false,

--- a/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
@@ -1,9 +1,10 @@
 package com.cloudogu.gitops.config
 
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier
@@ -81,12 +82,10 @@ class Config {
     @Mixin
     FeaturesSchema features = new FeaturesSchema()
 
+    @JsonIgnoreProperties
     static class HelmConfig {
-        @JsonPropertyDescription(HELM_CONFIG_CHART_DESCRIPTION)
         String chart = ''
-        @JsonPropertyDescription(HELM_CONFIG_REPO_URL_DESCRIPTION)
         String repoURL = ''
-        @JsonPropertyDescription(HELM_CONFIG_VERSION_DESCRIPTION)
         String version = ''
     }
 

--- a/src/test/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliTest.groovy
@@ -69,6 +69,18 @@ class GitopsPlaygroundCliTest {
         // Check application starts
         verify(application).start()
     }
+    @Test
+    void 'fails on starts because config file with helm overrides, not allowed'() {
+        String pathToConfigFile = "./src/test/resources/errorConfig.yaml"
+
+        assertThat(new File(pathToConfigFile).isFile()).withFailMessage("config file for test do not exists anymore.").isTrue()
+
+        def exception = shouldFail(RuntimeException) {
+            cli.run('--config-file=' + pathToConfigFile)
+        }
+        assertThat(exception.message).contains('Config file invalid')
+
+    }
     
     @Test
     void 'Starts with config map'() {

--- a/src/test/resources/errorConfig.yaml
+++ b/src/test/resources/errorConfig.yaml
@@ -10,6 +10,10 @@ registry:
   readOnlyUsername: ""
   readOnlyPassword: ""
   createImagePullSecrets: false
+  helm:
+    chart: "docker-registry"
+    repoURL: "https://helm.twun.io"
+    version: "2.2.3"
 jenkins:
   url: "http://172.18.0.2:9090"
   username: "admin"
@@ -23,6 +27,10 @@ scmm:
   url: "http://172.18.0.2:9091/scm"
   username: "admin"
   password: "admin"
+  helm:
+    chart: "scm-manager"
+    repoURL: "https://packages.scm-manager.org/repository/helm-v2-releases/"
+    version: "3.2.1"
 application:
   remote: false
   insecure: false
@@ -76,6 +84,9 @@ features:
     smtpUser: ""
     smtpPassword: ""
     helm:
+      chart: "mailhog"
+      repoURL: "https://codecentric.github.io/helm-charts"
+      version: "5.0.1"
       image: "ghcr.io/cloudogu/mailhog:v1.0.1"
   monitoring:
     active: false
@@ -83,6 +94,9 @@ features:
     grafanaEmailFrom: "grafana@example.org"
     grafanaEmailTo: "infra@example.org"
     helm:
+      chart: "kube-prometheus-stack"
+      repoURL: "https://prometheus-community.github.io/helm-charts"
+      version: "58.2.1"
       values: {}
       grafanaImage: ""
       grafanaSidecarImage: ""
@@ -92,6 +106,9 @@ features:
   secrets:
     externalSecrets:
       helm:
+        chart: "external-secrets"
+        repoURL: "https://charts.external-secrets.io"
+        version: "0.9.16"
         image: ""
         certControllerImage: ""
         webhookImage: ""
@@ -99,10 +116,16 @@ features:
       mode: "dev"
       url: ""
       helm:
+        chart: "vault"
+        repoURL: "https://helm.releases.hashicorp.com"
+        version: "0.25.0"
         image: ""
   ingressNginx:
     active: false
     helm:
+      chart: "ingress-nginx"
+      repoURL: "https://kubernetes.github.io/ingress-nginx"
+      version: "4.11.3"
       values: {}
       image: ""
   exampleApps:
@@ -113,6 +136,9 @@ features:
   certManager:
     active: false
     helm:
+      chart: "cert-manager"
+      repoURL: "https://charts.jetstack.io"
+      version: "1.16.1"
       values: {}
       image: ""
       webhookImage: ""


### PR DESCRIPTION
Currently it is not possible to change config for Helm repos using repoURL, chart and version.
So we remove this config option in order to avoid frustrated users.

Why?
In order to effectively use a different OCI or helm repo, we would have to add it to the AppProject.  Whilst this is not impossible, it is not implemented, yet. 
Same goes for authentication: If the different OCI repo would need credentials we would have to add those to the Argo CD config, which is also not implemented, yet.

So for now, we remove the option.
Once we have a requirement to implement it, we implemented with proper UX.