### PR TITLE
BREAKING: Disables Jenkins, Registry, example content by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ COPY --from=maven-build /app/gitops-playground.jar /app/
 # Create Graal native image config
 RUN java -agentlib:native-image-agent=config-output-dir=conf/ -jar gitops-playground.jar || true
 # Run again with different params in order to avoid NoSuchMethodException with config file
-RUN printf 'content:\n  examples: true\napplication:\n  "yes": true\nfeatures:\n  argocd:\n    active: true\n    env:\n      - name: mykey\n        value: myValue\n  secrets:\n    vault:\n      mode: "dev"\n  exampleApps:\n    petclinic:\n      baseDomain: "base"' > config.yaml && \
+RUN printf 'registry:\n  active: true\njenkins:\n  active: true\ncontent:\n  examples: true\napplication:\n  "yes": true\nfeatures:\n  argocd:\n    active: true\n    env:\n      - name: mykey\n        value: myValue\n  secrets:\n    vault:\n      mode: "dev"\n  exampleApps:\n    petclinic:\n      baseDomain: "base"' > config.yaml && \
     java -agentlib:native-image-agent=config-merge-dir=conf/ -jar gitops-playground.jar \
       --trace --config-file=config.yaml || true
 # Run again with different params in order to avoid NoSuchMethodException with output-config file

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ COPY --from=maven-build /app/gitops-playground.jar /app/
 # Create Graal native image config
 RUN java -agentlib:native-image-agent=config-output-dir=conf/ -jar gitops-playground.jar || true
 # Run again with different params in order to avoid NoSuchMethodException with config file
