### PR TITLE
CLI: Simple params no longer require k8s

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -18,11 +18,9 @@ class ApplicationConfigurator {
     }
 
     /**
-     * Sets dynamic fields and validates params
+     * Sets dynamic fields
      */
-    Config initAndValidateConfig(Config newConfig) {
-
-        validate(newConfig)
+    Config initConfig(Config newConfig) {
 
         addAdditionalApplicationConfig(newConfig)
 
@@ -223,7 +221,7 @@ class ApplicationConfigurator {
         return newUrl
     }
 
-    private void validate(Config configToSet) {
+    void validateConfig(Config configToSet) {
         if (configToSet.scmm.url && !configToSet.jenkins.url ||
                 !configToSet.scmm.url && configToSet.jenkins.url) {
             throw new RuntimeException('When setting jenkins URL, scmm URL must also be set and the other way round')

--- a/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ApplicationConfigurator.groovy
@@ -221,16 +221,28 @@ class ApplicationConfigurator {
         return newUrl
     }
 
+    /**
+     * Make sure that config does not contain contradictory values.
+     * Throws RuntimeException which meaningful message, if invalid.
+     */
     void validateConfig(Config configToSet) {
-        if (configToSet.scmm.url && !configToSet.jenkins.url ||
-                !configToSet.scmm.url && configToSet.jenkins.url) {
-            throw new RuntimeException('When setting jenkins URL, scmm URL must also be set and the other way round')
-        }
+        validateScmmAndJenkinsAreBothSet(configToSet)
+        validateMirrorReposHelmChartFolderSet(configToSet)
+    }
+
+    private void validateMirrorReposHelmChartFolderSet(Config configToSet) {
         if (configToSet.application.mirrorRepos && !configToSet.application.localHelmChartFolder) {
             // This should only happen when run outside the image, i.e. during development
             throw new RuntimeException("Missing config for localHelmChartFolder.\n" +
                     "Either run inside the official container image or setting env var " +
                     "LOCAL_HELM_CHART_FOLDER='charts' after running 'scripts/downloadHelmCharts.sh' from the repo")
+        }
+    }
+
+    private void validateScmmAndJenkinsAreBothSet(Config configToSet) {
+        if (configToSet.scmm.url && !configToSet.jenkins.url ||
+                !configToSet.scmm.url && configToSet.jenkins.url) {
+            throw new RuntimeException('When setting jenkins URL, scmm URL must also be set and the other way round')
         }
     }
 

--- a/src/test/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCliTest.groovy
@@ -49,7 +49,7 @@ class GitopsPlaygroundCliTest {
         def status = cli.run('--yes')
 
         assertThat(status).isEqualTo(ReturnCode.SUCCESS)
-        verify(applicationConfigurator).initAndValidateConfig(any(Config))
+        verify(applicationConfigurator).initConfig(any(Config))
         verify(application).start()
     }
 
@@ -63,7 +63,7 @@ class GitopsPlaygroundCliTest {
         assertThat(status).isEqualTo(ReturnCode.SUCCESS)
 
         // Verify the first interaction
-        verify(applicationConfigurator).initAndValidateConfig(any(Config))
+        verify(applicationConfigurator).initConfig(any(Config))
 
         // Check application starts
         verify(application).start()
@@ -77,7 +77,7 @@ class GitopsPlaygroundCliTest {
 
         assertThat(status).isEqualTo(ReturnCode.SUCCESS)
         // ensure init is called with Config
-        verify(applicationConfigurator).initAndValidateConfig(any(Config))
+        verify(applicationConfigurator).initConfig(any(Config))
         verify(application).start()
     }
 
@@ -86,7 +86,7 @@ class GitopsPlaygroundCliTest {
         def status = cli.run('--output-config-file')
 
         assertThat(status).isEqualTo(ReturnCode.SUCCESS)
-        verify(applicationConfigurator).initAndValidateConfig(any(Config))
+        verify(applicationConfigurator, never()).initConfig(any(Config))
         verify(application, never()).start()
     }
 
@@ -96,7 +96,7 @@ class GitopsPlaygroundCliTest {
         def status = cli.run('--version')
 
         assertThat(status).isEqualTo(ReturnCode.SUCCESS)
-        verify(applicationConfigurator).initAndValidateConfig(any(Config))
+        verify(applicationConfigurator, never()).initConfig(any(Config))
         verify(application, never()).start()
     }
 
@@ -106,7 +106,7 @@ class GitopsPlaygroundCliTest {
         def status = cli.run('--help')
 
         assertThat(status).isEqualTo(ReturnCode.SUCCESS)
-        verify(applicationConfigurator).initAndValidateConfig(any(Config))
+        verify(applicationConfigurator, never()).initConfig(any(Config))
         verify(application, never()).start()
     }
 
@@ -376,7 +376,7 @@ class GitopsPlaygroundCliTest {
         GitopsPlaygroundCliForTest() {
             super(GitopsPlaygroundCliTest.this.k8sClient, GitopsPlaygroundCliTest.this.applicationConfigurator)
 
-            when(applicationConfigurator.initAndValidateConfig(any(Config))).thenAnswer(new Answer<Config>() {
+            when(applicationConfigurator.initConfig(any(Config))).thenAnswer(new Answer<Config>() {
                 @Override
                 Config answer(InvocationOnMock invocation) throws Throwable {
                     lastSchema = invocation.getArgument(0)


### PR DESCRIPTION
`--help`, `--version` and `--output-config` should work even when there is no working kube-context.

e.g. 
```bash
docker run ghcr.io/cloudogu/gitops-playground:0.10.0 --version
```
Fails with:
```
couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
```

Because there is no working kube-context and initAndValidateConfig connects to k8s trying to find clusterBindAddress


This used to work before #241:
```
docker run ghcr.io/cloudogu/gitops-playground:0.8.0 --version
```

This PR fixes this issue.