### PR TITLE
don't prefix official presets with "preset"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,10 @@
     "minimumReleaseAge": "7 days",
 
     "extends": [
-        "preset:automergeMinor",
-        "preset:combinePatchMinorReleases",
-        "preset:configMigration",
-        "preset:autoMergeDigest"
+        ":automergeMinor",
+        ":combinePatchMinorReleases",
+        ":configMigration",
+        ":automergeDigest"
     ],
 
     "packageRules": [


### PR DESCRIPTION
This PR will fix #490 by correcting renovate.json syntax