### PR TITLE
fix(rbac): ensure Prometheus runs with correct permissions in ArgoCD-…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@
 !scripts/utils.sh
 !scripts/apply-ng.sh
 !scripts/downloadHelmCharts.sh
+!templates/kubernetes/rbac/
 !.curlrc
 !LICENSE
 

--- a/argocd/cluster-resources/misc/namespaces.ftl.yaml
+++ b/argocd/cluster-resources/misc/namespaces.ftl.yaml
@@ -1,4 +1,4 @@
-<#if config.application.openshift == false>
+<#if !config.application.openshift && !config.application.namespaceIsolation>
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/features/argocd/ArgoCD.groovy
@@ -327,6 +327,7 @@ class ArgoCD extends Feature {
                             namespace,
                             ["argocd-argocd-server", "argocd-argocd-application-controller", "argocd-applicationset-controller"]
                     )
+                    .withConfig(config)
                     .withRepo(argocdRepoInitializationAction.repo)
                     .withSubfolder(OPERATOR_RBAC_PATH)
                     .generate()

--- a/src/main/groovy/com/cloudogu/gitops/kubernetes/rbac/Role.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/kubernetes/rbac/Role.groovy
@@ -1,14 +1,23 @@
 package com.cloudogu.gitops.kubernetes.rbac
 
+import com.cloudogu.gitops.config.Config
+
 class Role {
     String name
     String namespace
     Variant variant
+    Config config
 
-    Role(String name, String namespace, Variant variant) {
+    Role(String name, String namespace, Variant variant, Config config) {
+        if (!name?.trim()) throw new IllegalArgumentException("Role name must not be blank")
+        if (!namespace?.trim()) throw new IllegalArgumentException("Role namespace must not be blank")
+        if (!variant) throw new IllegalArgumentException("Role variant must not be null")
+        if (!config) throw new IllegalArgumentException("Config must not be null")
+
         this.name = name
         this.namespace = namespace
         this.variant = variant
+        this.config = config
     }
 
     enum Variant {
@@ -24,7 +33,8 @@ class Role {
     Map<String, Object> toTemplateParams() {
         return [
                 name     : name,
-                namespace: namespace
+                namespace: namespace,
+                config   : config
         ]
     }
 

--- a/src/main/groovy/com/cloudogu/gitops/kubernetes/rbac/RoleBinding.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/kubernetes/rbac/RoleBinding.groovy
@@ -7,6 +7,11 @@ class RoleBinding {
     List<ServiceAccountRef> serviceAccounts
 
     RoleBinding(String name, String namespace, String roleName, List<ServiceAccountRef> serviceAccounts) {
+        if (!name?.trim()) throw new IllegalArgumentException("RoleBinding name must not be blank")
+        if (!namespace?.trim()) throw new IllegalArgumentException("RoleBinding namespace must not be blank")
+        if (!roleName?.trim()) throw new IllegalArgumentException("Role name must not be blank")
+        if (!serviceAccounts || serviceAccounts.isEmpty()) throw new IllegalArgumentException("At least one service account is required")
+
         this.name = name
         this.namespace = namespace
         this.roleName = roleName

--- a/src/main/groovy/com/cloudogu/gitops/kubernetes/rbac/ServiceAccountRef.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/kubernetes/rbac/ServiceAccountRef.groovy
@@ -1,16 +1,29 @@
 package com.cloudogu.gitops.kubernetes.rbac
 
 class ServiceAccountRef {
-    final String name
-    final String namespace
+    String name
+    String namespace
 
     ServiceAccountRef(String name, String namespace) {
+        if (!name?.trim()) {
+            throw new IllegalArgumentException("ServiceAccount name must not be blank")
+        }
+        if (!namespace?.trim()) {
+            throw new IllegalArgumentException("ServiceAccount namespace must not be blank")
+        }
         this.name = name
         this.namespace = namespace
     }
 
     static List<ServiceAccountRef> fromNames(String namespace, List<String> names) {
-        return names.collect { new ServiceAccountRef(it, namespace) }
+        if (!namespace?.trim()) {
+            throw new IllegalArgumentException("Namespace must not be blank for service accounts")
+        }
+
+        return names
+                .findAll { it?.trim() }
+                .unique()
+                .collect { new ServiceAccountRef(it, namespace) }
     }
 
     Map<String, String> toMap() {

--- a/templates/kubernetes/rbac/argocd-role.ftl.yaml
+++ b/templates/kubernetes/rbac/argocd-role.ftl.yaml
@@ -20,9 +20,19 @@ rules:
     resources: ["services", "endpoints"]
     verbs: ["list", "watch", "get", "create", "update", "delete"]
 
+  <#if config.application.openshift == false>
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/metrics"]
+    verbs: ["get", "list", "watch"]
+  </#if>
+
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+
+  - apiGroups: [ "batch" ]
+    resources: [ "jobs" ]
+    verbs: [ "create", "delete", "get", "list", "patch", "update", "watch" ]
 
   - apiGroups: ["extensions"]
     resources: ["ingresses"]


### PR DESCRIPTION
…managed namespaces

  - Add conditional node access rule for non-OpenShift environments
  - Pass config to Role for templating RBAC based on setup context
  - Replace hardcoded namespace list with config.application.activeNamespaces
  - Move validation logic into Role, RoleBinding, and ServiceAccountRef constructors
  - Update templates and tests to reflect RBAC and config handling changes

  This fixes permission issues that prevented Prometheus from working in a namespace-isolated setup via ArgoCD.