### PR TITLE
docs: add ArgoCD operator pre-installation hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Current existing profiles for argocd in non-operator mode:
 | full             | all available features                   | showcase a full-fledged IDP          |
 
 
-Follow profils for ArgoCD in Operator mode which has to be installed first:
+The following profiles require the ArgoCD operator to be installed in your cluster first:
 | Profile                   | Features                                 | Use-Case                                                             |
 |---------------------------|------------------------------------------|----------------------------------------------------------------------|
 | operator-minimal          | Argo-cd, SCM-Manager                     | minimal example for an operator based gitops-stack                   |

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -137,7 +137,7 @@ To keep things simpler, the GitOps playground only uses one kubernetes cluster, 
 pattern. However, the repo structure could also be used to serve multiple clusters, in a [Hub and Spoke](https://github.com/cloudogu/gitops-patterns/tree/8e1056f#hub-and-spoke) pattern:
 Additional clusters could either be defined in the `vaules.yaml` or as secrets via the `templates` folder.
 
-We're also working on an optional implementation of the [namespaced](https://github.com/cloudogu/gitops-patterns/tree/8e1056f#namespaced) pattern, using the [Argo CD operator](https://github.com/argoproj-labs/argocd-operator).
+We're also working on an optional implementation of the [namespaced](https://github.com/cloudogu/gitops-patterns/tree/8e1056f#namespaced) pattern, using the [Argo CD operator](https://github.com/argoproj-labs/argocd-operator). Note that when using one of the `operator-*` profiles, the Argo CD operator must be installed in the cluster beforehand.
 
 ### cluster-resources
 


### PR DESCRIPTION
Clarify that 'operator-*' profiles require the ArgoCD operator to be installed in the cluster beforehand.