### PR TITLE
Fix integration tests for ingress-nginx

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/utils/NetworkingUtils.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/NetworkingUtils.groovy
@@ -24,7 +24,7 @@ class NetworkingUtils {
     String findClusterBindAddress() {
         log.debug("Figuring out the address of the k8s cluster")
 
-        String potentialClusterBindAddress = k8sClient.getInternalNodeIp()
+        String potentialClusterBindAddress = k8sClient.waitForInternalNodeIp()
         potentialClusterBindAddress = potentialClusterBindAddress.replaceAll("'", "")
 
         String localAddress = localAddress

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -35,7 +35,7 @@ class JenkinsTest {
 
     @BeforeEach
     void setup() {
-        // getInternalNodeIp -> waitForNode()
+        // waitForInternalNodeIp -> waitForNode()
         when(k8sClient.waitForNode()).thenReturn("node/${expectedNodeName}".toString())
         when(k8sClient.run(anyString(), anyString(), anyString(), anyMap(), any())).thenReturn('')
     }

--- a/src/test/groovy/com/cloudogu/gitops/integration/GOPSmoketestsIT.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/integration/GOPSmoketestsIT.groovy
@@ -4,6 +4,8 @@ import com.cloudogu.gitops.integration.features.KubenetesApiTestSetup
 import io.kubernetes.client.openapi.models.V1NamespaceList
 import io.kubernetes.client.openapi.models.V1Pod
 import io.kubernetes.client.openapi.models.V1PodList
+import io.kubernetes.client.openapi.models.V1Service
+import io.kubernetes.client.openapi.models.V1ServiceList
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
@@ -57,24 +59,24 @@ class GOPSmoketestsIT extends KubenetesApiTestSetup {
     }
 
     @Test
-    void ensusreNamespacesExists() {
+    void ensureNamespacesExists() {
         List<String> expectedNamespaces = ["argocd",
-                                     "cert-manager",
-                                     "default",
-                                     "example-apps-production",
-                                     "example-apps-staging",
-                                     "ingress-nginx",
-                                     "kube-node-lease",
-                                     "kube-public",
-                                     "kube-system",
-                                     "monitoring",
-                                     "secrets"] as List<String>
+                                           "cert-manager",
+                                           "default",
+                                           "example-apps-production",
+                                           "example-apps-staging",
+                                           "ingress-nginx",
+                                           "kube-node-lease",
+                                           "kube-public",
+                                           "kube-system",
+                                           "monitoring",
+                                           "secrets"] as List<String>
 
 
         V1NamespaceList list = api.listNamespace().execute()
         //      list.items.each {println it.getMetadata().getName()} // print namespaces
         List<String> listOfNamespaces = list.getItems().collect { it.getMetadata().name }
-        assertThat(expectedNamespaces).containsAll (listOfNamespaces)
+        assertThat(expectedNamespaces).containsAll(listOfNamespaces)
 
     }
 
@@ -101,11 +103,16 @@ class GOPSmoketestsIT extends KubenetesApiTestSetup {
     @Override
     boolean isReadyToStartTests() {
         V1PodList list = api.listPodForAllNamespaces()
-                .execute();
-        if (list && !list.items.isEmpty()) {
+                .execute()
+        V1ServiceList services = api.listServiceForAllNamespaces()
+                .execute()
+        if (list && !list.items.isEmpty() &&
+            services && !services.items.isEmpty()) {
 
-            V1Pod argoPod = list.getItems().find { it.getMetadata().getName().startsWith("argo") }
-            if (argoPod) {
+            V1Pod argoPod = list.getItems().find { it.getMetadata().getName().startsWith("argo")}
+            V1Service service = services.getItems()find { it.getMetadata().getName().startsWith("ingress")}
+
+            if (argoPod && service) {
                 return true
             }
         }

--- a/src/test/groovy/com/cloudogu/gitops/utils/K8sClientForTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/K8sClientForTest.groovy
@@ -15,5 +15,6 @@ class K8sClientForTest extends K8sClient {
             }
         })
         commandExecutorForTest = commandExecutor
+        this.SLEEPTIME = 1
     }
 }

--- a/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/K8sClientTest.groovy
@@ -18,10 +18,10 @@ class K8sClientTest {
     void 'Gets internal nodeIp'() {
         // waitForNode()
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/k3d-gitops-playground-server-0', 0))
-        // getInternalNodeIp()
+        // waitForInternalNodeIp()
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', '1.2.3.4', 0))
 
-        def actualNodeIp = k8sClient.getInternalNodeIp()
+        def actualNodeIp = k8sClient.waitForInternalNodeIp()
         
         assertThat(actualNodeIp).isEqualTo('1.2.3.4')
         assertThat(commandExecutor.actualCommands[1]).isEqualTo(
@@ -35,10 +35,10 @@ class K8sClientTest {
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', '', 0))
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', '', 0))
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/k3d-gitops-playground-server-0', 0))
-        // getInternalNodeIp()
+        // waitForInternalNodeIp()
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', '1.2.3.4', 0))
 
-        def actualNodeIp = k8sClient.getInternalNodeIp()
+        def actualNodeIp = k8sClient.waitForInternalNodeIp()
 
         assertThat(actualNodeIp).isEqualTo('1.2.3.4')
     }

--- a/src/test/groovy/com/cloudogu/gitops/utils/NetworkingUtilsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/utils/NetworkingUtilsTest.groovy
@@ -18,9 +18,9 @@ class NetworkingUtilsTest {
     void 'clusterBindAddress: returns bind address for external cluster'() {
         def internalNodeIp = "1.2.3.4"
         def localIp = "5.6.7.8"
-        // getInternalNodeIp -> waitForNode()
+        // waitForInternalNodeIp -> waitForNode()
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/something', 0))
-        // getInternalNodeIp -> actual exec
+        // waitForInternalNodeIp -> actual exec
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', internalNodeIp, 0))
         commandExecutor.enqueueOutput(new CommandExecutor.Output('',
                 "1.0.0.0 via w.x.y.z dev someDevice src ${localIp} uid 1000", 0))
@@ -35,9 +35,9 @@ class NetworkingUtilsTest {
         def internalNodeIp = networkingUtils.localAddress
         assertThat(internalNodeIp).isNotEmpty()
 
-        // getInternalNodeIp -> waitForNode(), don't care
+        // waitForInternalNodeIp -> waitForNode(), don't care
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/something', 0))
-        // getInternalNodeIp -> actual exec
+        // waitForInternalNodeIp -> actual exec
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', internalNodeIp, 0))
 
         def actualBindAddress = networkingUtils.findClusterBindAddress()
@@ -48,9 +48,9 @@ class NetworkingUtilsTest {
     @Test
     void 'clusterBindAddress: fails when no potential bind address'() {
         def internalNodeIp = ''
-        // getInternalNodeIp -> waitForNode()
+        // waitForInternalNodeIp -> waitForNode()
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', 'node/something', 0))
-        // getInternalNodeIp -> actual exec
+        // waitForInternalNodeIp -> actual exec
         k8sClient.commandExecutorForTest.enqueueOutput(new CommandExecutor.Output('', internalNodeIp, 0))
         commandExecutor.enqueueOutput(new CommandExecutor.Output('',
                 "1.0.0.0 via w.x.y.z dev someDevice src 1.2.3.4 uid 1000", 0))
@@ -58,6 +58,6 @@ class NetworkingUtilsTest {
         def exception = shouldFail(RuntimeException) {
             networkingUtils.findClusterBindAddress()
         }
-        assertThat(exception.message).isEqualTo('Could not connect to kubernetes cluster: no cluster bind address')
+        assertThat(exception.message).isEqualTo('Failed to retrieve internal node IP')
     }
 }


### PR DESCRIPTION
Fixed two race condition issues:

- The integration test's start condition only checked for the presence of pods, while the test itself validated the Service. However, at that point, the Service was still in the process of being created.

- We waited for the node to return its name but did not wait for it to retrieve its IP. This occasionally caused flaky tests due to an empty IP value.