### PR TITLE
Fix argocd application is empty

### DIFF
--- a/argocd/argocd/applications/argocd.ftl.yaml
+++ b/argocd/argocd/applications/argocd.ftl.yaml
@@ -22,7 +22,7 @@ spec:
     repoURL: ${scmm.repoUrl}argocd/argocd<#if scmm.provider == "gitlab">.git</#if>
     targetRevision: main
     # needed to sync the operator/rbac folder
-    <#if argocd.isOperator??>
+    <#if argocd.isOperator>
     directory:
       recurse: true
     </#if>

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -237,7 +237,7 @@ scripts/init-cluster.sh --bind-ingress-port="808$INSTANCE" \
   --cluster-name="gitops-playground$INSTANCE" --bind-registry-port="3000$INSTANCE"
 
 docker run --rm -t -u $(id -u) \
- -v "$HOME/.config/k3d/kubeconfig-playground$INSTANCE.yaml:/home/.kube/config" \
+ -v "$HOME/.config/k3d/kubeconfig-gitops-playground$INSTANCE.yaml:/home/.kube/config" \
     --net=host \
     ghcr.io/cloudogu/gitops-playground --yes --internal-registry-port="3000$INSTANCE" -x \
       --base-url="http://localhost:808$INSTANCE" --argocd --ingress-nginx

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -123,7 +123,16 @@ class ArgoCDTest {
         assertThat(filesWithInternalSCMM).isNotEmpty()
         assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['server']['service']['type'])
                 .isEqualTo('ClusterIP')
+        assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['server']['service']['type'])
+                .isEqualTo('ClusterIP')
+        assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['notifications']['argocdUrl']).isNull()
 
+        Map repos = parseActualYaml(actualHelmValuesFile)['argo-cd']['configs']['repositories'] as Map
+        assertThat(repos['prometheus']['url']).isEqualTo('https://prometheus-community.github.io/helm-charts')
+
+        assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['crds']).isNull()
+        assertThat(parseActualYaml(actualHelmValuesFile)['global']).isNull()
+        
         // check repoTemplateSecretName
         k8sCommands.assertExecuted('kubectl create secret generic argocd-repo-creds-scmm -n argocd')
         k8sCommands.assertExecuted('kubectl label secret argocd-repo-creds-scmm -n argocd')
@@ -151,28 +160,25 @@ class ArgoCDTest {
         def deleteCommand = k8sCommands.assertExecuted('kubectl delete secret -n argocd')
         assertThat(deleteCommand).contains('owner=helm', 'name=argocd')
 
-        assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['server']['service']['type'])
-                .isEqualTo('ClusterIP')
-        assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['notifications']['argocdUrl']).isNull()
-
-
-        def namespacesYaml = clusterResourcesRepo.getAbsoluteLocalRepoTmpDir() + "/misc/namespaces.yaml"
-        assertThat(new File(namespacesYaml)).exists()
-        def yaml = parseActualYaml(namespacesYaml)
-        assertThat(yaml[0]['metadata']['name']).isEqualTo('example-apps-staging')
-        assertThat(yaml[1]['metadata']['name']).isEqualTo('example-apps-production')
-
-        Map repos = parseActualYaml(actualHelmValuesFile)['argo-cd']['configs']['repositories'] as Map
-        assertThat(repos['prometheus']['url']).isEqualTo('https://prometheus-community.github.io/helm-charts')
-
+        // Operator disabled
+        def argocdConfigPath = Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), ArgoCD.OPERATOR_CONFIG_PATH)
+        def rbacConfigPath = Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), ArgoCD.OPERATOR_RBAC_PATH)
+        assertThat(argocdConfigPath.toFile()).doesNotExist()
+        assertThat(rbacConfigPath.toFile()).doesNotExist()
+        
+        // Projects
         def clusterRessourcesYaml = new YamlSlurper().parse(Path.of argocdRepo.getAbsoluteLocalRepoTmpDir(), 'projects/cluster-resources.yaml')
         assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).contains(
                 'https://prometheus-community.github.io/helm-charts')
         assertThat(clusterRessourcesYaml['spec']['sourceRepos'] as List).doesNotContain(
-                'http://scmm.scm-manager.svc.cluster.local/scm/repo/3rd-party-dependencies/kube-prometheus-stack')
+                'http://scmm-scm-manager.default.svc.cluster.local/scm/repo/3rd-party-dependencies/kube-prometheus-stack')
+        // The other project files should be validated here as well!
 
