### PR TITLE
Fix missing space in Maven checkstyle skip flag in Jenkinsfiles

### DIFF
--- a/applications/argocd/petclinic/helm/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/helm/Jenkinsfile.ftl
@@ -68,7 +68,7 @@ node {
 
         stage('Test') {
             // Disable database integration tests because they start docker images (which won't work in air-gapped envs and take a lot of time in demos)
-            mvn "test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip" +
+            mvn "test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip " +
             '-Dtest=!org.springframework.samples.petclinic.MySqlIntegrationTests,!org.springframework.samples.petclinic.PostgresIntegrationTests'
         }
 

--- a/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
+++ b/applications/argocd/petclinic/plain-k8s/Jenkinsfile.ftl
@@ -61,7 +61,7 @@ node {
 
         stage('Test') {
             // Disable database integration tests because they start docker images (which won't work in air-gapped envs and take a lot of time in demos)
-            mvn 'test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip'
+            mvn 'test -Dmaven.test.failure.ignore=true -Dcheckstyle.skip ' +
             '-Dtest=!org.springframework.samples.petclinic.MySqlIntegrationTests,!org.springframework.samples.petclinic.PostgresIntegrationTests'
         }
 


### PR DESCRIPTION
- Add trailing space after -Dcheckstyle.skip in test stage of both Jenkinsfiles.
- This ensures the checkstyle skip flag is correctly recognized by Maven, preventing checkstyle errors during test execution.