### PR TITLE
Make Jenkins and SCM plugin install and restart optional

### DIFF
--- a/docs/configuration.schema.json
+++ b/docs/configuration.schema.json
@@ -611,6 +611,14 @@
           "type" : [ "string", "null" ],
           "description" : "Mandatory when jenkins-url is set"
         },
+        "skipPlugins" : {
+          "type" : [ "boolean", "null" ],
+          "description" : "Skips plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades."
+        },
+        "skipRestart" : {
+          "type" : [ "boolean", "null" ],
+          "description" : "Skips restarting Jenkins after plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades."
+        },
         "url" : {
           "type" : [ "string", "null" ],
           "description" : "The url of your external jenkins"
@@ -723,6 +731,14 @@
         "rootPath" : {
           "type" : [ "string", "null" ],
           "description" : "Sets the root path for the Git Repositories. In SCM-Manager it is always \"repo\""
+        },
+        "skipPlugins" : {
+          "type" : [ "boolean", "null" ],
+          "description" : "Skips plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades."
+        },
+        "skipRestart" : {
+          "type" : [ "boolean", "null" ],
+          "description" : "Skips restarting SCM-Manager after plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades.'"
         },
         "url" : {
           "type" : [ "string", "null" ],

--- a/scripts/jenkins/init-jenkins.sh
+++ b/scripts/jenkins/init-jenkins.sh
@@ -39,6 +39,11 @@ function waitForJenkins() {
 }
 
 function installPlugins() {
+  if [[ "${SKIP_PLUGINS:-false}" == "true" ]]; then
+    echo "Skipping Jenkins plugin installation due to SKIP_PLUGIN=true"
+    return
+  fi
+
   local pluginFolder
 
   waitForJenkins
@@ -66,13 +71,17 @@ function installPlugins() {
   done
   echo ""
 
-  safeRestart
+  if [[ "${SKIP_RESTART:-false}" != "true" ]]; then
+    safeRestart
 
-  # we add a sleep here since there are issues directly after jenkins is available and getting 403 when curling jenkins
-  # script executor. We think this might be a timing issue so we are waiting.
-  # Since safeRestart can take time until it really restarts jenkins, we will sleep here before querying jenkins status.
-  sleep 5
-  waitForJenkins
+    # we add a sleep here since there are issues directly after jenkins is available and getting 403 when curling jenkins
+    # script executor. We think this might be a timing issue so we are waiting.
+    # Since safeRestart can take time until it really restarts jenkins, we will sleep here before querying jenkins status.
+    sleep 5
+    waitForJenkins
+  else
+    echo "Skipping safeRestart due to SKIP_RESTART=true"
+  fi
 }
 
 initJenkins "$@"

--- a/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/Config.groovy
@@ -192,6 +192,14 @@ class Config {
         @JsonPropertyDescription(JENKINS_ENABLE_DESCRIPTION)
         Boolean active = false
 
+        @Option(names = ['--jenkins-skip-restart'], description = JENKINS_SKIP_RESTART_DESCRIPTION)
+        @JsonPropertyDescription(JENKINS_SKIP_RESTART_DESCRIPTION)
+        Boolean skipRestart = false
+
+        @Option(names = ['--jenkins-skip-plugins'], description = JENKINS_SKIP_PLUGINS_DESCRIPTION)
+        @JsonPropertyDescription(JENKINS_SKIP_PLUGINS_DESCRIPTION)
+        Boolean skipPlugins = false
+
         @Option(names = ['--jenkins-url'], description = JENKINS_URL_DESCRIPTION)
         @JsonPropertyDescription(JENKINS_URL_DESCRIPTION)
         String url = ''
@@ -245,6 +253,14 @@ class Config {
         @JsonIgnore String getHost() { return NetworkingUtils.getHost(url)}
         @JsonIgnore String getProtocol() { return NetworkingUtils.getProtocol(url)}
         String ingress = ''
+
+        @Option(names = ['--scmm-skip-restart'], description = SCMM_SKIP_RESTART_DESCRIPTION)
+        @JsonPropertyDescription(SCMM_SKIP_RESTART_DESCRIPTION)
+        Boolean skipRestart = false
+
+        @Option(names = ['--scmm-skip-plugins'], description = SCMM_SKIP_PLUGINS_DESCRIPTION)
+        @JsonPropertyDescription(SCMM_SKIP_PLUGINS_DESCRIPTION)
+        Boolean skipPlugins = false
 
         @Option(names = ['--scmm-url'], description = SCMM_URL_DESCRIPTION)
         @JsonPropertyDescription(SCMM_URL_DESCRIPTION)

--- a/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/ConfigConstants.groovy
@@ -32,6 +32,8 @@ interface ConfigConstants {
     
     // group jenkins
     String JENKINS_ENABLE_DESCRIPTION = 'Installs Jenkins as CI server'
+    String JENKINS_SKIP_RESTART_DESCRIPTION = 'Skips restarting Jenkins after plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades.'
+    String JENKINS_SKIP_PLUGINS_DESCRIPTION = 'Skips plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades.'
     String JENKINS_DESCRIPTION = 'Config parameters for Jenkins CI/CD Pipeline Server'
     String JENKINS_URL_DESCRIPTION = 'The url of your external jenkins'
     String JENKINS_USERNAME_DESCRIPTION = 'Mandatory when jenkins-url is set'
@@ -43,6 +45,8 @@ interface ConfigConstants {
 
     // group scmm
     String SCMM_DESCRIPTION = 'Config parameters for SCMManager (Git repository Server, https://scm-manager.org/)'
+    String SCMM_SKIP_RESTART_DESCRIPTION = 'Skips restarting SCM-Manager after plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades.\''
+    String SCMM_SKIP_PLUGINS_DESCRIPTION = 'Skips plugin installation. Use with caution! If the plugins are not installed up front, the installation will likely fail. The intended use case for this is after the first installation, for config changes only. Do not use on first installation or upgrades.'
     String SCMM_URL_DESCRIPTION = 'The host of your external scm-manager'
     String SCMM_USERNAME_DESCRIPTION = 'Mandatory when scmm-url is set'
     String SCMM_PASSWORD_DESCRIPTION = 'Mandatory when scmm-url is set'

--- a/src/main/groovy/com/cloudogu/gitops/config/schema/JsonSchemaGenerator.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/config/schema/JsonSchemaGenerator.groovy
@@ -4,18 +4,20 @@ import com.cloudogu.gitops.config.Config
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.victools.jsonschema.generator.*
-import com.github.victools.jsonschema.module.jackson.JacksonModule 
+import com.github.victools.jsonschema.module.jackson.JacksonModule
+import jakarta.inject.Singleton
 
+@Singleton
 class JsonSchemaGenerator {
     static ObjectNode createSchema() {
-        SchemaGeneratorConfigBuilder configBuilder = 
+        SchemaGeneratorConfigBuilder configBuilder =
                 new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
-                        // Make the schema strict: Only allow our fields, warn when additional fields are passed
+                // Make the schema strict: Only allow our fields, warn when additional fields are passed
                         .with(Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT)
-                        // Exception to the above: For Maps allow additional fields. 
-                        // We use this to allow inline helm values without having to validate them
+                // Exception to the above: For Maps allow additional fields. 
+                // We use this to allow inline helm values without having to validate them
                         .with(Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES)
-                        // All fields can be set to null to use the default
+                // All fields can be set to null to use the default
                         .with(Option.NULLABLE_FIELDS_BY_DEFAULT)
                         .with(new JacksonModule( /* no options for now */))
         // Apply the rule to include only fields with @JsonProperty annotation

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -139,6 +139,8 @@ class Jenkins extends Feature {
                 INSTALL_ARGOCD            : config.features.argocd.active,
                 NAME_PREFIX               : config.application.namePrefix,
                 INSECURE                  : config.application.insecure,
+                SKIP_RESTART              : config.jenkins.skipRestart,
+                SKIP_PLUGINS              : config.jenkins.skipPlugins
 
         ])
 

--- a/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/Jenkins.groovy
@@ -178,7 +178,10 @@ class Jenkins extends Feature {
 
         userManager.grantPermission(config.jenkins.metricsUsername, UserManager.Permissions.METRICS_VIEW)
 
-        prometheusConfigurator.enableAuthentication()
+        if (config.features.monitoring.active && config.jenkins.internal) {
+            // And external Jenkins can likely not be monitored
+            prometheusConfigurator.enableAuthentication()
+        }
 
         if (config.content.examples) {
 

--- a/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/ScmManager.groovy
@@ -141,7 +141,9 @@ class ScmManager extends Feature {
                 INSECURE                     : config.application.insecure,
                 SCM_ROOT_PATH                : config.scmm.rootPath,
                 SCM_PROVIDER                 : config.scmm.provider,
-                CONTENT_EXAMPLES             : config.content.examples
+                CONTENT_EXAMPLES             : config.content.examples,
+                SKIP_RESTART                 : config.scmm.skipRestart,
+                SKIP_PLUGINS                 : config.scmm.skipPlugins
         ])
     }
 

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -176,6 +176,8 @@ me:x:1000:''')
         config.jenkins.url = 'http://jenkins'
         config.jenkins.metricsUsername = 'metrics-usr'
         config.jenkins.metricsPassword = 'metrics-pw'
+        config.jenkins.skipPlugins = true
+        config.jenkins.skipRestart = true
 
         createJenkins().install()
 
@@ -197,6 +199,9 @@ me:x:1000:''')
         assertThat(env['SCMM_URL']).isEqualTo('http://scmm/scm')
         assertThat(env['SCMM_PASSWORD']).isEqualTo('scmm-pw')
         assertThat(env['INSTALL_ARGOCD']).isEqualTo('true')
+
+        assertThat(env['SKIP_PLUGINS']).isEqualTo('true')
+        assertThat(env['SKIP_RESTART']).isEqualTo('true')
 
         verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_SCMM_URL', 'http://scmm/scm')
         verify(globalPropertyManager).setGlobalProperty('MY_PREFIX_K8S_VERSION', Config.K8S_VERSION)

--- a/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/JenkinsTest.groovy
@@ -214,8 +214,6 @@ me:x:1000:''')
         verify(userManager).createUser('metrics-usr', 'metrics-pw')
         verify(userManager).grantPermission('metrics-usr', UserManager.Permissions.METRICS_VIEW)
 
-        verify(prometheusConfigurator).enableAuthentication()
-
         verify(jobManger).createCredential('my-prefix-example-apps', 'scmm-user',
                 'my-prefix-gitops', 'scmm-pw', 'credentials for accessing scm-manager')
 
@@ -229,6 +227,36 @@ me:x:1000:''')
                 anyString(), anyString(), anyString())
         verify(jobManger, never()).createCredential(eq('my-prefix-example-apps'), eq('registry-proxy-user'),
                 anyString(), anyString(), anyString())
+    }
+
+    @Test
+    void 'Does not configure prometheus when external Jenkins'() {
+        config.features.monitoring.active = true
+        config.jenkins.internal = false
+        
+        createJenkins().install()
+
+        verify(prometheusConfigurator, never()).enableAuthentication()
+    }
+    
+    @Test
+    void 'Does not configure prometheus when monitoring off'() {
+        config.features.monitoring.active = false
+        config.jenkins.internal = true
+        
+        createJenkins().install()
+
+        verify(prometheusConfigurator, never()).enableAuthentication()
+    }
+    
+    @Test
+    void 'Configures prometheus'() {
+        config.features.monitoring.active = true
+        config.jenkins.internal = true
+        
+        createJenkins().install()
+
+        verify(prometheusConfigurator).enableAuthentication()
     }
 
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/features/ScmManagerTest.groovy
@@ -72,6 +72,8 @@ class ScmManagerTest {
         config.scmm.username = 'scmm-usr'
         config.features.ingressNginx.active = true
         config.features.argocd.active = true
+        config.scmm.skipPlugins = true
+        config.scmm.skipRestart = true
         createScmManager().install()
 
         assertThat(parseActualYaml()['extraEnv'] as String).contains('SCM_WEBAPP_INITIALUSER\n  value: "scmm-usr"')
@@ -111,6 +113,8 @@ class ScmManagerTest {
         assertThat(env['NAME_PREFIX']).isEqualTo('foo-')
         assertThat(env['INSECURE']).isEqualTo('false')
         assertThat(env['CONTENT_EXAMPLES']).isEqualTo('false')
+        assertThat(env['SKIP_PLUGINS']).isEqualTo('true')
+        assertThat(env['SKIP_RESTART']).isEqualTo('true')
     }
 
     @Test


### PR DESCRIPTION
Add skipPlugins and skipRestart flags for Jenkins and SCM-Manager.

- Update config schema and CLI options
- Add env var support to feature classes
- Skip plugin install and restart in init scripts
- Extract SCM plugin install logic to installScmmPlugins
- Add tests to verify skipping behavior
Config:
```yaml
scmm: 
   skipRestart: true
   skipPlugins: true
jenkins:
    skipRestart: true
    skipPlugins: true
```
CLI Options:
```
--jenkins-skip-restart
--jenkins-skip-plugins
--scmm-skip-restart
--scmm-skip-plugins
```