### PR TITLE
Petclinic: disable DB integrationstests

### DIFF
--- a/applications/argocd/petclinic/helm/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/helm/Jenkinsfile.ftl
@@ -66,7 +66,10 @@ node {
         }
 
         stage('Test') {
-            mvn "test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip"
+            mvn "test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip" +
+                // Disable database integration tests because they start docker images (which won't work in air-gapped envs and take a lot of time in demos)
+                '-Dtest=!org.springframework.samples.petclinic.MySqlIntegrationTests,!org.springframework.samples.petclinic.PostgresIntegrationTests'
+
         }
 
         String imageName = ""

--- a/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
@@ -60,6 +60,8 @@ node {
         stage('Test') {
             // Tests skipped for faster demo and exercise purposes
             //mvn 'test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip'
+            // Disable database integration tests because they start docker images (which won't work in air-gapped envs and take a lot of time in demos)
+            //'-Dtest=!org.springframework.samples.petclinic.MySqlIntegrationTests,!org.springframework.samples.petclinic.PostgresIntegrationTests'
         }
 
         String imageName = ""

--- a/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
@@ -391,7 +391,7 @@ class Config {
         @JsonPropertyDescription(SPRING_PETCLINIC_DESCRIPTION)
         RepositorySchemaWithRef springPetclinic = new RepositorySchemaWithRef(
                 url: System.getenv('SPRING_PETCLINIC_REPO') ?: 'https://github.com/cloudogu/spring-petclinic.git',
-                ref: 'faf9b7c'
+                ref: 'b0738b2'
         )
         @JsonPropertyDescription(GITOPS_BUILD_LIB_DESCRIPTION)
         RepositorySchema gitopsBuildLib = new RepositorySchema(


### PR DESCRIPTION
Petclinic: Disable database integration tests because they start docker images (which won't work in air-gapped envs and take a lot of time in demos)