-RUN printf 'application:\n  "yes": true\nfeatures:\n  argocd:\n    active: true\n    env:\n      - name: mykey\n        value: myValue\n  secrets:\n    vault:\n      mode: "dev"\n  exampleApps:\n    petclinic:\n      baseDomain: "base"' > config.yaml && \
+RUN printf 'content:\n  examples: true\napplication:\n  "yes": true\nfeatures:\n  argocd:\n    active: true\n    env:\n      - name: mykey\n        value: myValue\n  secrets:\n    vault:\n      mode: "dev"\n  exampleApps:\n    petclinic:\n      baseDomain: "base"' > config.yaml && \
     java -agentlib:native-image-agent=config-merge-dir=conf/ -jar gitops-playground.jar \
       --trace --config-file=config.yaml || true
 # Run again with different params in order to avoid NoSuchMethodException with output-config file

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ node('high-cpu') {
                                         .inside("-e KUBECONFIG=${env.WORKSPACE}/.kube/config " +
                                                 " --network=host --entrypoint=''") {
                                             sh "/app/apply-ng --yes --trace --internal-registry-port=${registryPort} " +
-                                                    "--content-examples'" + 
+                                                    "--registry --jenkins --content-examples " + 
                                                     "--argocd --monitoring --vault=dev --ingress-nginx --mailhog --base-url=http://localhost --cert-manager"
                                         }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,6 +98,7 @@ node('high-cpu') {
                                         .inside("-e KUBECONFIG=${env.WORKSPACE}/.kube/config " +
                                                 " --network=host --entrypoint=''") {
                                             sh "/app/apply-ng --yes --trace --internal-registry-port=${registryPort} " +
+                                                    "--content-examples'" + 
                                                     "--argocd --monitoring --vault=dev --ingress-nginx --mailhog --base-url=http://localhost --cert-manager"
                                         }
                             }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ bash <(curl -s \
     -v ~/.config/k3d/kubeconfig-gitops-playground.yaml:/home/.kube/config \
     --net=host \
     ghcr.io/cloudogu/gitops-playground --yes --argocd --ingress-nginx --base-url=http://localhost
-# If you want to try all features, you might want to add these params: --mail --monitoring --vault=dev
+# More IDP-features: --mailhog --monitoring --vault=dev --cert-manager
+# More features for developers: --jenkins --registry --content-examples
 ```
 
 Note that on some linux distros like debian do not support subdomains of localhost.
@@ -956,7 +957,12 @@ The following video shows this demo in time-lapse:
 The playground comes with example applications that provide a turnkey solution for GitOps-Pipelines  
 from a developer's point of view.
 
-This includes staging and production environments, providing a ready-to-use solution for promotion.
+These can be enabled using `--content-examples`.  
+They require a registry, so locally use `--registry` or pass in an existing instance using `registry-url`.  
+The examples very much rely on jenkins. So it is recommended to enable it using `--jenkins` or pass in an existing 
+instance using `--jenkins-url`.  
+
+The examples include staging and production environments, providing a ready-to-use solution for promotion.
 
 All applications are deployed via separated application and GitOps repos:
 

--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -144,6 +144,17 @@
       "additionalProperties" : false,
       "description" : "Application configuration parameter for GOP"
     },
+    "content" : {
+      "type" : [ "object", "null" ],
+      "properties" : {
+        "examples" : {
+          "type" : [ "boolean", "null" ],
+          "description" : "Deploy example content: source repos, GitOps repos, Jenkins Job, Argo CD apps/project"
+        }
+      },
+      "additionalProperties" : false,
+      "description" : "Config parameters for content, i.e. end-user or tenant applications as opposed to cluster-resources"
+    },
     "features" : {
       "type" : [ "object", "null" ],
       "properties" : {
@@ -565,6 +576,10 @@
     "jenkins" : {
       "type" : [ "object", "null" ],
       "properties" : {
+        "active" : {
+          "type" : [ "boolean", "null" ],
+          "description" : "Installs Jenkins as CI server"
+        },
         "additionalEnvs" : {
           "anyOf" : [ {
             "type" : "null"
@@ -611,6 +626,10 @@
     "registry" : {
       "type" : [ "object", "null" ],
       "properties" : {
+        "active" : {
+          "type" : [ "boolean", "null" ],
+          "description" : "Installs a simple cluster-local registry for demonstration purposes. Warning: Registry does not provide authentication!"
+        },
         "createImagePullSecrets" : {
           "type" : [ "boolean", "null" ],
           "description" : "Create image pull secrets for registry and proxy-registry for all GOP namespaces and helm charts. Uses proxy-username, read-only-username or registry-username (in this order).  Use this if your cluster is not auto-provisioned with credentials for your private registries or if you configure individual helm images to be pulled from the proxy-registry that requires authentication."

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -185,7 +185,7 @@ We should automate this!
     `JENKINS_PLUGIN_FOLDER=$(pwd) java -classpath .. # See above`.  
     A working combination of plugins be extracted from the image:
       ```bash
-      id=$(docker create --pull=always ghcr.io/cloudogu/gitops-playground)
+      id=$(docker create --pull=always ghcr.io/cloudogu/gitops-playground:main)
       docker cp $id:/gitops/jenkins-plugins .
       docker rm -v $id
       ```

--- a/scripts/scm-manager/init-scmm.sh
+++ b/scripts/scm-manager/init-scmm.sh
@@ -36,12 +36,12 @@ function initSCMM() {
         "${SCMM_URL_FOR_JENKINS}" "${INSTALL_ARGOCD}"
   fi
 
-
-
-  pushHelmChartRepo "3rd-party-dependencies/spring-boot-helm-chart"
-  pushHelmChartRepoWithDependency "3rd-party-dependencies/spring-boot-helm-chart-with-dependency"
-  pushRepoMirror "${GITOPS_BUILD_LIB_REPO}" "3rd-party-dependencies/gitops-build-lib"
-  pushRepoMirror "${CES_BUILD_LIB_REPO}" "3rd-party-dependencies/ces-build-lib" 'develop'
+  if [[ $CONTENT_EXAMPLES == true ]]; then
+    pushHelmChartRepo "3rd-party-dependencies/spring-boot-helm-chart"
+    pushHelmChartRepoWithDependency "3rd-party-dependencies/spring-boot-helm-chart-with-dependency"
+    pushRepoMirror "${GITOPS_BUILD_LIB_REPO}" "3rd-party-dependencies/gitops-build-lib"
+    pushRepoMirror "${CES_BUILD_LIB_REPO}" "3rd-party-dependencies/ces-build-lib" 'develop'
+  fi
 }
 
 
@@ -182,6 +182,16 @@ function configureScmmManager() {
 
   ### ArgoCD Repos
   if [[ $INSTALL_ARGOCD == true ]]; then
+    addRepo "${NAME_PREFIX}argocd" "argocd" "GitOps repo for administration of ArgoCD"
+    setPermission "${NAME_PREFIX}argocd" "argocd" "${GITOPS_USERNAME}" "WRITE"
+      
+    addRepo "${NAME_PREFIX}argocd" "cluster-resources" "GitOps repo for basic cluster-resources"
+    setPermission "${NAME_PREFIX}argocd" "cluster-resources" "${GITOPS_USERNAME}" "WRITE"
+
+    setPermissionForNamespace "${NAME_PREFIX}argocd" "${GITOPS_USERNAME}" "CI-SERVER"
+  fi
+
+  if [[ $CONTENT_EXAMPLES == true ]]; then
     addRepo "${NAME_PREFIX}argocd" "nginx-helm-jenkins" "3rd Party app (NGINX) with helm, templated in Jenkins (gitops-build-lib)"
     setPermission "${NAME_PREFIX}argocd" "nginx-helm-jenkins" "${GITOPS_USERNAME}" "WRITE"
     
@@ -191,40 +201,32 @@ function configureScmmManager() {
     addRepo "${NAME_PREFIX}argocd" "petclinic-helm" "Java app with custom helm chart"
     setPermission "${NAME_PREFIX}argocd" "petclinic-helm" "${GITOPS_USERNAME}" "WRITE"
   
-    addRepo "${NAME_PREFIX}argocd" "argocd" "GitOps repo for administration of ArgoCD"
-    setPermission "${NAME_PREFIX}argocd" "argocd" "${GITOPS_USERNAME}" "WRITE"
-      
-    addRepo "${NAME_PREFIX}argocd" "cluster-resources" "GitOps repo for basic cluster-resources"
-    setPermission "${NAME_PREFIX}argocd" "cluster-resources" "${GITOPS_USERNAME}" "WRITE"
-    
     addRepo "${NAME_PREFIX}argocd" "example-apps" "GitOps repo for examples of end-user applications"
     setPermission "${NAME_PREFIX}argocd" "example-apps" "${GITOPS_USERNAME}" "WRITE"
-
-    setPermissionForNamespace "${NAME_PREFIX}argocd" "${GITOPS_USERNAME}" "CI-SERVER"
-  fi
-
-  ### Repos with replicated dependencies
-  addRepo "3rd-party-dependencies" "spring-boot-helm-chart"
-  setPermission "3rd-party-dependencies" "spring-boot-helm-chart" "${GITOPS_USERNAME}" "WRITE"
-
-  addRepo "3rd-party-dependencies" "spring-boot-helm-chart-with-dependency"
-  setPermission "3rd-party-dependencies" "spring-boot-helm-chart-with-dependency" "${GITOPS_USERNAME}" "WRITE"
-
-  addRepo "3rd-party-dependencies" "gitops-build-lib" "Jenkins pipeline shared library for automating deployments via GitOps "
-  setPermission "3rd-party-dependencies" "gitops-build-lib" "${GITOPS_USERNAME}" "WRITE"
-
-  addRepo "3rd-party-dependencies" "ces-build-lib" "Jenkins pipeline shared library adding features for Maven, Gradle, Docker, SonarQube, Git and others"
-  setPermission "3rd-party-dependencies" "ces-build-lib" "${GITOPS_USERNAME}" "WRITE"
-
-  ### Exercise Repos
-  addRepo "${NAME_PREFIX}exercises" "petclinic-helm"
-  setPermission "${NAME_PREFIX}exercises" "petclinic-helm" "${GITOPS_USERNAME}" "WRITE"
-
-  addRepo "${NAME_PREFIX}exercises" "nginx-validation"
-  setPermission "${NAME_PREFIX}exercises" "nginx-validation" "${GITOPS_USERNAME}" "WRITE"
-
-  addRepo "${NAME_PREFIX}exercises" "broken-application"
-  setPermission "${NAME_PREFIX}exercises" "broken-application" "${GITOPS_USERNAME}" "WRITE"
+    
+    ### Repos with replicated dependencies
+    addRepo "3rd-party-dependencies" "spring-boot-helm-chart"
+    setPermission "3rd-party-dependencies" "spring-boot-helm-chart" "${GITOPS_USERNAME}" "WRITE"
+  
+    addRepo "3rd-party-dependencies" "spring-boot-helm-chart-with-dependency"
+    setPermission "3rd-party-dependencies" "spring-boot-helm-chart-with-dependency" "${GITOPS_USERNAME}" "WRITE"
+  
+    addRepo "3rd-party-dependencies" "gitops-build-lib" "Jenkins pipeline shared library for automating deployments via GitOps "
+    setPermission "3rd-party-dependencies" "gitops-build-lib" "${GITOPS_USERNAME}" "WRITE"
+  
+    addRepo "3rd-party-dependencies" "ces-build-lib" "Jenkins pipeline shared library adding features for Maven, Gradle, Docker, SonarQube, Git and others"
+    setPermission "3rd-party-dependencies" "ces-build-lib" "${GITOPS_USERNAME}" "WRITE"
+  
+    ### Exercise Repos
+    addRepo "${NAME_PREFIX}exercises" "petclinic-helm"
+    setPermission "${NAME_PREFIX}exercises" "petclinic-helm" "${GITOPS_USERNAME}" "WRITE"
+  
+    addRepo "${NAME_PREFIX}exercises" "nginx-validation"
+    setPermission "${NAME_PREFIX}exercises" "nginx-validation" "${GITOPS_USERNAME}" "WRITE"
+  
+    addRepo "${NAME_PREFIX}exercises" "broken-application"
+    setPermission "${NAME_PREFIX}exercises" "broken-application" "${GITOPS_USERNAME}" "WRITE"
+  fi 
 
   # Install necessary plugins
   installScmmPlugin "scm-mail-plugin" "false"

--- a/src/main/groovy/com/cloudogu/gitops/Application.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/Application.groovy
@@ -37,7 +37,7 @@ class Application {
         Set<String> namespaces = new HashSet<>()
         String namePrefix = config.application.namePrefix
 
-        if (config.features.argocd.active) {
+        if (config.content.examples) {
             namespaces.addAll(Arrays.asList(
                     namePrefix + "example-apps-staging",
                     namePrefix + "example-apps-production"

--- a/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
@@ -82,6 +82,16 @@ class Config {
     @Mixin
     FeaturesSchema features = new FeaturesSchema()
 
+    @JsonPropertyDescription(CONTENT_DESCRIPTION)
+    @Mixin
+    ContentSchema content = new ContentSchema()
+
+    class ContentSchema {
+        @Option(names = ['--content-examples'], description = CONTENT_EXAMPLES_DESCRIPTION)
+        @JsonPropertyDescription(CONTENT_EXAMPLES_DESCRIPTION)
+        Boolean examples = false
+    }
+
     static class HelmConfig {
         @JsonPropertyDescription(HELM_CONFIG_CHART_DESCRIPTION)
         String chart = ''
@@ -100,6 +110,10 @@ class Config {
         Boolean internal = true
         Boolean twoRegistries = false
 
+        @Option(names = ['--registry'], description = REGISTRY_ENABLE_DESCRIPTION)
+        @JsonPropertyDescription(REGISTRY_ENABLE_DESCRIPTION)
+        Boolean active = false
+        
         @Option(names = ['--internal-registry-port'], description = REGISTRY_INTERNAL_PORT_DESCRIPTION)
         @JsonPropertyDescription(REGISTRY_INTERNAL_PORT_DESCRIPTION)
         Integer internalPort = DEFAULT_REGISTRY_PORT
@@ -173,6 +187,10 @@ class Config {
           $ curl -s https://download.docker.com/linux/debian/dists/bullseye/stable/binary-amd64/Packages  | grep -EA5 'Package\: docker-ce$' | grep Version | sort | uniq | tail -n1
           Version: 5:27.1.1-1~debian.11~bullseye */
         String internalDockerClientVersion = '27.1.2'
+
+        @Option(names = ['--jenkins'], description = JENKINS_ENABLE_DESCRIPTION)
+        @JsonPropertyDescription(JENKINS_ENABLE_DESCRIPTION)
+        Boolean active = false
 
         @Option(names = ['--jenkins-url'], description = JENKINS_URL_DESCRIPTION)
         @JsonPropertyDescription(JENKINS_URL_DESCRIPTION)

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -23,6 +23,11 @@ interface ConfigConstants {
     String REGISTRY_CREATE_IMAGE_PULL_SECRETS_DESCRIPTION = 'Create image pull secrets for registry and proxy-registry for all GOP namespaces and helm charts. Uses proxy-username, read-only-username or registry-username (in this order).  Use this if your cluster is not auto-provisioned with credentials for your private registries or if you configure individual helm images to be pulled from the proxy-registry that requires authentication.'
 
     String FEATURES_DESCRIPTION = 'Config parameters for features or tools'
+
+    String CONTENT_DESCRIPTION = 'Config parameters for content, i.e. end-user or tenant applications as opposed to cluster-resources'
+
+    // Content
+    String CONTENT_EXAMPLES_DESCRIPTION = 'Deploy example content: source repos, GitOps repos, Jenkins Job, Argo CD apps/project'
     
     // group jenkins
     String JENKINS_DESCRIPTION = 'Config parameters for Jenkins CI/CD Pipeline Server'

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -7,6 +7,7 @@ interface ConfigConstants {
     public static final String APP_DESCRIPTION = 'CLI-tool to deploy gitops-playground.'
     
     // group registry
+    String REGISTRY_ENABLE_DESCRIPTION = 'Installs a simple cluster-local registry for demonstration purposes. Warning: Registry does not provide authentication!'
     String REGISTRY_DESCRIPTION = 'Config parameters for Registry'
     String REGISTRY_INTERNAL_PORT_DESCRIPTION = 'Port of registry registry. Ignored when a registry*url params are set'
     String REGISTRY_URL_DESCRIPTION = 'The url of your external registry, used for pushing images'
@@ -30,6 +31,7 @@ interface ConfigConstants {
     String CONTENT_EXAMPLES_DESCRIPTION = 'Deploy example content: source repos, GitOps repos, Jenkins Job, Argo CD apps/project'
     
     // group jenkins
+    String JENKINS_ENABLE_DESCRIPTION = 'Installs Jenkins as CI server'
     String JENKINS_DESCRIPTION = 'Config parameters for Jenkins CI/CD Pipeline Server'
     String JENKINS_URL_DESCRIPTION = 'The url of your external jenkins'
     String JENKINS_USERNAME_DESCRIPTION = 'Mandatory when jenkins-url is set'

--- a/src/main/groovy/com/cloudogu/gitops/features/Content.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Content.groovy
@@ -32,7 +32,7 @@ class Content extends Feature {
 
     @Override
     void enable() {
-        if (config.registry.createImagePullSecrets) {
+        if (config.registry.createImagePullSecrets && config.content.examples) {
             String registryUsername = config.registry.readOnlyUsername ?: config.registry.username
             String registryPassword = config.registry.readOnlyPassword ?: config.registry.password
 

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -65,8 +65,7 @@ class Jenkins extends Feature {
 
     @Override
     boolean isEnabled() {
-        return true
-//        return true // For now, we either deploy an internal or configure an external instance
+        return config.jenkins.active
     }
 
     @Override

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -179,7 +179,7 @@ class Jenkins extends Feature {
 
         prometheusConfigurator.enableAuthentication()
 
-        if (config.features.argocd.active) {
+        if (config.content.examples) {
 
             String jobName = "${config.application.namePrefix}example-apps"
             def credentialId = "scmm-user"

--- a/src/main/groovy/com/cloudogu/gitops/features/Registry.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Registry.groovy
@@ -46,56 +46,58 @@ class Registry extends Feature {
 
     @Override
     boolean isEnabled() {
-        return config.registry.internal
+        return config.registry.active
     }
 
     @Override
     void enable() {
 
-        def helmConfig = config.registry.helm
+        if (config.registry.internal) {
 
-        Map yaml = [
-                service: [
-                        nodePort: Config.DEFAULT_REGISTRY_PORT,
-                        type: 'NodePort'
-                ]
-        ]
-        def mergedMap = MapUtils.deepMerge(helmConfig.values, yaml)
+            def helmConfig = config.registry.helm
 
-        def tempValuesPath = fileSystemUtils.writeTempFile(mergedMap)
-        log.trace("Helm yaml to be applied: ${yaml}")
+            Map yaml = [
+                    service: [
+                            nodePort: Config.DEFAULT_REGISTRY_PORT,
+                            type    : 'NodePort'
+                    ]
+            ]
+            def mergedMap = MapUtils.deepMerge(helmConfig.values, yaml)
+
+            def tempValuesPath = fileSystemUtils.writeTempFile(mergedMap)
+            log.trace("Helm yaml to be applied: ${yaml}")
 
 
-        deployer.deployFeature(
-                helmConfig.repoURL,
-                'registry',
-                helmConfig.chart,
-                helmConfig.version,
-                namespace,
-                'docker-registry',
-                tempValuesPath
-        )
+            deployer.deployFeature(
+                    helmConfig.repoURL,
+                    'registry',
+                    helmConfig.chart,
+                    helmConfig.version,
+                    namespace,
+                    'docker-registry',
+                    tempValuesPath
+            )
 
-        if (config.registry.internalPort != Config.DEFAULT_REGISTRY_PORT) {
-            /* Add additional node port
+            if (config.registry.internalPort != Config.DEFAULT_REGISTRY_PORT) {
+                /* Add additional node port
                30000 is needed as a static by docker via port mapping of k3d, e.g. 32769 -> 30000 on server-0 container
                See "-p 30000" in init-cluster.sh
                e.g 32769 is needed so the kubelet can access the image inside the server-0 container
              */
-            k8sClient.createServiceNodePort('docker-registry-internal-port',
-                    CONTAINER_PORT, config.registry.internalPort.toString(),
-                    namespace)
+                k8sClient.createServiceNodePort('docker-registry-internal-port',
+                        CONTAINER_PORT, config.registry.internalPort.toString(),
+                        namespace)
+            }
+
+            deployer.deployFeature(
+                    helmConfig.repoURL,
+                    'registry',
+                    helmConfig.chart,
+                    helmConfig.version,
+                    namespace,
+                    'docker-registry',
+                    tempValuesPath
+            )
         }
-
-        deployer.deployFeature(
-                helmConfig.repoURL,
-                'registry',
-                helmConfig.chart,
-                helmConfig.version,
-                namespace,
-                'docker-registry',
-                tempValuesPath
-        )
-
     }
 }

--- a/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
@@ -141,6 +141,7 @@ class ScmManager extends Feature {
                 INSECURE                     : config.application.insecure,
                 SCM_ROOT_PATH                : config.scmm.rootPath,
                 SCM_PROVIDER                 : config.scmm.provider,
+                CONTENT_EXAMPLES             : config.content.examples
         ])
     }
 

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
@@ -24,6 +24,8 @@ class ApplicationTest {
 
     @Test
     void 'get active namespaces correctly'() {
+        config.registry.active = true
+        config.jenkins.active = true
         config.features.monitoring.active = true
         config.features.argocd.active = true
         config.content.examples = true
@@ -47,6 +49,8 @@ class ApplicationTest {
     }
     @Test
     void 'get active namespaces correctly in Openshift'() {
+        config.registry.active = true
+        config.jenkins.active = true
         config.features.monitoring.active = true
         config.features.argocd.active = true
         config.content.examples = true

--- a/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/ApplicationTest.groovy
@@ -26,6 +26,7 @@ class ApplicationTest {
     void 'get active namespaces correctly'() {
         config.features.monitoring.active = true
         config.features.argocd.active = true
+        config.content.examples = true
         config.features.ingressNginx.active = true
         config.application.namePrefix = 'test1-'
         List<String> namespaceList = new ArrayList<>(Arrays.asList(
@@ -48,6 +49,7 @@ class ApplicationTest {
     void 'get active namespaces correctly in Openshift'() {
         config.features.monitoring.active = true
         config.features.argocd.active = true
+        config.content.examples = true
         config.features.ingressNginx.active = true
         config.application.namePrefix = 'test1-'
         config.application.openshift = true

--- a/src/test/groovy/com/cloudogu/gitops/config/schema/ConfigTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/config/schema/ConfigTest.groovy
@@ -18,8 +18,6 @@ class ConfigTest {
         assertThat(config).startsWith("""---
 registry:
   internal: true
-  twoRegistries: true
-  internalPort: 123
 """)
     }
 
@@ -30,7 +28,7 @@ registry:
 
         assertThat(config).startsWith("""---
 registry:
-  internalPort: 123
+  active: false
 """)
     }
     

--- a/src/test/groovy/com/cloudogu/gitops/features/ContentTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ContentTest.groovy
@@ -26,6 +26,7 @@ class ContentTest {
 
     @Test
     void 'deploys image pull secrets'() {
+        config.content.examples = true
         config.registry.createImagePullSecrets = true
 
         createContent().install()
@@ -35,6 +36,7 @@ class ContentTest {
 
     @Test
     void 'deploys image pull secrets from read-only vars'() {
+        config.content.examples = true
         config.registry.createImagePullSecrets = true
         config.registry.readOnlyUsername = 'other-user'
         config.registry.readOnlyPassword = 'other-pw'
@@ -46,6 +48,7 @@ class ContentTest {
 
     @Test
     void 'deploys additional image pull secrets for proxy registry'() {
+        config.content.examples = true
         config.registry.createImagePullSecrets = true
         config.registry.twoRegistries = true
         config.registry.proxyUrl = 'proxy-url'

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -155,6 +155,7 @@ me:x:1000:''')
         config.application.remote = true
         config.application.trace = true
         config.features.argocd.active = true
+        config.content.examples = true
         config.scmm.url = 'http://scmm'
         config.scmm.urlForJenkins ='http://scmm/scm'
         config.scmm.username = 'scmm-usr'
@@ -249,7 +250,7 @@ me:x:1000:''')
     @Test
     void 'Handles two registries'() {
         config.registry.twoRegistries = true
-        config.features.argocd.active = true
+        config.content.examples = true
         config.application.namePrefix = 'my-prefix-'
         config.application.namePrefixForEnvVars = 'MY_PREFIX_'
         

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
 
 class JenkinsTest {
-    Config config = new Config()
+    Config config = new Config( jenkins: new Config.JenkinsSchema(active: true))
 
     String expectedNodeName = 'something'
     

--- a/src/test/groovy/com/cloudogu/gitops/features/RegistryTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/RegistryTest.groovy
@@ -22,9 +22,7 @@ class RegistryTest {
 
     @Test
     void 'is disabled when external registry is configured'() {
-        def registryConfig = new RegistrySchema(internal: false)
-        
-        createRegistry(registryConfig).install()
+        createRegistry().install()
 
         assertThat(helmCommands.actualCommands).isEmpty()
         assertThat(k8sClient.commandExecutorForTest.actualCommands).isEmpty()
@@ -32,7 +30,7 @@ class RegistryTest {
 
     @Test
     void 'is installed'() {
-        createRegistry().install()
+        createRegistry(new RegistrySchema(active: true)).install()
 
         assertThat(parseActualYaml()['service']['nodePort']).isEqualTo(DEFAULT_REGISTRY_PORT)
         assertThat(parseActualYaml()['service']['type']).isEqualTo('NodePort')
@@ -49,7 +47,7 @@ class RegistryTest {
     @Test
     void 'creates an additional service when different port is set'() {
         def expectedNodePort = DEFAULT_REGISTRY_PORT as int + 1
-        def registryConfig = new RegistrySchema(internalPort: expectedNodePort)
+        def registryConfig = new RegistrySchema(active: true, internalPort: expectedNodePort)
         
         createRegistry(registryConfig).install()
 
@@ -58,7 +56,7 @@ class RegistryTest {
 
     @Test
     void 'inject custom value into chart'() {
-        def registryConfig = new RegistrySchema(internal: true,
+        def registryConfig = new RegistrySchema(active: true,
                 helm: new HelmConfigWithValues(
                         chart: 'test',
                         values: [

--- a/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
@@ -110,6 +110,7 @@ class ScmManagerTest {
         assertThat(env['CES_BUILD_LIB_REPO']).isEqualTo('cesBuildLibUrl')
         assertThat(env['NAME_PREFIX']).isEqualTo('foo-')
         assertThat(env['INSECURE']).isEqualTo('false')
+        assertThat(env['CONTENT_EXAMPLES']).isEqualTo('false')
     }
 
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -65,6 +65,9 @@ class ArgoCDTest {
                             url: 'https://github.com/cloudogu/ces-build-lib.git',
                     ]
             ],
+            content: [
+                    examples: true
+            ],
             features    : [
                     argocd      : [
                             operator    : false,
@@ -179,6 +182,22 @@ class ArgoCDTest {
         assertThat(argocdYaml['spec']['source']['directory']).isNull()
         assertThat(argocdYaml['spec']['source']['path']).isEqualTo('argocd/')
         // The other application files should be validated here as well!
+        
+        // Content examples
+        assertThat(Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'projects/example-apps.yaml')).exists()
+        assertThat(Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'applications/example-apps.yaml')).exists()
+    }
+
+
+    @Test
+    void 'Disables example content'() {
+        config.content.examples = false
+
+        def argocd = createArgoCD()
+        argocd.install()
+        
+        assertThat(Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'projects/example-apps.yaml')).doesNotExist()
+        assertThat(Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'applications/example-apps.yaml')).doesNotExist()
     }
 
     @Test
@@ -1422,11 +1441,14 @@ class ArgoCDTest {
             argocdRepo = argocdRepoInitializationAction.repo
             actualHelmValuesFile = Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), HELM_VALUES_PATH)
             clusterResourcesRepo = clusterResourcesInitializationAction.repo
-            exampleAppsRepo = exampleAppsInitializationAction.repo
-            nginxHelmJenkinsRepo = nginxHelmJenkinsInitializationAction.repo
-            nginxValidationRepo = nginxValidationInitializationAction.repo
-            brokenApplicationRepo = brokenApplicationInitializationAction.repo
-            petClinicRepos = petClinicInitializationActions.collect { it.repo }
+            
+            if (config.content.examples) {
+                exampleAppsRepo = exampleAppsInitializationAction.repo
+                nginxHelmJenkinsRepo = nginxHelmJenkinsInitializationAction.repo
+                nginxValidationRepo = nginxValidationInitializationAction.repo
+                brokenApplicationRepo = brokenApplicationInitializationAction.repo
+                petClinicRepos = petClinicInitializationActions.collect { it.repo }
+            }
         }
 
         @Override

--- a/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/argocd/ArgoCDTest.groovy
@@ -188,7 +188,6 @@ class ArgoCDTest {
         assertThat(Path.of(argocdRepo.getAbsoluteLocalRepoTmpDir(), 'applications/example-apps.yaml')).exists()
     }
 
-
     @Test
     void 'Disables example content'() {
         config.content.examples = false


### PR DESCRIPTION
This is part of our ongoing effort to make everything opt-in.

Breaking change for local installations:  
now `--jenkins --registry --content-examples` are necessary.

When running remotely, using `registry.url` and `jenkins.url` nothing changes, but `content.examples` will have to be set to `true`.

After this only SCM-Manager is installed (if no external scm-url is passed).
