### PR TITLE
feat: Mailhog SecurityContext removed in Openshift. Openshift will set own SCC constraints by this

### DIFF
--- a/applications/cluster-resources/mailhog-helm-values.ftl.yaml
+++ b/applications/cluster-resources/mailhog-helm-values.ftl.yaml
@@ -6,7 +6,6 @@ image:
 <#if imageObject.tag?has_content>  tag: ${imageObject.tag}</#if>
 </#if>
 <#if config.registry.createImagePullSecrets == true>
-
 imagePullSecrets: 
  - name: proxy-registry
 </#if>
@@ -39,4 +38,11 @@ resources:
   requests:
     memory: 10Mi
     cpu: 20m
+</#if>
+  
+<#if config.application.openshift == true>
+securityContext:
+  fsGroup: null
+  runAsGroup: null
+  runAsUser: null
 </#if>

--- a/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
+++ b/applications/cluster-resources/monitoring/prometheus-stack-helm-values.ftl.yaml
@@ -267,6 +267,7 @@ grafana:
 prometheus:
   prometheusSpec:
     <#if config.application.openshift == true>
+    automountServiceAccountToken: null
     securityContext: 
       fsGroup: null
       runAsGroup: null
@@ -287,14 +288,44 @@ prometheus:
           </#if>
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorNamespaceSelector:
-      matchLabels: {}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          <#if namespaces?has_content>
+          <#list namespaces as namespace>
+          - ${namespace}
+          </#list>
+          <#else>
+          { }
+          </#if>
     podMonitorSelectorNilUsesHelmValues: false
     ruleNamespaceSelector:
-      matchLabels: {}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          <#if namespaces?has_content>
+          <#list namespaces as namespace>
+          - ${namespace}
+          </#list>
+          <#else>
+          { }
+          </#if>
     ruleSelectorNilUsesHelmValues: false
     scrapeConfigSelectorNilUsesHelmValues: false
     probeNamespaceSelector:
-      matchLabels: {}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          <#if namespaces?has_content>
+          <#list namespaces as namespace>
+          - ${namespace}
+          </#list>
+          <#else>
+          { }
+          </#if>
     probeSelectorNilUsesHelmValues: false
   <#if podResources == true>
     resources:

--- a/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/MailhogTest.groovy
@@ -203,6 +203,15 @@ class MailhogTest {
         assertThat(parseActualYaml()['imagePullSecrets']).isEqualTo([[name: 'proxy-registry']])
     }
 
+    @Test
+    void 'empty security context in openshift'() {
+        config.application.openshift = true
+        createMailhog().install()
+        assertThat(parseActualYaml()['securityContext']['fsGroup']).isEqualTo(null)
+        assertThat(parseActualYaml()['securityContext']['runAsUser']).isEqualTo(null)
+        assertThat(parseActualYaml()['securityContext']['runAsGroup']).isEqualTo(null)
+    }
+
     private Mailhog createMailhog() {
         // We use the real FileSystemUtils and not a mock to make sure file editing works as expected
 


### PR DESCRIPTION
removing the default securityContext from the helm chart in Openshift. So Openshift will inject it's own SCC Contraints to the pods allowing the pods to run properly