-        assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['crds']).isNull()
-        assertThat(parseActualYaml(actualHelmValuesFile)['global']).isNull()
+        // Applications
+        def argocdYaml = new YamlSlurper().parse(Path.of argocdRepo.getAbsoluteLocalRepoTmpDir(), 'applications/argocd.yaml')
+        assertThat(argocdYaml['spec']['source']['directory']).isNull()
+        assertThat(argocdYaml['spec']['source']['path']).isEqualTo('argocd/')
+        // The other application files should be validated here as well!
     }
 
     @Test
@@ -783,9 +789,9 @@ class ArgoCDTest {
         createArgoCD().install()
 
         assertThat(parseActualYaml(actualHelmValuesFile)['argo-cd']['global']['networkPolicy']['create']).isEqualTo(true)
-        assertThat(new File(argocdRepo.getAbsoluteLocalRepoTmpDir(), '/argocd/values.yaml').text.contains("namespace: monitoring")).isTrue()
-        assertThat(new File(argocdRepo.getAbsoluteLocalRepoTmpDir(), '/argocd/templates/allow-namespaces.yaml').text.contains("namespace: monitoring")).isTrue()
-        assertThat(new File(argocdRepo.getAbsoluteLocalRepoTmpDir(), '/argocd/templates/allow-namespaces.yaml').text.contains("namespace: scm-manager")).isTrue()
+        assertThat(new File(argocdRepo.getAbsoluteLocalRepoTmpDir(), '/argocd/values.yaml').text.contains("namespace: monitoring"))
+        assertThat(new File(argocdRepo.getAbsoluteLocalRepoTmpDir(), '/argocd/templates/allow-namespaces.yaml').text.contains("namespace: monitoring"))
+        assertThat(new File(argocdRepo.getAbsoluteLocalRepoTmpDir(), '/argocd/templates/allow-namespaces.yaml').text.contains("namespace: default"))
     }
 
     @Test
@@ -1155,17 +1161,6 @@ class ArgoCDTest {
     }
 
     @Test
-    void 'No files for operator when operator is false'() {
-        createArgoCD().install()
-
-        def argocdConfigPath = Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), ArgoCD.OPERATOR_CONFIG_PATH)
-        def rbacConfigPath = Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), ArgoCD.OPERATOR_RBAC_PATH)
-
-        assertThat(argocdConfigPath.toFile()).doesNotExist()
-        assertThat(rbacConfigPath.toFile()).doesNotExist()
-    }
-
-    @Test
     void 'Deploys with operator without OpenShift configuration'() {
         def argoCD = setupOperatorTest(openshift: false)
 
@@ -1177,6 +1172,11 @@ class ArgoCDTest {
         def yaml = parseActualYaml(argocdConfigPath.toFile().toString())
         assertThat(yaml['spec']['rbac']).isNull()
         assertThat(yaml['spec']['sso']).isNull()
+
+        def argocdYaml = new YamlSlurper().parse(Path.of argocdRepo.getAbsoluteLocalRepoTmpDir(), 'applications/argocd.yaml')
+        assertThat(argocdYaml['spec']['source']['directory']['recurse'] as Boolean).isTrue()
+        assertThat(argocdYaml['spec']['source']['path']).isEqualTo('operator/')
+        // Here we should assert all <#if argocd.isOperator> in YAML 😐️
     }
 
     @Test


### PR DESCRIPTION
Due to a templating error the application that managed Argo CD itself was empty.

That is, Argo CD was installed imperatively on bootstrap but never taken
 under gitops ownership.
![Screenshot from 2025-05-27 13-35-49](https://github.com/user-attachments/assets/dba14c2a-6231-4e8f-8567-cbca4dde3db6)

Managing Argo CD using itself is one of our main promises.
Now,  we fulfill it again 🥳

![Screenshot from 2025-05-27 13-21-58](https://github.com/user-attachments/assets/158ce477-b64d-4e97-a162-94a4e02396e2)

