### PR TITLE
Fix a regression in Jenkinsfile resulting in release images not beeing tagged with the version number

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
         BUILD_DATE = sh(script: 'date --rfc-3339 ns', returnStdout: true).trim()
         K3D_CLUSTER_NAME = "k3d-gop-cluster-${env.BUILD_ID}"
         FULL_IMAGE_TAG = "${env.DOCKER_REGISTRY_BASE_URL}/${env.DOCKER_IMAGE_NAME}:${env.SHORT_SHA}"
-        TAG_NAME = sh(returnStdout: true, script: "git --no-pager tag --points-at HEAD").trim()
+        TAG_NAME = sh(returnStdout: true, script: "git fetch --tags && git --no-pager tag --points-at HEAD").trim()
         // Shared docker args for integration tests
         INTEGRATION_TEST_DOCKER_ARGS = "-e KUBECONFIG=${env.WORKSPACE}/.kubeconfig.yaml -v maven-cache:/root/.m2 -v /var/run/docker.sock:/var/run/docker.sock -u :${env.BUILD_GROUP} --network=host --entrypoint ''"
     }
@@ -162,6 +162,7 @@ pipeline {
                         if (params.forcePushImage) { image.push(env.BRANCH_NAME) }
                         if (env.TAG_NAME) {
                             image.push('latest')
+                            image.push(env.TAG_NAME)
                             currentBuild.description += "\nImage: ${env.DOCKER_REGISTRY_BASE_URL}/${env.DOCKER_IMAGE_NAME}:latest"
                             currentBuild.description += "\nRelease: ${env.TAG_NAME}"
                         }


### PR DESCRIPTION
pull git tag even on a shallow clone and tag the build image with the corresponding git tag