### PR TITLE
feat: add multi-tenancy support for argocd-operator

### DIFF
--- a/argocd/argocd/operator/argocd.ftl.yaml
+++ b/argocd/argocd/operator/argocd.ftl.yaml
@@ -103,6 +103,7 @@ spec:
     </#list>
     </#if>
   server:
+    insecure: ${isInsecure?c}
     resources:
       limits:
         cpu: "500m"
@@ -120,6 +121,11 @@ spec:
     route:
       enabled: ${isOpenshift?c}
     host: "${argocd.host}"
+    # Enable ingress only if we are not on OpenShift and insecure mode is NOT enabled.
+    # Note: When insecure mode is enabled, forced HTTP redirect to HTTPS cannot be disabled here(likely due to a bug),
+    # so we cannot use this ingress for insecure mode. For insecure mode we use a separate file (ingress.ftl.yaml).
+    ingress:
+      enabled: ${((!isOpenshift) && (!isInsecure))?c}
   initialRepositories: |
     - name: argocd
       url: ${scmm.repoUrl}argocd/argocd<#if scmm.provider == "gitlab">.git</#if>
@@ -144,6 +150,13 @@ spec:
       type: helm
       url: https://kubernetes.github.io/ingress-nginx
   resourceInclusions: |
+    - apiGroups:
+      - "batch"
+      kinds:
+      - "Job"
+      clusters:
+      - "https://kubernetes.default.svc"
+      - "${argocd.resourceInclusionsCluster}"
     - apiGroups:
       - ""
       kinds:

--- a/argocd/argocd/operator/ingress.ftl.yaml
+++ b/argocd/argocd/operator/ingress.ftl.yaml
@@ -1,0 +1,25 @@
+  <#if (!isOpenshift && isInsecure)>
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: argocd
+    namespace: "${namePrefix}argocd"
+    labels:
+      app: argocd-server
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+  spec:
+    rules:
+      - host: "${argocd.host}"
+        http:
+          paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                service:
+                  name: argocd-server
+                  port:
+                    number: 80
+    </#if>
+

--- a/argocd/argocd/operator/rbac/example-apps-production.ftl.yaml
+++ b/argocd/argocd/operator/rbac/example-apps-production.ftl.yaml
@@ -5,6 +5,18 @@ metadata:
   name: argocd
 rules:
   - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - "route.openshift.io"
     resources:
       - routes
@@ -170,13 +182,13 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: argocd-argocd-server
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-argocd-application-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-applicationset-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
 roleRef:
   kind: Role
   name: argocd

--- a/argocd/argocd/operator/rbac/example-apps-staging.ftl.yaml
+++ b/argocd/argocd/operator/rbac/example-apps-staging.ftl.yaml
@@ -5,6 +5,18 @@ metadata:
   name: argocd
 rules:
   - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - "route.openshift.io"
     resources:
       - routes
@@ -170,13 +182,13 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: argocd-argocd-server
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-argocd-application-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-applicationset-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
 roleRef:
   kind: Role
   name: argocd

--- a/argocd/argocd/operator/rbac/ingress-nginx.ftl.yaml
+++ b/argocd/argocd/operator/rbac/ingress-nginx.ftl.yaml
@@ -5,6 +5,18 @@ metadata:
   name: argocd
 rules:
   - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - "route.openshift.io"
     resources:
       - routes
@@ -170,13 +182,13 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: argocd-argocd-server
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-argocd-application-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-applicationset-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
 roleRef:
   kind: Role
   name: argocd

--- a/argocd/argocd/operator/rbac/monitoring.ftl.yaml
+++ b/argocd/argocd/operator/rbac/monitoring.ftl.yaml
@@ -5,6 +5,18 @@ metadata:
   name: argocd
 rules:
   - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - "route.openshift.io"
     resources:
       - routes
@@ -170,13 +182,13 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: argocd-argocd-server
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-argocd-application-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-applicationset-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
 roleRef:
   kind: Role
   name: argocd

--- a/argocd/argocd/operator/rbac/secrets.ftl.yaml
+++ b/argocd/argocd/operator/rbac/secrets.ftl.yaml
@@ -5,6 +5,18 @@ metadata:
   name: argocd
 rules:
   - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - "route.openshift.io"
     resources:
       - routes
@@ -170,13 +182,13 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: argocd-argocd-server
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-argocd-application-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
   - kind: ServiceAccount
     name: argocd-applicationset-controller
-    namespace: argocd
+    namespace: "${namePrefix}argocd"
 roleRef:
   kind: Role
   name: argocd

--- a/src/main/groovy/com/cloudogu/gitops/utils/TemplatingEngine.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/utils/TemplatingEngine.groovy
@@ -18,11 +18,17 @@ class TemplatingEngine {
      */
     File replaceTemplate(File templateFile, Map parameters) {
         def targetFile = new File(templateFile.toString().replace(".ftl", ""))
+        def rendered = template(templateFile, parameters)
 
-        template(templateFile, targetFile, parameters)
+        // Only write file if template has non-empty output.
+        // This avoids creating empty files when the entire template is skipped via <#if>.
+        if (rendered?.trim()) {
+            targetFile.text = rendered
+        } else {
+            targetFile.delete()
+        }
 
         templateFile.delete()
-
         return targetFile
     }
 


### PR DESCRIPTION
- Template service account and resource namespaces using `namePrefix`
- Add batch/Job permissions to all RBAC roles
- Set argocd.yaml `.spec.server.insecure` when `--insecure` is enabled
- Conditionally generate ingress.yaml for insecure mode (non-OpenShift), because argocd-operator always enforces https
- Include `batch/Job` in resourceInclusions for operator CR and operator/RBAC
- Prevent creation of empty rendered files when templates are fully conditional
- Add tests covering all new conditional and templated logic