### PR TITLE
Add build date to version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
     
     <!--suppress UnresolvedMavenProperty -->
     <!-- git is provided by git-commit-id-maven-plugin -->
-    <versionName>${git.tags} (${git.commit.id.abbrev})\n${project.licenses[0].comments}\n${project.licenses[0].name}\n${project.licenses[0].url}</versionName>
+    <versionName>${git.tags} (${git.commit.id.abbrev}, ${maven.build.timestamp})\n${project.licenses[0].comments}\n${project.licenses[0].name}\n${project.licenses[0].url}</versionName>
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     
     <versionNameVersion>2.2.0</versionNameVersion>
     <mockitoVersion>4.8.0</mockitoVersion>


### PR DESCRIPTION
This helps identify, if the running version is the intended one at single glance.

E.g. untagged commit hashes that have been built a long time ago might not be the intended one.
Or development versions with old build date might not be the intended ones.

Example output:

With tag
`1.0.0 (abc123, 2025-09-10 17:15)`
or without tag
`abc123, 2025-09-10 17:15`

<img width="682" height="46" alt="image" src="https://github.com/user-attachments/assets/ca5e6076-76e7-4ba2-9d4a-1334cc48c4f0" />
