### PR TITLE
Feature/openshift create projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ install-operator: ## installs argocd operator via kubectl and kustomize
 .PHONY: image
 image: ## builds the docker image for local testing
 	docker buildx prune -f && docker build . -t local/gop
+	echo "created docker image local/gop"
 
 %:
 	@:

--- a/pom.xml
+++ b/pom.xml
@@ -1,60 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.cloudogu</groupId>
-  <artifactId>gitops-playground-cli</artifactId>
-  <version>0.1</version>
-  <packaging>${packaging}</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.cloudogu</groupId>
+    <artifactId>gitops-playground-cli</artifactId>
+    <version>0.1</version>
+    <packaging>${packaging}</packaging>
 
-  <parent>
-    <groupId>io.micronaut.platform</groupId>
-    <artifactId>micronaut-parent</artifactId>
-    <!-- ON NEXT GROOVY UPDATE: check if we can get rid of explicit jackson-dataformat-yaml without critical CVE -->
-    <version>4.10.12</version>
-  </parent>
+    <parent>
+        <groupId>io.micronaut.platform</groupId>
+        <artifactId>micronaut-parent</artifactId>
+        <!-- ON NEXT GROOVY UPDATE: check if we can get rid of explicit jackson-dataformat-yaml without critical CVE -->
+        <version>4.10.12</version>
+    </parent>
 
-  <properties>
-    <packaging>jar</packaging>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <exec.mainClass>com.cloudogu.gitops.cli.GitopsPlaygroundCliMain</exec.mainClass>
-    
-    <!--suppress UnresolvedMavenProperty -->
-    <!-- git is provided by git-commit-id-maven-plugin -->
-    <versionName>${git.tags} (${git.commit.id.abbrev}, ${maven.build.timestamp})\n${project.licenses[0].comments}\n${project.licenses[0].name}\n${project.licenses[0].url}</versionName>
-    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-    
-    <versionNameVersion>2.2.0</versionNameVersion>
-    <okhttpVersion>5.3.2</okhttpVersion>
-    <retrofitVersion>3.0.0</retrofitVersion>
-    <groovy.version>5.0.5</groovy.version>
-    <jsonschema.version>5.0.0</jsonschema.version>
-    <kubernetes.client.java.version>26.0.0</kubernetes.client.java.version>
-    <kubernetes.fabric8.java.version>7.7.0</kubernetes.fabric8.java.version>
-    <wiremock.version>3.13.2</wiremock.version>
-  </properties>
+    <properties>
+        <packaging>jar</packaging>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <exec.mainClass>com.cloudogu.gitops.cli.GitopsPlaygroundCliMain</exec.mainClass>
 
-  <scm>
-    <connection>scm:git:https://github.com/cloudogu/gitops-playground.git</connection>
-    <developerConnection>scm:git:git@github.com:cloudogu/gitops-playground.git</developerConnection>
-    <url>https://github.com/cloudogu/gitops-playground</url>
-  </scm>
+        <!--suppress UnresolvedMavenProperty -->
+        <!-- git is provided by git-commit-id-maven-plugin -->
+        <versionName>${git.tags} (${git.commit.id.abbrev},
+            ${maven.build.timestamp})\n${project.licenses[0].comments}\n${project.licenses[0].name}\n${project.licenses[0].url}
+        </versionName>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
-  <licenses>
-    <license>
-      <name>GNU AFFERO GENERAL PUBLIC LICENSE, Version 3</name>
-      <comments>Copyright 2020 - present Cloudogu GmbH</comments>
-      <url>https://github.com/cloudogu/gitops-playground/blob/main/LICENSE</url>
-    </license>
-  </licenses>
+        <versionNameVersion>2.2.0</versionNameVersion>
+        <okhttpVersion>5.3.2</okhttpVersion>
+        <retrofitVersion>3.0.0</retrofitVersion>
+        <groovy.version>5.0.5</groovy.version>
+        <jsonschema.version>5.0.0</jsonschema.version>
+        <kubernetes.client.java.version>26.0.0</kubernetes.client.java.version>
+        <kubernetes.fabric8.java.version>7.7.0</kubernetes.fabric8.java.version>
+        <wiremock.version>3.13.2</wiremock.version>
+    </properties>
 
-  <inceptionYear>2020</inceptionYear>
+    <scm>
+        <connection>scm:git:https://github.com/cloudogu/gitops-playground.git</connection>
+        <developerConnection>scm:git:git@github.com:cloudogu/gitops-playground.git</developerConnection>
+        <url>https://github.com/cloudogu/gitops-playground</url>
+    </scm>
 
-  <organization>
-    <name>Cloudogu GmbH</name>
-    <url>https://www.cloudogu.com/</url>
-  </organization>
+    <licenses>
+        <license>
+            <name>GNU AFFERO GENERAL PUBLIC LICENSE, Version 3</name>
+            <comments>Copyright 2020 - present Cloudogu GmbH</comments>
+            <url>https://github.com/cloudogu/gitops-playground/blob/main/LICENSE</url>
+        </license>
+    </licenses>
+
+    <inceptionYear>2020</inceptionYear>
+
+    <organization>
+        <name>Cloudogu GmbH</name>
+        <url>https://www.cloudogu.com/</url>
+    </organization>
 
     <!-- Wiremock requires the jetty12 dependency for Jetty 12 support -->
     <dependencyManagement>
@@ -76,531 +78,534 @@
         </dependencies>
     </dependencyManagement>
 
-    <dependencies>    <dependency>
-      <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-inject-groovy</artifactId>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-inject-groovy</artifactId>
+        </dependency>
 
-    <!-- Source: https://mvnrepository.com/artifact/io.micronaut.reactor/micronaut-reactor -->
-    <dependency>
-        <groupId>io.micronaut.reactor</groupId>
-        <artifactId>micronaut-reactor</artifactId>
-        <version>3.9.1</version>
-        <scope>runtime</scope>
-    </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/io.micronaut.reactor/micronaut-reactor -->
+        <dependency>
+            <groupId>io.micronaut.reactor</groupId>
+            <artifactId>micronaut-reactor</artifactId>
+            <version>3.9.1</version>
+            <scope>runtime</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>${groovy.version}</version>
-      <type>pom</type>
-      <exclusions>
-        <exclusion>
-          <groupId>org.testng</groupId>
-          <artifactId>testng</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.groovy</groupId>
-          <artifactId>groovy-testng</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.groovy</groupId>
-          <artifactId>groovy-test</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>${groovy.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-testng</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-test</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <!-- not included in groovy-all -->
-    <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy-yaml</artifactId>
-    </dependency>
+        <!-- not included in groovy-all -->
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-yaml</artifactId>
+        </dependency>
 
-    <!-- Avoid CVE-2022-1471 in transitive dependency of groovy-yaml. -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.21.2</version>
-    </dependency>
+        <!-- Avoid CVE-2022-1471 in transitive dependency of groovy-yaml. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.21.2</version>
+        </dependency>
 
-    <dependency>
-      <groupId>info.picocli</groupId>
-      <artifactId>picocli</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>io.micronaut.groovy</groupId>
-      <artifactId>micronaut-runtime-groovy</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.micronaut.groovy</groupId>
+            <artifactId>micronaut-runtime-groovy</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>io.micronaut.picocli</groupId>
-      <artifactId>micronaut-picocli</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.micronaut.picocli</groupId>
+            <artifactId>micronaut-picocli</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>info.picocli</groupId>
-      <artifactId>picocli-codegen</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli-codegen</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-inject</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-inject</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>io.micronaut.validation</groupId>
-      <artifactId>micronaut-validation</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.micronaut.validation</groupId>
+            <artifactId>micronaut-validation</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.22.0</version>
-    </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.22.0</version>
+        </dependency>
 
-      <!--Used for BCrypt functions-->
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-crypto</artifactId>
-        <version>7.0.5</version>
-      </dependency>
+        <!--Used for BCrypt functions-->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>7.0.5</version>
+        </dependency>
 
-      <dependency>
-        <groupId>org.eclipse.jgit</groupId>
-        <artifactId>org.eclipse.jgit</artifactId>
-        <!-- JGit is known to cause trouble with GraalVM. So when updating, keep calm and read the developers.md#JGit docs -->
-      <version>7.6.0.202603022253-r</version>
-    </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <!-- JGit is known to cause trouble with GraalVM. So when updating, keep calm and read the developers.md#JGit docs -->
+            <version>7.6.0.202603022253-r</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>${okhttpVersion}</version>
-    </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttpVersion}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp-urlconnection</artifactId>
-      <version>${okhttpVersion}</version>
-    </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-urlconnection</artifactId>
+            <version>${okhttpVersion}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>logging-interceptor</artifactId>
-      <version>5.3.2</version>
-    </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>5.3.2</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.squareup.retrofit2</groupId>
-      <artifactId>retrofit</artifactId>
-      <version>${retrofitVersion}</version>
-    </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+            <version>${retrofitVersion}</version>
+        </dependency>
 
-    <dependency>
-      <!-- Converts HTTP body objects from groovy to JSON -->
-      <groupId>com.squareup.retrofit2</groupId>
-      <artifactId>converter-jackson</artifactId>
-      <version>${retrofitVersion}</version>
-    </dependency>
+        <dependency>
+            <!-- Converts HTTP body objects from groovy to JSON -->
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofitVersion}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-jetty12</artifactId>
-      <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-jetty12</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp-tls</artifactId>
-      <version>${okhttpVersion}</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-tls</artifactId>
+            <version>${okhttpVersion}</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <!-- Avoids java.lang.NoClassDefFoundError: org/apache/commons/logging/Log-->
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-jcl</artifactId>
-      <version>6.2.18</version>
-      <!-- Right now only needed in new BCryptPasswordEncoder() used in tests -->
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <!-- Avoids java.lang.NoClassDefFoundError: org/apache/commons/logging/Log-->
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jcl</artifactId>
+            <version>6.2.18</version>
+            <!-- Right now only needed in new BCryptPasswordEncoder() used in tests -->
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.freemarker</groupId>
-      <artifactId>freemarker</artifactId>
-      <version>2.3.34</version>
-    </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.34</version>
+        </dependency>
 
-    <!-- Source: https://mvnrepository.com/artifact/io.fabric8/kubernetes-server-mock -->
-    <dependency>
-        <groupId>io.fabric8</groupId>
-        <artifactId>kubernetes-server-mock</artifactId>
-        <version>${kubernetes.fabric8.java.version}</version>
-        <scope>test</scope>
-    </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/io.fabric8/kubernetes-server-mock -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <version>${kubernetes.fabric8.java.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-    <!-- Source: https://mvnrepository.com/artifact/io.fabric8/openshift-client -->
-    <dependency>
-        <groupId>io.fabric8</groupId>
-        <artifactId>openshift-client</artifactId>
-         <version>${kubernetes.fabric8.java.version}</version>
-    </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/io.fabric8/openshift-client -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+            <version>${kubernetes.fabric8.java.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>io.kubernetes</groupId>
-      <artifactId>client-java</artifactId>
-      <version>${kubernetes.client.java.version}</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java</artifactId>
+            <version>${kubernetes.client.java.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-http-client</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-client</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.micronaut.test</groupId>
-      <artifactId>micronaut-test-junit5</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>io.micronaut.test</groupId>
+            <artifactId>micronaut-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>4.0.0-M1</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>4.0.0-M1</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy-test</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <!-- provides withEnvironmentVariable in Tests -->
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-lambda</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-    </dependency>
+        <!-- provides withEnvironmentVariable in Tests -->
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.gitlab4j</groupId>
-      <artifactId>gitlab4j-api</artifactId>
-      <version>6.2.0</version>
-    </dependency>
+        <dependency>
+            <groupId>org.gitlab4j</groupId>
+            <artifactId>gitlab4j-api</artifactId>
+            <version>6.2.0</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.github.victools</groupId>
-      <artifactId>jsonschema-generator</artifactId>
-      <version>${jsonschema.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-generator</artifactId>
+            <version>${jsonschema.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.github.victools</groupId>
-      <artifactId>jsonschema-module-jackson</artifactId>
-      <version>${jsonschema.version}</version>
-    </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jackson</artifactId>
+            <version>${jsonschema.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.networknt</groupId>
-      <artifactId>json-schema-validator</artifactId>
-      <version>3.0.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>3.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>com.cloudogu.versionName</groupId>
-      <artifactId>processor</artifactId>
-      <version>${versionNameVersion}</version>
-      <!-- This dependency is only necessary during compile time -->
-      <scope>provided</scope>
-    </dependency>
+        <dependency>
+            <groupId>com.cloudogu.versionName</groupId>
+            <artifactId>processor</artifactId>
+            <version>${versionNameVersion}</version>
+            <!-- This dependency is only necessary during compile time -->
+            <scope>provided</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>4.3.0</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.github.classgraph</groupId>
-      <artifactId>classgraph</artifactId>
-      <version>4.8.184</version>
-    </dependency>
+        <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.184</version>
+        </dependency>
 
-    <!-- Fix NoClassDefFoundError: jakarta/xml/bind/annotation/XmlElement on Java 17 -->
-    <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>4.0.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>4.0.7</version>
-      <scope>runtime</scope>
-    </dependency>
+        <!-- Fix NoClassDefFoundError: jakarta/xml/bind/annotation/XmlElement on Java 17 -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.7</version>
+            <scope>runtime</scope>
+        </dependency>
 
-  </dependencies>
+    </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.5</version>
-        <configuration>
-          <!-- Needed to allow unit tests to do reflection, e.g. for SystemLambda's withEnvironmentVariable -->
-          <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED</argLine>
-          <systemProperties>
-            <property>
-              <name>ROOT_LOG_LEVEL</name>
-              <value>OFF</value>
-            </property>
-            <property>
-              <name>APP_LOG_LEVEL</name>
-              <value>OFF</value>
-            </property>
-          </systemProperties>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+                <configuration>
+                    <!-- Needed to allow unit tests to do reflection, e.g. for SystemLambda's withEnvironmentVariable -->
+                    <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+                    <systemProperties>
+                        <property>
+                            <name>ROOT_LOG_LEVEL</name>
+                            <value>OFF</value>
+                        </property>
+                        <property>
+                            <name>APP_LOG_LEVEL</name>
+                            <value>OFF</value>
+                        </property>
+                    </systemProperties>
 
-        </configuration>
-      </plugin>
-     <plugin>
-         <groupId>org.jacoco</groupId>
-         <artifactId>jacoco-maven-plugin</artifactId>
-         <version>0.8.14</version>
-         <executions>
-             <execution>
-                 <goals>
-                     <goal>prepare-agent</goal>
-                 </goals>
-                 <phase>initialize</phase>
-             </execution>
-             <execution>
-                 <id>report</id>
-                 <phase>test</phase>
-                 <goals>
-                     <goal>report</goal>
-                 </goals>
-                 <configuration>
-                     <formats>
-                         <format>HTML</format>
-                         <format>XML</format>
-                     </formats>
-                 </configuration>
-             </execution>
-             <execution>
-                 <id>jacoco-check</id>
-                 <phase>test</phase>
-                 <goals>
-                     <goal>check</goal>
-                 </goals>
-                 <configuration>
-                     <haltOnFailure>false</haltOnFailure>
-                     <rules>
-                         <rule>
-                             <element>PACKAGE</element>
-                             <limits>
-                                 <limit>
-                                     <counter>LINE</counter>
-                                     <value>COVEREDRATIO</value>
-                                     <minimum>0.80</minimum>
-                                 </limit>
-                             </limits>
-                         </rule>
-                     </rules>
-                     <excludes>
-                         <exclude>**/*Test.class</exclude>
-                     </excludes>
-                 </configuration>
-             </execution>
-         </executions>
-     </plugin>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <formats>
+                                <format>HTML</format>
+                                <format>XML</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>false</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                            <excludes>
+                                <exclude>**/*Test.class</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.5.0</version>
-      </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
 
-      <plugin>
-        <groupId>io.micronaut.maven</groupId>
-        <artifactId>micronaut-maven-plugin</artifactId>
-      </plugin>
+            <plugin>
+                <groupId>io.micronaut.maven</groupId>
+                <artifactId>micronaut-maven-plugin</artifactId>
+            </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.gmavenplus</groupId>
-        <artifactId>gmavenplus-plugin</artifactId>
-        <version>4.3.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <configScript>compiler.groovy</configScript>
-          <targetBytecode>17</targetBytecode>
-        </configuration>
-      </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>4.3.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configScript>compiler.groovy</configScript>
+                    <targetBytecode>17</targetBytecode>
+                </configuration>
+            </plugin>
 
-      <!--  Since some dependencies are signed, and we have an uber jar, there will be some security conflicts.
-            So we delete the responsible files -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>truezip-maven-plugin</artifactId>
-        <version>1.2</version>
-        <executions>
-          <execution>
-            <id>remove-a-file-in-sub-archive</id>
-            <goals>
-              <goal>remove</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <fileset>
-                <directory>${project.build.directory}/${project.artifactId}-${project.version}.jar/META-INF/</directory>
-                <includes>
-                  <include>*.DSA</include>
-                  <include>*.RSA</include>
-                  <include>*.SF</include>
-                </includes>
-              </fileset>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+            <!--  Since some dependencies are signed, and we have an uber jar, there will be some security conflicts.
+                  So we delete the responsible files -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>truezip-maven-plugin</artifactId>
+                <version>1.2</version>
+                <executions>
+                    <execution>
+                        <id>remove-a-file-in-sub-archive</id>
+                        <goals>
+                            <goal>remove</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <fileset>
+                                <directory>
+                                    ${project.build.directory}/${project.artifactId}-${project.version}.jar/META-INF/
+                                </directory>
+                                <includes>
+                                    <include>*.DSA</include>
+                                    <include>*.RSA</include>
+                                    <include>*.SF</include>
+                                </includes>
+                            </fileset>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.15.0</version>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.cloudogu.versionName</groupId>
-              <artifactId>processor</artifactId>
-              <version>${versionNameVersion}</version>
-            </path>
-          </annotationProcessorPaths>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.cloudogu.versionName</groupId>
+                            <artifactId>processor</artifactId>
+                            <version>${versionNameVersion}</version>
+                        </path>
+                    </annotationProcessorPaths>
 
-          <compilerArgs>
-            <arg>-AversionName=${versionName}</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
+                    <compilerArgs>
+                        <arg>-AversionName=${versionName}</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
 
-      <plugin>
-        <groupId>io.github.git-commit-id</groupId>
-        <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>10.0.0</version>
-        <executions>
-          <execution>
-            <id>get-the-git-infos</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-            <phase>initialize</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <includeOnlyProperties>
-            <includeOnlyProperty>^git.tags$</includeOnlyProperty>
-            <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
-          </includeOnlyProperties>
-        </configuration>
-      </plugin>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>10.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.tags$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                </configuration>
+            </plugin>
 
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.10.0</version>
-      </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.10.0</version>
+            </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*IT</include>
-          </includes>
-        </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-          </execution>
-        </executions>
-      </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*IT</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>1.3.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <property>
-                  <name>groovy.target.directory</name>
-                  <value>${project.build.directory}/classes</value>
-                </property>
-                <property>
-                  <name>groovy.parameters</name>
-                  <value>true</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-system-properties</goal>
+                        </goals>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <name>groovy.target.directory</name>
+                                    <value>${project.build.directory}/classes</value>
+                                </property>
+                                <property>
+                                    <name>groovy.parameters</name>
+                                    <value>true</value>
+                                </property>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
-  <pluginRepositories>
-  </pluginRepositories>
+    <pluginRepositories>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <groovy.version>5.0.5</groovy.version>
     <jsonschema.version>5.0.0</jsonschema.version>
     <kubernetes.client.java.version>26.0.0</kubernetes.client.java.version>
-    <kubernetes.fabric8.java.version>7.6.1</kubernetes.fabric8.java.version>
+    <kubernetes.fabric8.java.version>7.7.0</kubernetes.fabric8.java.version>
     <wiremock.version>3.13.2</wiremock.version>
   </properties>
 
@@ -246,11 +246,11 @@
         <scope>test</scope>
     </dependency>
 
-    <!-- Source: https://mvnrepository.com/artifact/io.fabric8/kubernetes-client -->
+    <!-- Source: https://mvnrepository.com/artifact/io.fabric8/openshift-client -->
     <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>kubernetes-client</artifactId>
-        <version>${kubernetes.fabric8.java.version}</version>
+        <artifactId>openshift-client</artifactId>
+         <version>${kubernetes.fabric8.java.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/groovy/com/cloudogu/gitops/application/Application.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/application/Application.groovy
@@ -54,7 +54,7 @@ class Application {
 		log.debug("Storing GOP configuration in secret 'gop-configuration' in namespace '${namespace}'")
 		k8sClient.createNamespace(namespace)
 		k8sClient.createSecret('generic', 'gop-configuration', namespace,
-			new Tuple2('gop-initial-password', config.DEFAULT_ADMIN_PW),
+			new Tuple2('gop-initial-password', config.application.password),
 			new Tuple2('gop-config', config.toYaml(true)))
 	}
 

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -226,7 +226,7 @@ class GitopsPlaygroundCli {
 	}
 
 	void printWelcomeScreen() {
-		def password = Config.DEFAULT_ADMIN_PW
+		def password = Config.application.password
 		log.info '''\n
   |----------------------------------------------------------------------------------------------|
   |                       Welcome to the GitOps playground by Cloudogu!

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -96,7 +96,7 @@ class GitopsPlaygroundCli {
 			app = context.getBean(Application)
 			app.start()
 
-			printWelcomeScreen()
+			printWelcomeScreen(config)
 		}
 
 		return ReturnCode.SUCCESS
@@ -225,8 +225,8 @@ class GitopsPlaygroundCli {
 		return map as Map
 	}
 
-	void printWelcomeScreen() {
-		def password = Config.application.password
+	void printWelcomeScreen(Config newConfig) {
+		def password = newConfig.application.password
 		log.info '''\n
   |----------------------------------------------------------------------------------------------|
   |                       Welcome to the GitOps playground by Cloudogu!

--- a/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/cli/GitopsPlaygroundCli.groovy
@@ -1,11 +1,9 @@
 package com.cloudogu.gitops.cli
 
-import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.Logger
-import ch.qos.logback.classic.LoggerContext
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.ConsoleAppender
+import static com.cloudogu.gitops.config.ConfigConstants.APP_NAME
+import static com.cloudogu.gitops.utils.MapUtils.deepMerge
+import static com.cloudogu.gitops.utils.MapUtils.deepMergeDefaults
+
 import com.cloudogu.gitops.application.Application
 import com.cloudogu.gitops.config.Config
 import com.cloudogu.gitops.config.schema.JsonSchemaValidator
@@ -13,15 +11,20 @@ import com.cloudogu.gitops.destroy.Destroyer
 import com.cloudogu.gitops.infrastructure.kubernetes.api.K8sClient
 import com.cloudogu.gitops.tools.common.CommonToolConfig
 import com.cloudogu.gitops.tools.common.Tool
+
+import io.micronaut.context.ApplicationContext
+
 import groovy.util.logging.Slf4j
 import groovy.yaml.YamlSlurper
-import io.micronaut.context.ApplicationContext
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.ConsoleAppender
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
-
-import static com.cloudogu.gitops.config.ConfigConstants.APP_NAME
-import static com.cloudogu.gitops.utils.MapUtils.deepMerge
-import static com.cloudogu.gitops.utils.MapUtils.deepMergeDefaults
 
 /**
  * Provides the entrypoint to the application as well as all config parameters.
@@ -96,7 +99,7 @@ class GitopsPlaygroundCli {
 			app = context.getBean(Application)
 			app.start()
 
-			printWelcomeScreen(config)
+			printWelcomeScreen(config.application.password)
 		}
 
 		return ReturnCode.SUCCESS
@@ -225,8 +228,7 @@ class GitopsPlaygroundCli {
 		return map as Map
 	}
 
-	void printWelcomeScreen(Config newConfig) {
-		def password = newConfig.application.password
+	void printWelcomeScreen(String password) {
 		log.info '''\n
   |----------------------------------------------------------------------------------------------|
   |                       Welcome to the GitOps playground by Cloudogu!

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -1322,7 +1322,9 @@ com.cloudogu.gitops.config.Config gopConfig
 	}
 
 	private boolean runInOpenshift() {
-		return this.gopConfig.application.openshift
+		// gopConfig can be null, in tests or at startup
+		boolean result = this.gopConfig != null && this.gopConfig.application.openshift
+		return result
 	}
 
 	// ========================================

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -258,11 +258,15 @@ class K8sClient {
 			if (runInOpenshift()) {
 				OpenShiftClient osClient = client.adapt(OpenShiftClient.class)
 
-				Project project = new ProjectBuilder().withNewMetadata().withName(name).endMetadata().build()
-				executeWithErrorHandling("create project ${project}") {
+				Project project = new ProjectBuilder()
+					.withNewMetadata()
+					.withName(name)
+					.endMetadata()
+					.build()
+				executeWithErrorHandling("create project ${name}") {
 					osClient.projects().resource(project).create()
 				}
-				log.debug("Project ${project} created successfully.")
+				log.debug("Project ${name} created successfully.")
 			} else {
 
 				Namespace namespace = new NamespaceBuilder()

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -1328,8 +1328,7 @@ class K8sClient {
 
 	private boolean runInOpenshift() {
 		// gopConfig can be null, in tests or at startup
-		boolean result = this.gopConfig != null && this.gopConfig.application.openshift
-		return result
+		return this.gopConfig?.application?.openshift ?: false
 	}
 
 	// ========================================

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -259,10 +259,10 @@ class K8sClient {
 				OpenShiftClient osClient = client.adapt(OpenShiftClient.class)
 
 				Project project = new ProjectBuilder().withNewMetadata().withName(name).endMetadata().build()
-				executeWithErrorHandling("create project ${project}") {
+				executeWithErrorHandling("create project ${name}") {
 					osClient.projects().resource(project).create()
 				}
-				log.debug("Project ${project} created successfully.")
+				log.debug("Project ${name} created successfully.")
 			} else {
 
 				Namespace namespace = new NamespaceBuilder()

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -54,8 +54,9 @@ class K8sClient {
 	protected int DEFAULT_RETRIES = 120
 
 	KubernetesClient client
+com.cloudogu.gitops.config.Config gopConfig
 
-	K8sClient() {
+	K8sClient(com.cloudogu.gitops.config.Config gopConfig = null) {
 		Config config = new ConfigBuilder()
 			.withRequestTimeout(FABRIC8_REQUEST_TIMEOUT_MILLIS)
 			.withConnectionTimeout(FABRIC8_CONNECTION_TIMEOUT_MILLIS)
@@ -65,7 +66,7 @@ class K8sClient {
 			.withConfig(config)
 			.build()
 		/* Openshift client inlcudes kubernetes client! */
-
+		this.gopConfig = gopConfig
 	}
 
 	// ========================================
@@ -255,7 +256,7 @@ class K8sClient {
 		if (!namespaceExists(name)) {
 			log.debug("Namespace ${name} does not exist, proceeding to create.")
 
-			if (runInOpenShift()) {
+			if (runInOpenshift()) {
 				OpenShiftClient osClient = client.adapt(OpenShiftClient.class)
 
 				Project project = new ProjectBuilder().withNewMetadata().withName(name).endMetadata().build()
@@ -1320,8 +1321,8 @@ class K8sClient {
 		return this.client.getNamespace()
 	}
 
-	boolean runInOpenShift() {
-		return false
+	private boolean runInOpenshift() {
+		return this.gopConfig.application.openshift
 	}
 
 	// ========================================

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -64,7 +64,7 @@ class K8sClient {
 		this.client = new KubernetesClientBuilder()
 			.withConfig(config)
 			.build()
-		/* Openshift client inlcudes kubernetes client! */
+		/* OpenShift client includes Kubernetes client APIs. */
 		this.gopConfig = gopConfig
 	}
 

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -259,10 +259,10 @@ class K8sClient {
 				OpenShiftClient osClient = client.adapt(OpenShiftClient.class)
 
 				Project project = new ProjectBuilder().withNewMetadata().withName(name).endMetadata().build()
-				executeWithErrorHandling("create project ${name}") {
+				executeWithErrorHandling("create project ${project}") {
 					osClient.projects().resource(project).create()
 				}
-				log.debug("Project ${name} created successfully.")
+				log.debug("Project ${project} created successfully.")
 			} else {
 
 				Namespace namespace = new NamespaceBuilder()

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -13,6 +13,7 @@ import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Slf4j
 
 import io.fabric8.kubernetes.api.model.*
+import io.fabric8.kubernetes.client.Client
 import io.fabric8.kubernetes.client.Config
 import io.fabric8.kubernetes.client.ConfigBuilder
 import io.fabric8.kubernetes.client.KubernetesClient
@@ -21,6 +22,9 @@ import io.fabric8.kubernetes.client.dsl.base.PatchContext
 import io.fabric8.kubernetes.client.dsl.base.PatchType
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext
 import io.fabric8.kubernetes.client.utils.Serialization
+import io.fabric8.openshift.api.model.Project
+import io.fabric8.openshift.api.model.ProjectBuilder
+import io.fabric8.openshift.client.OpenShiftClient
 
 /**
  * Kubernetes client using Fabric8 Kubernetes Client.*/
@@ -53,13 +57,14 @@ class K8sClient {
 
 	K8sClient() {
 		Config config = new ConfigBuilder()
-				.withRequestTimeout(FABRIC8_REQUEST_TIMEOUT_MILLIS)
-				.withConnectionTimeout(FABRIC8_CONNECTION_TIMEOUT_MILLIS)
-				.build()
+			.withRequestTimeout(FABRIC8_REQUEST_TIMEOUT_MILLIS)
+			.withConnectionTimeout(FABRIC8_CONNECTION_TIMEOUT_MILLIS)
+			.build()
 
 		this.client = new KubernetesClientBuilder()
-				.withConfig(config)
-				.build()
+			.withConfig(config)
+			.build()
+		/* Openshift client inlcudes kubernetes client! */
 
 	}
 
@@ -250,17 +255,28 @@ class K8sClient {
 		if (!namespaceExists(name)) {
 			log.debug("Namespace ${name} does not exist, proceeding to create.")
 
-			Namespace namespace = new NamespaceBuilder()
-				.withNewMetadata()
-				.withName(name)
-				.endMetadata()
-				.build()
+			if (runInOpenShift()) {
+				OpenShiftClient osClient = client.adapt(OpenShiftClient.class)
 
-			executeWithErrorHandling("create namespace ${name}") {
-				client.namespaces().resource(namespace).create()
+				Project project = new ProjectBuilder().withNewMetadata().withName(name).endMetadata().build()
+				executeWithErrorHandling("create project ${project}") {
+					osClient.projects().resource(project).create()
+				}
+				log.debug("Project ${project} created successfully.")
+			} else {
+
+				Namespace namespace = new NamespaceBuilder()
+					.withNewMetadata()
+					.withName(name)
+					.endMetadata()
+					.build()
+
+				executeWithErrorHandling("create namespace ${name}") {
+					client.namespaces().resource(namespace).create()
+				}
+
+				log.debug("Namespace ${name} created successfully.")
 			}
-
-			log.debug("Namespace ${name} created successfully.")
 		}
 	}
 
@@ -544,8 +560,7 @@ class K8sClient {
 			yamlFiles = yamlFiles.sort { it.absolutePath }
 
 			int appliedResources = 0
-			yamlFiles.each { File file ->
-				appliedResources += applyYamlStream(file.newInputStream(), file.absolutePath)
+			yamlFiles.each { File file -> appliedResources += applyYamlStream(file.newInputStream(), file.absolutePath)
 			}
 
 			return "Applied ${appliedResources} resource(s) from directory $yamlLocation"
@@ -914,6 +929,7 @@ class K8sClient {
 		def status = resource.getAdditionalProperties()?.get('status') as Map
 		return status?.get('phase') as String
 	}
+
 	/**
 	 * Waits for a resource to reach a desired phase with default timeout and interval.
 	 *
@@ -1129,24 +1145,21 @@ class K8sClient {
 		String normalized = resourceType.toLowerCase()
 
 		def crd = client.apiextensions()
-				.v1()
-				.customResourceDefinitions()
-				.list()
-				.items
-				.find { crd ->
-					crd.spec.names.kind?.equalsIgnoreCase(resourceType) ||
-							crd.spec.names.plural?.equalsIgnoreCase(normalized) ||
-							crd.spec.names.singular?.equalsIgnoreCase(normalized) ||
-							crd.spec.names.shortNames?.any { it.equalsIgnoreCase(normalized) }
-				}
+			.v1()
+			.customResourceDefinitions()
+			.list()
+			.items
+			.find { crd ->
+				crd.spec.names.kind?.equalsIgnoreCase(resourceType) || crd.spec.names.plural?.equalsIgnoreCase(normalized) ||
+					crd.spec.names.singular?.equalsIgnoreCase(normalized) ||
+					crd.spec.names.shortNames?.any { it.equalsIgnoreCase(normalized) }
+			}
 
 		if (!crd) {
 			throw new RuntimeException("No CRD found for custom resource type '${resourceType}'")
 		}
 
-		def version = crd.spec.versions.find { it.storage && it.served }?.name ?:
-				crd.spec.versions.find { it.storage }?.name ?:
-						crd.spec.versions.find { it.served }?.name
+		def version = crd.spec.versions.find { it.storage && it.served }?.name ?: crd.spec.versions.find { it.storage }?.name ?: crd.spec.versions.find { it.served }?.name
 		log.debug("Using CRD ${crd.metadata.name} with version ${version}, kind=${crd.spec.names.kind}, plural=${crd.spec.names.plural}")
 
 		if (!version) {
@@ -1154,12 +1167,12 @@ class K8sClient {
 		}
 
 		ResourceDefinitionContext context = new ResourceDefinitionContext.Builder()
-				.withGroup(crd.spec.group)
-				.withVersion(version)
-				.withKind(crd.spec.names.kind)
-				.withPlural(crd.spec.names.plural)
-				.withNamespaced(crd.spec.scope == "Namespaced")
-				.build()
+			.withGroup(crd.spec.group)
+			.withVersion(version)
+			.withKind(crd.spec.names.kind)
+			.withPlural(crd.spec.names.plural)
+			.withNamespaced(crd.spec.scope == "Namespaced")
+			.build()
 
 		def resourceClient = client.genericKubernetesResources(context)
 
@@ -1305,6 +1318,10 @@ class K8sClient {
 	 */
 	String getCurrentNamespace() {
 		return this.client.getNamespace()
+	}
+
+	boolean runInOpenShift() {
+		return false
 	}
 
 	// ========================================

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -13,7 +13,6 @@ import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Slf4j
 
 import io.fabric8.kubernetes.api.model.*
-import io.fabric8.kubernetes.client.Client
 import io.fabric8.kubernetes.client.Config
 import io.fabric8.kubernetes.client.ConfigBuilder
 import io.fabric8.kubernetes.client.KubernetesClient
@@ -54,7 +53,7 @@ class K8sClient {
 	protected int DEFAULT_RETRIES = 120
 
 	KubernetesClient client
-com.cloudogu.gitops.config.Config gopConfig
+	com.cloudogu.gitops.config.Config gopConfig
 
 	K8sClient(com.cloudogu.gitops.config.Config gopConfig = null) {
 		Config config = new ConfigBuilder()
@@ -561,7 +560,9 @@ com.cloudogu.gitops.config.Config gopConfig
 			yamlFiles = yamlFiles.sort { it.absolutePath }
 
 			int appliedResources = 0
-			yamlFiles.each { File file -> appliedResources += applyYamlStream(file.newInputStream(), file.absolutePath)
+			yamlFiles.each { File file ->
+				appliedResources += applyYamlStream(file.newInputStream(),
+					file.absolutePath)
 			}
 
 			return "Applied ${appliedResources} resource(s) from directory $yamlLocation"

--- a/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
@@ -4,6 +4,7 @@ import static groovy.test.GroovyAssert.shouldFail
 import static org.assertj.core.api.Assertions.assertThat
 
 import com.cloudogu.gitops.config.Credentials
+import com.cloudogu.gitops.config.Config
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -13,6 +14,7 @@ import io.fabric8.kubernetes.api.model.*
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer
+import io.fabric8.openshift.api.model.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -362,6 +364,68 @@ class K8sClientTest {
         // Then - Verify namespace was created
     }
 
+	@Test
+    void 'createNamespace creates OpenShift project when openshift config is enabled'() {
+        // Given
+        Config config = Config.fromMap([application: [openshift: true]])
+        k8sApiClient.gopConfig = config
+
+        server.expect()
+                .get()
+                .withPath("/api/v1/namespaces/test-project")
+                .andReturn(404, "")
+                .once()
+
+        server.expect()
+                .post()
+                .withPath("/apis/project.openshift.io/v1/projects")
+                .andReturn(201, new ProjectBuilder()
+                        .withNewMetadata()
+                        .withName("test-project")
+                        .endMetadata()
+                        .build())
+                .once()
+
+        // When
+        k8sApiClient.createNamespace("test-project")
+
+        // Then
+        def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
+        assertThat(requestBody["kind"]).isEqualTo("Project")
+        assertThat(requestBody["metadata"]["name"]).isEqualTo("test-project")
+    }
+
+	@Test
+    void 'createNamespace creates Kubernetes namespace when openshift config is disabled'() {
+        // Given
+        Config config = Config.fromMap([application: [openshift: false]])
+        k8sApiClient.gopConfig = config
+
+        server.expect()
+                .get()
+                .withPath("/api/v1/namespaces/test-ns")
+                .andReturn(404, "")
+                .once()
+
+        server.expect()
+                .post()
+                .withPath("/api/v1/namespaces")
+                .andReturn(201, new NamespaceBuilder()
+                        .withNewMetadata()
+                        .withName("test-ns")
+                        .endMetadata()
+                        .build())
+                .once()
+
+        // When
+        k8sApiClient.createNamespace("test-ns")
+
+        // Then
+        def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
+        assertThat(requestBody["kind"]).isEqualTo("Namespace")
+        assertThat(requestBody["metadata"]["name"]).isEqualTo("test-ns")
+    }
+
     @Test
     void 'createNamespace does not create existing namespace'() {
         // Given
@@ -380,7 +444,65 @@ class K8sClientTest {
         // When
         k8sApiClient.createNamespace("test-ns")
 
-        // Then - No POST request should be made
+        // Then
+        assertThat(server.getLastRequest().method).isEqualTo("GET")
+        assertThat(server.getLastRequest().path).isEqualTo("/api/v1/namespaces/test-ns")
+    }
+
+	@Test
+    void 'createNamespace creates Kubernetes namespace when config is null'() {
+        // Given
+        k8sApiClient.gopConfig = null
+
+        server.expect()
+                .get()
+                .withPath("/api/v1/namespaces/test-ns")
+                .andReturn(404, "")
+                .once()
+
+        server.expect()
+                .post()
+                .withPath("/api/v1/namespaces")
+                .andReturn(201, new NamespaceBuilder()
+                        .withNewMetadata()
+                        .withName("test-ns")
+                        .endMetadata()
+                        .build())
+                .once()
+
+        // When
+        k8sApiClient.createNamespace("test-ns")
+
+        // Then
+        def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
+        assertThat(requestBody["kind"]).isEqualTo("Namespace")
+        assertThat(requestBody["metadata"]["name"]).isEqualTo("test-ns")
+    }
+
+	@Test
+    void 'createNamespace does not create OpenShift project when namespace already exists'() {
+        // Given
+        Config config = Config.fromMap([application: [openshift: true]])
+        k8sApiClient.gopConfig = config
+
+        def namespace = new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("existing-project")
+                .endMetadata()
+                .build()
+
+        server.expect()
+                .get()
+                .withPath("/api/v1/namespaces/existing-project")
+                .andReturn(200, namespace)
+                .once()
+
+        // When
+        k8sApiClient.createNamespace("existing-project")
+
+        // Then
+        assertThat(server.getLastRequest().method).isEqualTo("GET")
+        assertThat(server.getLastRequest().path).isEqualTo("/api/v1/namespaces/existing-project")
     }
 
     @Test

--- a/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
@@ -3,8 +3,8 @@ package com.cloudogu.gitops.infrastructure.kubernetes.api
 import static groovy.test.GroovyAssert.shouldFail
 import static org.assertj.core.api.Assertions.assertThat
 
-import com.cloudogu.gitops.config.Credentials
 import com.cloudogu.gitops.config.Config
+import com.cloudogu.gitops.config.Credentials
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -22,976 +22,976 @@ import org.junit.jupiter.api.io.TempDir
 @EnableKubernetesMockClient
 class K8sClientTest {
 
-    KubernetesMockServer server
-    KubernetesClient client
+	KubernetesMockServer server
+	KubernetesClient client
 
-    K8sClient k8sApiClient
+	K8sClient k8sApiClient
 
-    @TempDir
-    Path tempDir
+	@TempDir
+	Path tempDir
 
-    @BeforeEach
-    void setup() {
-        k8sApiClient = new K8sClient()
-        k8sApiClient.client = client
-        k8sApiClient.SLEEPTIME = 10 // Speed up tests
-        k8sApiClient.DEFAULT_RETRIES = 3
-    }
+	@BeforeEach
+	void setup() {
+		k8sApiClient = new K8sClient()
+		k8sApiClient.client = client
+		k8sApiClient.SLEEPTIME = 10 // Speed up tests
+		k8sApiClient.DEFAULT_RETRIES = 3
+	}
 
-    // ========================================
-    // Node Operations Tests
-    // ========================================
-
-    @Test
-    void 'waitForNode returns first node name'() {
-        // Given
-        def node = new NodeBuilder()
-                .withNewMetadata()
-                .withName("test-node-1")
-                .endMetadata()
-                .build()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes")
-                .andReturn(200, new NodeListBuilder().withItems(node).build())
-                .once()
-
-        // When
-        String nodeName = k8sApiClient.waitForNode()
-
-        // Then
-        assertThat(nodeName).isEqualTo("test-node-1")
-    }
-
-    @Test
-    void 'waitForNode retries when no nodes available'() {
-        // Given
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes")
-                .andReturn(200, new NodeListBuilder().build())
-                .times(2)
-
-        def node = new NodeBuilder()
-                .withNewMetadata()
-                .withName("test-node-1")
-                .endMetadata()
-                .build()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes")
-                .andReturn(200, new NodeListBuilder().withItems(node).build())
-                .once()
-
-        // When
-        String nodeName = k8sApiClient.waitForNode()
-
-        // Then
-        assertThat(nodeName).isEqualTo("test-node-1")
-    }
-
-    @Test
-    void 'waitForNode throws exception after max retries'() {
-        // Given
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes")
-                .andReturn(200, new NodeListBuilder().build())
-                .times(k8sApiClient.DEFAULT_RETRIES + 1)
-
-        // When/Then
-        def exception = shouldFail(RuntimeException) {
-            k8sApiClient.waitForNode()
-        }
-        assertThat(exception.message).contains("Failed to retrieve node")
-    }
-
-    @Test
-    void 'waitForInternalNodeIp returns node internal IP'() {
-        // Given - First call for waitForNode
-        def node = new NodeBuilder()
-                .withNewMetadata()
-                .withName("test-node-1")
-                .endMetadata()
-                .withNewStatus()
-                .addNewAddress()
-                .withType("InternalIP")
-                .withAddress("192.168.1.100")
-                .endAddress()
-                .endStatus()
-                .build()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes")
-                .andReturn(200, new NodeListBuilder().withItems(node).build())
-                .once()
-
-        // Second call for waitForInternalNodeIp
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes/test-node-1")
-                .andReturn(200, node)
-                .once()
-
-        // When
-        String ip = k8sApiClient.waitForInternalNodeIp()
-
-        // Then
-        assertThat(ip).isEqualTo("192.168.1.100")
-    }
-
-    @Test
-    void 'waitForInternalNodeIp ignores IPv6 addresses'() {
-        // Given
-        def node = new NodeBuilder()
-                .withNewMetadata()
-                .withName("test-node-1")
-                .endMetadata()
-                .withNewStatus()
-                .addNewAddress()
-                .withType("InternalIP")
-                .withAddress("192.168.1.100")
-                .endAddress()
-                .addNewAddress()
-                .withType("InternalIP")
-                .withAddress("fe80::1")
-                .endAddress()
-                .endStatus()
-                .build()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes")
-                .andReturn(200, new NodeListBuilder().withItems(node).build())
-                .once()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/nodes/test-node-1")
-                .andReturn(200, node)
-                .once()
-
-        // When
-        String ip = k8sApiClient.waitForInternalNodeIp()
-
-        // Then
-        assertThat(ip).isEqualTo("192.168.1.100")
-    }
-
-    // ========================================
-    // Service Operations Tests
-    // ========================================
-
-    @Test
-    void 'waitForNodePort returns service nodePort'() {
-        // Given
-        def service = new ServiceBuilder()
-                .withNewMetadata()
-                .withName("test-service")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewSpec()
-                .addNewPort()
-                .withPort(8080)
-                .withNodePort(30080)
-                .endPort()
-                .endSpec()
-                .build()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/services/test-service")
-                .andReturn(200, service)
-                .once()
-
-        // When
-        String nodePort = k8sApiClient.waitForNodePort("test-service", "test-ns")
-
-        // Then
-        assertThat(nodePort).isEqualTo("30080")
-    }
-
-    @Test
-    void 'createServiceNodePort creates service with nodePort'() {
-        // Given
-        // createOrReplace() tries POST first
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces/default/services")
-                .andReturn(201, new ServiceBuilder()
-                        .withNewMetadata()
-                        .withName("my-service")
-                        .withNamespace("default")
-                        .endMetadata()
-                        .build())
-                .once()
-
-        // When
-        k8sApiClient.createServiceNodePort("my-service", "8080:80", "30000", "")
-
-        // Then - Verify the request was made (mock server expectation will fail if not)
-    }
-
-    @Test
-    void 'createServiceNodePort creates service without explicit nodePort'() {
-        // Given
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces/test-ns/services")
-                .andReturn(201, new ServiceBuilder()
-                        .withNewMetadata()
-                        .withName("my-service")
-                        .withNamespace("test-ns")
-                        .endMetadata()
-                        .build())
-                .once()
-
-        // When
-        k8sApiClient.createServiceNodePort("my-service", "8080:80", "", "test-ns")
-
-        // Then - Verify the request was made
-    }
-
-    @Test
-    void 'patchServiceNodePort updates service port'() {
-        // Given
-        def service = new ServiceBuilder()
-                .withNewMetadata()
-                .withName("test-service")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewSpec()
-                .addNewPort()
-                .withName("http")
-                .withPort(8080)
-                .withNodePort(30080)
-                .endPort()
-                .endSpec()
-                .build()
-
-        // patchServiceNodePort makes a GET, then patch() makes another GET followed by PATCH
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/services/test-service")
-                .andReturn(200, service)
-                .once()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/services/test-service")
-                .andReturn(200, service)
-                .once()
-
-        server.expect()
-                .patch()
-                .withPath("/api/v1/namespaces/test-ns/services/test-service")
-                .andReturn(200, service)
-                .once()
-
-        // When
-        k8sApiClient.patchServiceNodePort("test-service", "test-ns", "http", 30090)
-
-        // Then - Verify patch was called
-    }
-
-    @Test
-    void 'patchServiceNodePort throws exception for invalid parameters'() {
-        // When/Then
-        def exception = shouldFail(IllegalArgumentException) {
-            k8sApiClient.patchServiceNodePort("", "test-ns", "http", 30000)
-        }
-        assertThat(exception.message).contains("Service name")
-    }
-
-    @Test
-    void 'patchServiceNodePort throws exception when port not found'() {
-        // Given
-        def service = new ServiceBuilder()
-                .withNewMetadata()
-                .withName("test-service")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewSpec()
-                .addNewPort()
-                .withName("http")
-                .withPort(8080)
-                .endPort()
-                .endSpec()
-                .build()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/services/test-service")
-                .andReturn(200, service)
-                .once()
-
-        // When/Then
-        def exception = shouldFail(RuntimeException) {
-            k8sApiClient.patchServiceNodePort("test-service", "test-ns", "https", 30000)
-        }
-        assertThat(exception.message).contains("Port with name https not found")
-    }
-
-    // ========================================
-    // Namespace Operations Tests
-    // ========================================
-
-    @Test
-    void 'createNamespace creates new namespace'() {
-        // Given
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns")
-                .andReturn(404, "")
-                .once()
-
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces")
-                .andReturn(201, new NamespaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-ns")
-                        .endMetadata()
-                        .build())
-                .once()
-
-        // When
-        k8sApiClient.createNamespace("test-ns")
-
-        // Then - Verify namespace was created
-    }
+	// ========================================
+	// Node Operations Tests
+	// ========================================
 
 	@Test
-    void 'createNamespace creates OpenShift project when openshift config is enabled'() {
-        // Given
-        Config config = Config.fromMap([application: [openshift: true]])
-        k8sApiClient.gopConfig = config
+	void 'waitForNode returns first node name'() {
+		// Given
+		def node = new NodeBuilder()
+			.withNewMetadata()
+			.withName("test-node-1")
+			.endMetadata()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-project")
-                .andReturn(404, "")
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes")
+			.andReturn(200, new NodeListBuilder().withItems(node).build())
+			.once()
 
-        server.expect()
-                .post()
-                .withPath("/apis/project.openshift.io/v1/projects")
-                .andReturn(201, new ProjectBuilder()
-                        .withNewMetadata()
-                        .withName("test-project")
-                        .endMetadata()
-                        .build())
-                .once()
+		// When
+		String nodeName = k8sApiClient.waitForNode()
 
-        // When
-        k8sApiClient.createNamespace("test-project")
-
-        // Then
-        def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
-        assertThat(requestBody["kind"]).isEqualTo("Project")
-        assertThat(requestBody["metadata"]["name"]).isEqualTo("test-project")
-    }
+		// Then
+		assertThat(nodeName).isEqualTo("test-node-1")
+	}
 
 	@Test
-    void 'createNamespace creates Kubernetes namespace when openshift config is disabled'() {
-        // Given
-        Config config = Config.fromMap([application: [openshift: false]])
-        k8sApiClient.gopConfig = config
+	void 'waitForNode retries when no nodes available'() {
+		// Given
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes")
+			.andReturn(200, new NodeListBuilder().build())
+			.times(2)
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns")
-                .andReturn(404, "")
-                .once()
+		def node = new NodeBuilder()
+			.withNewMetadata()
+			.withName("test-node-1")
+			.endMetadata()
+			.build()
 
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces")
-                .andReturn(201, new NamespaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-ns")
-                        .endMetadata()
-                        .build())
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes")
+			.andReturn(200, new NodeListBuilder().withItems(node).build())
+			.once()
 
-        // When
-        k8sApiClient.createNamespace("test-ns")
+		// When
+		String nodeName = k8sApiClient.waitForNode()
 
-        // Then
-        def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
-        assertThat(requestBody["kind"]).isEqualTo("Namespace")
-        assertThat(requestBody["metadata"]["name"]).isEqualTo("test-ns")
-    }
-
-    @Test
-    void 'createNamespace does not create existing namespace'() {
-        // Given
-        def namespace = new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("test-ns")
-                .endMetadata()
-                .build()
-
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns")
-                .andReturn(200, namespace)
-                .once()
-
-        // When
-        k8sApiClient.createNamespace("test-ns")
-
-        // Then
-        assertThat(server.getLastRequest().method).isEqualTo("GET")
-        assertThat(server.getLastRequest().path).isEqualTo("/api/v1/namespaces/test-ns")
-    }
+		// Then
+		assertThat(nodeName).isEqualTo("test-node-1")
+	}
 
 	@Test
-    void 'createNamespace creates Kubernetes namespace when config is null'() {
-        // Given
-        k8sApiClient.gopConfig = null
+	void 'waitForNode throws exception after max retries'() {
+		// Given
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes")
+			.andReturn(200, new NodeListBuilder().build())
+			.times(k8sApiClient.DEFAULT_RETRIES + 1)
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns")
-                .andReturn(404, "")
-                .once()
-
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces")
-                .andReturn(201, new NamespaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-ns")
-                        .endMetadata()
-                        .build())
-                .once()
-
-        // When
-        k8sApiClient.createNamespace("test-ns")
-
-        // Then
-        def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
-        assertThat(requestBody["kind"]).isEqualTo("Namespace")
-        assertThat(requestBody["metadata"]["name"]).isEqualTo("test-ns")
-    }
+		// When/Then
+		def exception = shouldFail(RuntimeException) {
+			k8sApiClient.waitForNode()
+		}
+		assertThat(exception.message).contains("Failed to retrieve node")
+	}
 
 	@Test
-    void 'createNamespace does not create OpenShift project when namespace already exists'() {
-        // Given
-        Config config = Config.fromMap([application: [openshift: true]])
-        k8sApiClient.gopConfig = config
+	void 'waitForInternalNodeIp returns node internal IP'() {
+		// Given - First call for waitForNode
+		def node = new NodeBuilder()
+			.withNewMetadata()
+			.withName("test-node-1")
+			.endMetadata()
+			.withNewStatus()
+			.addNewAddress()
+			.withType("InternalIP")
+			.withAddress("192.168.1.100")
+			.endAddress()
+			.endStatus()
+			.build()
 
-        def namespace = new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("existing-project")
-                .endMetadata()
-                .build()
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes")
+			.andReturn(200, new NodeListBuilder().withItems(node).build())
+			.once()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/existing-project")
-                .andReturn(200, namespace)
-                .once()
+		// Second call for waitForInternalNodeIp
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes/test-node-1")
+			.andReturn(200, node)
+			.once()
 
-        // When
-        k8sApiClient.createNamespace("existing-project")
+		// When
+		String ip = k8sApiClient.waitForInternalNodeIp()
 
-        // Then
-        assertThat(server.getLastRequest().method).isEqualTo("GET")
-        assertThat(server.getLastRequest().path).isEqualTo("/api/v1/namespaces/existing-project")
-    }
+		// Then
+		assertThat(ip).isEqualTo("192.168.1.100")
+	}
 
-    @Test
-    void 'createNamespace throws exception for invalid name'() {
-        // When/Then
-        def exception = shouldFail(IllegalArgumentException) {
-            k8sApiClient.createNamespace("")
-        }
-        assertThat(exception.message).contains("Namespace name must be provided")
-    }
+	@Test
+	void 'waitForInternalNodeIp ignores IPv6 addresses'() {
+		// Given
+		def node = new NodeBuilder()
+			.withNewMetadata()
+			.withName("test-node-1")
+			.endMetadata()
+			.withNewStatus()
+			.addNewAddress()
+			.withType("InternalIP")
+			.withAddress("192.168.1.100")
+			.endAddress()
+			.addNewAddress()
+			.withType("InternalIP")
+			.withAddress("fe80::1")
+			.endAddress()
+			.endStatus()
+			.build()
 
-    @Test
-    void 'createNamespaces creates multiple namespaces'() {
-        // Given
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/ns1")
-                .andReturn(404, "")
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes")
+			.andReturn(200, new NodeListBuilder().withItems(node).build())
+			.once()
 
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces")
-                .andReturn(201, new NamespaceBuilder().withNewMetadata().withName("ns1").endMetadata().build())
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/nodes/test-node-1")
+			.andReturn(200, node)
+			.once()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/ns2")
-                .andReturn(404, "")
-                .once()
+		// When
+		String ip = k8sApiClient.waitForInternalNodeIp()
 
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces")
-                .andReturn(201, new NamespaceBuilder().withNewMetadata().withName("ns2").endMetadata().build())
-                .once()
+		// Then
+		assertThat(ip).isEqualTo("192.168.1.100")
+	}
 
-        // When
-        k8sApiClient.createNamespaces(["ns1", "ns2"])
+	// ========================================
+	// Service Operations Tests
+	// ========================================
 
-        // Then - Verify both namespaces were created
-    }
+	@Test
+	void 'waitForNodePort returns service nodePort'() {
+		// Given
+		def service = new ServiceBuilder()
+			.withNewMetadata()
+			.withName("test-service")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewSpec()
+			.addNewPort()
+			.withPort(8080)
+			.withNodePort(30080)
+			.endPort()
+			.endSpec()
+			.build()
 
-    @Test
-    void 'namespaceExists returns true for existing namespace'() {
-        // Given
-        def namespace = new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("test-ns")
-                .endMetadata()
-                .build()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/services/test-service")
+			.andReturn(200, service)
+			.once()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns")
-                .andReturn(200, namespace)
-                .once()
+		// When
+		String nodePort = k8sApiClient.waitForNodePort("test-service", "test-ns")
 
-        // When
-        boolean exists = k8sApiClient.namespaceExists("test-ns")
+		// Then
+		assertThat(nodePort).isEqualTo("30080")
+	}
 
-        // Then
-        assertThat(exists).isTrue()
-    }
+	@Test
+	void 'createServiceNodePort creates service with nodePort'() {
+		// Given
+		// createOrReplace() tries POST first
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces/default/services")
+			.andReturn(201, new ServiceBuilder()
+				.withNewMetadata()
+				.withName("my-service")
+				.withNamespace("default")
+				.endMetadata()
+				.build())
+			.once()
 
-    @Test
-    void 'namespaceExists returns false for non-existing namespace'() {
-        // Given
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/non-existing")
-                .andReturn(404, "")
-                .once()
+		// When
+		k8sApiClient.createServiceNodePort("my-service", "8080:80", "30000", "")
 
-        // When
-        boolean exists = k8sApiClient.namespaceExists("non-existing")
+		// Then - Verify the request was made (mock server expectation will fail if not)
+	}
 
-        // Then
-        assertThat(exists).isFalse()
-    }
+	@Test
+	void 'createServiceNodePort creates service without explicit nodePort'() {
+		// Given
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces/test-ns/services")
+			.andReturn(201, new ServiceBuilder()
+				.withNewMetadata()
+				.withName("my-service")
+				.withNamespace("test-ns")
+				.endMetadata()
+				.build())
+			.once()
 
-    // ========================================
-    // Secret Operations Tests
-    // ========================================
+		// When
+		k8sApiClient.createServiceNodePort("my-service", "8080:80", "", "test-ns")
 
-    @Test
-    void 'createSecret creates generic secret'() {
-        // Given
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces/test-ns/secrets")
-                .andReturn(201, new SecretBuilder()
-                        .withNewMetadata()
-                        .withName("my-secret")
-                        .withNamespace("test-ns")
-                        .endMetadata()
-                        .withType("Opaque")
-                        .build())
-                .once()
+		// Then - Verify the request was made
+	}
 
-        // When
-        k8sApiClient.createSecret("Opaque", "my-secret", "test-ns",
-                new Tuple2("username", "admin"),
-                new Tuple2("password", "secret"))
+	@Test
+	void 'patchServiceNodePort updates service port'() {
+		// Given
+		def service = new ServiceBuilder()
+			.withNewMetadata()
+			.withName("test-service")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewSpec()
+			.addNewPort()
+			.withName("http")
+			.withPort(8080)
+			.withNodePort(30080)
+			.endPort()
+			.endSpec()
+			.build()
 
-        // Then - Verify secret was created
-    }
+		// patchServiceNodePort makes a GET, then patch() makes another GET followed by PATCH
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/services/test-service")
+			.andReturn(200, service)
+			.once()
 
-    @Test
-    void 'createImagePullSecret creates docker registry secret'() {
-        // Given
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces/default/secrets")
-                .andReturn(201, new SecretBuilder()
-                        .withNewMetadata()
-                        .withName("my-registry")
-                        .withNamespace("default")
-                        .endMetadata()
-                        .withType("kubernetes.io/dockerconfigjson")
-                        .build())
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/services/test-service")
+			.andReturn(200, service)
+			.once()
 
-        // When
-        k8sApiClient.createImagePullSecret("my-registry", "", "docker.io", "user", "pass")
+		server.expect()
+			.patch()
+			.withPath("/api/v1/namespaces/test-ns/services/test-service")
+			.andReturn(200, service)
+			.once()
 
-        // Then - Verify secret was created
-    }
+		// When
+		k8sApiClient.patchServiceNodePort("test-service", "test-ns", "http", 30090)
 
-    @Test
-    void 'getArgoCDNamespacesSecret retrieves secret data'() {
-        // Given
-        def secret = new SecretBuilder()
-                .withNewMetadata()
-                .withName("argocd-secret")
-                .withNamespace("argocd")
-                .endMetadata()
-                .withData(["namespaces": Base64.encoder.encodeToString("ns1,ns2".bytes)])
-                .build()
+		// Then - Verify patch was called
+	}
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/argocd/secrets/argocd-secret")
-                .andReturn(200, secret)
-                .once()
+	@Test
+	void 'patchServiceNodePort throws exception for invalid parameters'() {
+		// When/Then
+		def exception = shouldFail(IllegalArgumentException) {
+			k8sApiClient.patchServiceNodePort("", "test-ns", "http", 30000)
+		}
+		assertThat(exception.message).contains("Service name")
+	}
 
-        // When
-        String data = k8sApiClient.getArgoCDNamespacesSecret("argocd-secret", "argocd")
+	@Test
+	void 'patchServiceNodePort throws exception when port not found'() {
+		// Given
+		def service = new ServiceBuilder()
+			.withNewMetadata()
+			.withName("test-service")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewSpec()
+			.addNewPort()
+			.withName("http")
+			.withPort(8080)
+			.endPort()
+			.endSpec()
+			.build()
 
-        // Then
-        assertThat(data).isEqualTo(Base64.encoder.encodeToString("ns1,ns2".bytes))
-    }
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/services/test-service")
+			.andReturn(200, service)
+			.once()
 
-    @Test
-    void 'getCredentialsFromSecret extracts username and password'() {
-        // Given
-        def secret = new SecretBuilder()
-                .withNewMetadata()
-                .withName("my-secret")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withData(["username": Base64.encoder.encodeToString("admin".bytes),
-                           "password": Base64.encoder.encodeToString("secret123".bytes)])
-                .build()
+		// When/Then
+		def exception = shouldFail(RuntimeException) {
+			k8sApiClient.patchServiceNodePort("test-service", "test-ns", "https", 30000)
+		}
+		assertThat(exception.message).contains("Port with name https not found")
+	}
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/secrets/my-secret")
-                .andReturn(200, secret)
-                .once()
+	// ========================================
+	// Namespace Operations Tests
+	// ========================================
 
-        // When
-        Credentials creds = k8sApiClient.getCredentialsFromSecret("my-secret", "test-ns")
+	@Test
+	void 'createNamespace creates new namespace'() {
+		// Given
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns")
+			.andReturn(404, "")
+			.once()
 
-        // Then
-        assertThat(creds.username).isEqualTo("admin")
-        assertThat(creds.password).isEqualTo("secret123")
-    }
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces")
+			.andReturn(201, new NamespaceBuilder()
+				.withNewMetadata()
+				.withName("test-ns")
+				.endMetadata()
+				.build())
+			.once()
 
-    @Test
-    void 'getCredentialsFromSecret with Credentials object'() {
-        // Given
-        def inputCreds = new Credentials(secretName: "my-secret",
-                secretNamespace: "test-ns",
-                usernameKey: "user",
-                passwordKey: "pass")
+		// When
+		k8sApiClient.createNamespace("test-ns")
 
-        def secret = new SecretBuilder()
-                .withNewMetadata()
-                .withName("my-secret")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withData(["user": Base64.encoder.encodeToString("testuser".bytes),
-                           "pass": Base64.encoder.encodeToString("testpass".bytes)])
-                .build()
+		// Then - Verify namespace was created
+	}
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/secrets/my-secret")
-                .andReturn(200, secret)
-                .once()
+	@Test
+	void 'createNamespace creates OpenShift project when openshift config is enabled'() {
+		// Given
+		Config config = Config.fromMap([application: [openshift: true]])
+		k8sApiClient.gopConfig = config
 
-        // When
-        Credentials result = k8sApiClient.getCredentialsFromSecret(inputCreds)
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-project")
+			.andReturn(404, "")
+			.once()
 
-        // Then
-        assertThat(result.username).isEqualTo("testuser")
-        assertThat(result.password).isEqualTo("testpass")
-    }
+		server.expect()
+			.post()
+			.withPath("/apis/project.openshift.io/v1/projects")
+			.andReturn(201, new ProjectBuilder()
+				.withNewMetadata()
+				.withName("test-project")
+				.endMetadata()
+				.build())
+			.once()
 
-    // ========================================
-    // ConfigMap Operations Tests
-    // ========================================
+		// When
+		k8sApiClient.createNamespace("test-project")
 
-    @Test
-    void 'createConfigMapFromFile creates configmap'() {
-        // Given
-        Path testFile = tempDir.resolve("test.txt")
-        Files.writeString(testFile, "test content")
+		// Then
+		def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
+		assertThat(requestBody["kind"]).isEqualTo("Project")
+		assertThat(requestBody["metadata"]["name"]).isEqualTo("test-project")
+	}
 
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces/default/configmaps")
-                .andReturn(201, new ConfigMapBuilder()
-                        .withNewMetadata()
-                        .withName("my-config")
-                        .withNamespace("default")
-                        .endMetadata()
-                        .build())
-                .once()
+	@Test
+	void 'createNamespace creates Kubernetes namespace when openshift config is disabled'() {
+		// Given
+		Config config = Config.fromMap([application: [openshift: false]])
+		k8sApiClient.gopConfig = config
 
-        // When
-        k8sApiClient.createConfigMapFromFile("my-config", "", testFile.toString())
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns")
+			.andReturn(404, "")
+			.once()
 
-        // Then - Verify configmap was created
-    }
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces")
+			.andReturn(201, new NamespaceBuilder()
+				.withNewMetadata()
+				.withName("test-ns")
+				.endMetadata()
+				.build())
+			.once()
 
-    @Test
-    void 'createConfigMapFromFile throws exception for non-existing file'() {
-        // When/Then
-        def exception = shouldFail(RuntimeException) {
-            k8sApiClient.createConfigMapFromFile("my-config", "", "/non/existing/file.txt")
-        }
-        assertThat(exception.message).contains("File not found")
-    }
+		// When
+		k8sApiClient.createNamespace("test-ns")
 
-    @Test
-    void 'getConfigMap retrieves value from configmap'() {
-        // Given
-        def configMap = new ConfigMapBuilder()
-                .withNewMetadata()
-                .withName("my-config")
-                .withNamespace("default")
-                .endMetadata()
-                .withData(["key1": "value1", "key2": "value2"])
-                .build()
+		// Then
+		def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
+		assertThat(requestBody["kind"]).isEqualTo("Namespace")
+		assertThat(requestBody["metadata"]["name"]).isEqualTo("test-ns")
+	}
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/configmaps/my-config")
-                .andReturn(200, configMap)
-                .once()
+	@Test
+	void 'createNamespace does not create existing namespace'() {
+		// Given
+		def namespace = new NamespaceBuilder()
+			.withNewMetadata()
+			.withName("test-ns")
+			.endMetadata()
+			.build()
 
-        // When
-        String value = k8sApiClient.getConfigMap("my-config", "key1")
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns")
+			.andReturn(200, namespace)
+			.once()
 
-        // Then
-        assertThat(value).isEqualTo("value1")
-    }
+		// When
+		k8sApiClient.createNamespace("test-ns")
 
-    @Test
-    void 'getConfigMap throws exception for non-existing key'() {
-        // Given
-        def configMap = new ConfigMapBuilder()
-                .withNewMetadata()
-                .withName("my-config")
-                .withNamespace("default")
-                .endMetadata()
-                .withData(["key1": "value1"])
-                .build()
+		// Then
+		assertThat(server.getLastRequest().method).isEqualTo("GET")
+		assertThat(server.getLastRequest().path).isEqualTo("/api/v1/namespaces/test-ns")
+	}
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/configmaps/my-config")
-                .andReturn(200, configMap)
-                .once()
+	@Test
+	void 'createNamespace creates Kubernetes namespace when config is null'() {
+		// Given
+		k8sApiClient.gopConfig = null
 
-        // When/Then
-        def exception = shouldFail(RuntimeException) {
-            k8sApiClient.getConfigMap("my-config", "non-existing-key")
-        }
-        assertThat(exception.message).contains("Could not fetch non-existing-key")
-    }
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns")
+			.andReturn(404, "")
+			.once()
 
-    // ========================================
-    // Resource Management Tests
-    // ========================================
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces")
+			.andReturn(201, new NamespaceBuilder()
+				.withNewMetadata()
+				.withName("test-ns")
+				.endMetadata()
+				.build())
+			.once()
 
-    @Test
-    void 'applyYaml applies resources from file'() {
-        // Given
-        Path yamlFile = tempDir.resolve("test.yaml")
-        Files.writeString(yamlFile, """
+		// When
+		k8sApiClient.createNamespace("test-ns")
+
+		// Then
+		def requestBody = new JsonSlurper().parseText(server.getLastRequest().getUtf8Body()) as Map
+		assertThat(requestBody["kind"]).isEqualTo("Namespace")
+		assertThat(requestBody["metadata"]["name"]).isEqualTo("test-ns")
+	}
+
+	@Test
+	void 'createNamespace does not create OpenShift project when namespace already exists'() {
+		// Given
+		Config config = Config.fromMap([application: [openshift: true]])
+		k8sApiClient.gopConfig = config
+
+		def namespace = new NamespaceBuilder()
+			.withNewMetadata()
+			.withName("existing-project")
+			.endMetadata()
+			.build()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/existing-project")
+			.andReturn(200, namespace)
+			.once()
+
+		// When
+		k8sApiClient.createNamespace("existing-project")
+
+		// Then
+		assertThat(server.getLastRequest().method).isEqualTo("GET")
+		assertThat(server.getLastRequest().path).isEqualTo("/api/v1/namespaces/existing-project")
+	}
+
+	@Test
+	void 'createNamespace throws exception for invalid name'() {
+		// When/Then
+		def exception = shouldFail(IllegalArgumentException) {
+			k8sApiClient.createNamespace("")
+		}
+		assertThat(exception.message).contains("Namespace name must be provided")
+	}
+
+	@Test
+	void 'createNamespaces creates multiple namespaces'() {
+		// Given
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/ns1")
+			.andReturn(404, "")
+			.once()
+
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces")
+			.andReturn(201, new NamespaceBuilder().withNewMetadata().withName("ns1").endMetadata().build())
+			.once()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/ns2")
+			.andReturn(404, "")
+			.once()
+
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces")
+			.andReturn(201, new NamespaceBuilder().withNewMetadata().withName("ns2").endMetadata().build())
+			.once()
+
+		// When
+		k8sApiClient.createNamespaces(["ns1", "ns2"])
+
+		// Then - Verify both namespaces were created
+	}
+
+	@Test
+	void 'namespaceExists returns true for existing namespace'() {
+		// Given
+		def namespace = new NamespaceBuilder()
+			.withNewMetadata()
+			.withName("test-ns")
+			.endMetadata()
+			.build()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns")
+			.andReturn(200, namespace)
+			.once()
+
+		// When
+		boolean exists = k8sApiClient.namespaceExists("test-ns")
+
+		// Then
+		assertThat(exists).isTrue()
+	}
+
+	@Test
+	void 'namespaceExists returns false for non-existing namespace'() {
+		// Given
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/non-existing")
+			.andReturn(404, "")
+			.once()
+
+		// When
+		boolean exists = k8sApiClient.namespaceExists("non-existing")
+
+		// Then
+		assertThat(exists).isFalse()
+	}
+
+	// ========================================
+	// Secret Operations Tests
+	// ========================================
+
+	@Test
+	void 'createSecret creates generic secret'() {
+		// Given
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces/test-ns/secrets")
+			.andReturn(201, new SecretBuilder()
+				.withNewMetadata()
+				.withName("my-secret")
+				.withNamespace("test-ns")
+				.endMetadata()
+				.withType("Opaque")
+				.build())
+			.once()
+
+		// When
+		k8sApiClient.createSecret("Opaque", "my-secret", "test-ns",
+			new Tuple2("username", "admin"),
+			new Tuple2("password", "secret"))
+
+		// Then - Verify secret was created
+	}
+
+	@Test
+	void 'createImagePullSecret creates docker registry secret'() {
+		// Given
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces/default/secrets")
+			.andReturn(201, new SecretBuilder()
+				.withNewMetadata()
+				.withName("my-registry")
+				.withNamespace("default")
+				.endMetadata()
+				.withType("kubernetes.io/dockerconfigjson")
+				.build())
+			.once()
+
+		// When
+		k8sApiClient.createImagePullSecret("my-registry", "", "docker.io", "user", "pass")
+
+		// Then - Verify secret was created
+	}
+
+	@Test
+	void 'getArgoCDNamespacesSecret retrieves secret data'() {
+		// Given
+		def secret = new SecretBuilder()
+			.withNewMetadata()
+			.withName("argocd-secret")
+			.withNamespace("argocd")
+			.endMetadata()
+			.withData(["namespaces": Base64.encoder.encodeToString("ns1,ns2".bytes)])
+			.build()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/argocd/secrets/argocd-secret")
+			.andReturn(200, secret)
+			.once()
+
+		// When
+		String data = k8sApiClient.getArgoCDNamespacesSecret("argocd-secret", "argocd")
+
+		// Then
+		assertThat(data).isEqualTo(Base64.encoder.encodeToString("ns1,ns2".bytes))
+	}
+
+	@Test
+	void 'getCredentialsFromSecret extracts username and password'() {
+		// Given
+		def secret = new SecretBuilder()
+			.withNewMetadata()
+			.withName("my-secret")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withData(["username": Base64.encoder.encodeToString("admin".bytes),
+			           "password": Base64.encoder.encodeToString("secret123".bytes)])
+			.build()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/secrets/my-secret")
+			.andReturn(200, secret)
+			.once()
+
+		// When
+		Credentials creds = k8sApiClient.getCredentialsFromSecret("my-secret", "test-ns")
+
+		// Then
+		assertThat(creds.username).isEqualTo("admin")
+		assertThat(creds.password).isEqualTo("secret123")
+	}
+
+	@Test
+	void 'getCredentialsFromSecret with Credentials object'() {
+		// Given
+		def inputCreds = new Credentials(secretName: "my-secret",
+			secretNamespace: "test-ns",
+			usernameKey: "user",
+			passwordKey: "pass")
+
+		def secret = new SecretBuilder()
+			.withNewMetadata()
+			.withName("my-secret")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withData(["user": Base64.encoder.encodeToString("testuser".bytes),
+			           "pass": Base64.encoder.encodeToString("testpass".bytes)])
+			.build()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/secrets/my-secret")
+			.andReturn(200, secret)
+			.once()
+
+		// When
+		Credentials result = k8sApiClient.getCredentialsFromSecret(inputCreds)
+
+		// Then
+		assertThat(result.username).isEqualTo("testuser")
+		assertThat(result.password).isEqualTo("testpass")
+	}
+
+	// ========================================
+	// ConfigMap Operations Tests
+	// ========================================
+
+	@Test
+	void 'createConfigMapFromFile creates configmap'() {
+		// Given
+		Path testFile = tempDir.resolve("test.txt")
+		Files.writeString(testFile, "test content")
+
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces/default/configmaps")
+			.andReturn(201, new ConfigMapBuilder()
+				.withNewMetadata()
+				.withName("my-config")
+				.withNamespace("default")
+				.endMetadata()
+				.build())
+			.once()
+
+		// When
+		k8sApiClient.createConfigMapFromFile("my-config", "", testFile.toString())
+
+		// Then - Verify configmap was created
+	}
+
+	@Test
+	void 'createConfigMapFromFile throws exception for non-existing file'() {
+		// When/Then
+		def exception = shouldFail(RuntimeException) {
+			k8sApiClient.createConfigMapFromFile("my-config", "", "/non/existing/file.txt")
+		}
+		assertThat(exception.message).contains("File not found")
+	}
+
+	@Test
+	void 'getConfigMap retrieves value from configmap'() {
+		// Given
+		def configMap = new ConfigMapBuilder()
+			.withNewMetadata()
+			.withName("my-config")
+			.withNamespace("default")
+			.endMetadata()
+			.withData(["key1": "value1", "key2": "value2"])
+			.build()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/configmaps/my-config")
+			.andReturn(200, configMap)
+			.once()
+
+		// When
+		String value = k8sApiClient.getConfigMap("my-config", "key1")
+
+		// Then
+		assertThat(value).isEqualTo("value1")
+	}
+
+	@Test
+	void 'getConfigMap throws exception for non-existing key'() {
+		// Given
+		def configMap = new ConfigMapBuilder()
+			.withNewMetadata()
+			.withName("my-config")
+			.withNamespace("default")
+			.endMetadata()
+			.withData(["key1": "value1"])
+			.build()
+
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/configmaps/my-config")
+			.andReturn(200, configMap)
+			.once()
+
+		// When/Then
+		def exception = shouldFail(RuntimeException) {
+			k8sApiClient.getConfigMap("my-config", "non-existing-key")
+		}
+		assertThat(exception.message).contains("Could not fetch non-existing-key")
+	}
+
+	// ========================================
+	// Resource Management Tests
+	// ========================================
+
+	@Test
+	void 'applyYaml applies resources from file'() {
+		// Given
+		Path yamlFile = tempDir.resolve("test.yaml")
+		Files.writeString(yamlFile, """
 apiVersion: v1
 kind: Namespace
 metadata:
   name: test-ns
 """)
 
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces")
-                .andReturn(201, new NamespaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-ns")
-                        .endMetadata()
-                        .build())
-                .once()
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces")
+			.andReturn(201, new NamespaceBuilder()
+				.withNewMetadata()
+				.withName("test-ns")
+				.endMetadata()
+				.build())
+			.once()
 
-        // When
-        String result = k8sApiClient.applyYaml(yamlFile.toString())
+		// When
+		String result = k8sApiClient.applyYaml(yamlFile.toString())
 
-        // Then
-        assertThat(result).contains("Applied 1 resource(s)")
-    }
+		// Then
+		assertThat(result).contains("Applied 1 resource(s)")
+	}
 
-    @Test
-    void 'applyYaml throws exception for non-existing file or directory'() {
-        // When/Then
-        def exception = shouldFail(RuntimeException) {
-            k8sApiClient.applyYaml("/non/existing/file.yaml")
-        }
+	@Test
+	void 'applyYaml throws exception for non-existing file or directory'() {
+		// When/Then
+		def exception = shouldFail(RuntimeException) {
+			k8sApiClient.applyYaml("/non/existing/file.yaml")
+		}
 
-        assertThat(exception.message).contains("File or directory not found")
-        assertThat(exception.message).contains("/non/existing/file.yaml")
-    }
+		assertThat(exception.message).contains("File or directory not found")
+		assertThat(exception.message).contains("/non/existing/file.yaml")
+	}
 
-    @Test
-    void 'label adds labels to resource'() {
-        // Given
-        def pod = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("default")
-                .withLabels(["existing": "label"])
-                .endMetadata()
-                .build()
+	@Test
+	void 'label adds labels to resource'() {
+		// Given
+		def pod = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("default")
+			.withLabels(["existing": "label"])
+			.endMetadata()
+			.build()
 
-        // label() makes a GET, then replace() makes another GET followed by PUT
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		// label() makes a GET, then replace() makes another GET followed by PUT
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        server.expect()
-                .put()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.put()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        // When
-        k8sApiClient.label("pod", "test-pod", "default",
-                new Tuple2("app", "myapp"),
-                new Tuple2("version", "1.0"))
+		// When
+		k8sApiClient.label("pod", "test-pod", "default",
+			new Tuple2("app", "myapp"),
+			new Tuple2("version", "1.0"))
 
-        // Then - Verify labels were updated
-    }
+		// Then - Verify labels were updated
+	}
 
-    @Test
-    void 'labelRemove removes labels from resource'() {
-        // Given
-        def pod = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("default")
-                .withLabels(["app": "myapp", "version": "1.0"])
-                .endMetadata()
-                .build()
+	@Test
+	void 'labelRemove removes labels from resource'() {
+		// Given
+		def pod = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("default")
+			.withLabels(["app": "myapp", "version": "1.0"])
+			.endMetadata()
+			.build()
 
-        // label() makes a GET, then replace() makes another GET followed by PUT
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		// label() makes a GET, then replace() makes another GET followed by PUT
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        server.expect()
-                .put()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.put()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        // When
-        k8sApiClient.labelRemove("pod", "test-pod", "default", "version")
+		// When
+		k8sApiClient.labelRemove("pod", "test-pod", "default", "version")
 
-        // Then - Verify label was removed
-    }
+		// Then - Verify label was removed
+	}
 
-    @Test
-    void 'patch patches resource with strategic merge'() {
-        // Given
-        def pod = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("default")
-                .endMetadata()
-                .build()
+	@Test
+	void 'patch patches resource with strategic merge'() {
+		// Given
+		def pod = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("default")
+			.endMetadata()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        server.expect()
-                .patch()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.patch()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        // When
-        k8sApiClient.patch("pod", "test-pod", "default", "strategic", ["metadata": ["labels": ["new": "label"]]])
+		// When
+		k8sApiClient.patch("pod", "test-pod", "default", "strategic", ["metadata": ["labels": ["new": "label"]]])
 
-        // Then - Verify patch was applied
-    }
+		// Then - Verify patch was applied
+	}
 
-    @Test
-    void 'delete removes resources by label selector'() {
-        // Given
-        server.expect()
-                .delete()
-                .withPath("/api/v1/namespaces/test-ns/pods?labelSelector=app%3Dmyapp")
-                .andReturn(200, new StatusBuilder().build())
-                .once()
+	@Test
+	void 'delete removes resources by label selector'() {
+		// Given
+		server.expect()
+			.delete()
+			.withPath("/api/v1/namespaces/test-ns/pods?labelSelector=app%3Dmyapp")
+			.andReturn(200, new StatusBuilder().build())
+			.once()
 
-        // When
-        k8sApiClient.delete("pod", "test-ns", new Tuple2("app", "myapp"))
+		// When
+		k8sApiClient.delete("pod", "test-ns", new Tuple2("app", "myapp"))
 
-        // Then - Verify delete was called
-    }
+		// Then - Verify delete was called
+	}
 
-    @Test
-    void 'delete removes specific resource by name'() {
-        // Given
-        server.expect()
-                .delete()
-                .withPath("/api/v1/namespaces/test-ns/pods/test-pod")
-                .andReturn(200, new StatusBuilder().build())
-                .once()
+	@Test
+	void 'delete removes specific resource by name'() {
+		// Given
+		server.expect()
+			.delete()
+			.withPath("/api/v1/namespaces/test-ns/pods/test-pod")
+			.andReturn(200, new StatusBuilder().build())
+			.once()
 
-        // When
-        k8sApiClient.delete("pod", "test-ns", "test-pod")
+		// When
+		k8sApiClient.delete("pod", "test-ns", "test-pod")
 
-        // Then - Verify delete was called
-    }
+		// Then - Verify delete was called
+	}
 
-    @Test
-    void 'run creates pod with image'() {
-        // Given
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces/default/pods")
-                .andReturn(201, new PodBuilder()
-                        .withNewMetadata()
-                        .withName("test-pod")
-                        .endMetadata()
-                        .build())
-                .once()
+	@Test
+	void 'run creates pod with image'() {
+		// Given
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces/default/pods")
+			.andReturn(201, new PodBuilder()
+				.withNewMetadata()
+				.withName("test-pod")
+				.endMetadata()
+				.build())
+			.once()
 
-        // When
-        String result = k8sApiClient.run("test-pod", "nginx:latest", "", [:])
+		// When
+		String result = k8sApiClient.run("test-pod", "nginx:latest", "", [:])
 
-        // Then
-        assertThat(result).contains("pod/test-pod created")
-    }
+		// Then
+		assertThat(result).contains("pod/test-pod created")
+	}
 
 	@Test
 	void 'run applies pod overrides instead of generated parameter values'() {
@@ -1104,283 +1104,283 @@ metadata:
 	}
 
 	// ========================================
-    // Query Operations Tests
-    // ========================================
+	// Query Operations Tests
+	// ========================================
 
-    @Test
-    void 'getCustomResource returns list of custom resources'() {
-        // Given - Mock server setup for generic resources is complex, simplifying
-        // When/Then - This would need more sophisticated mocking
-        // Skipping detailed test due to complexity with genericKubernetesResources
-    }
+	@Test
+	void 'getCustomResource returns list of custom resources'() {
+		// Given - Mock server setup for generic resources is complex, simplifying
+		// When/Then - This would need more sophisticated mocking
+		// Skipping detailed test due to complexity with genericKubernetesResources
+	}
 
-    @Test
-    void 'getAnnotation retrieves annotation value'() {
-        // Given
-        def pod = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("default")
-                .withAnnotations(["key1": "value1", "key2": "value2"])
-                .endMetadata()
-                .build()
+	@Test
+	void 'getAnnotation retrieves annotation value'() {
+		// Given
+		def pod = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("default")
+			.withAnnotations(["key1": "value1", "key2": "value2"])
+			.endMetadata()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        // When
-        String value = k8sApiClient.getAnnotation("pod", "test-pod", "key1", "default")
+		// When
+		String value = k8sApiClient.getAnnotation("pod", "test-pod", "key1", "default")
 
-        // Then
-        assertThat(value).isEqualTo("value1")
-    }
+		// Then
+		assertThat(value).isEqualTo("value1")
+	}
 
-    @Test
-    void 'getAnnotation returns null for non-existing annotation'() {
-        // Given
-        def pod = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("default")
-                .withAnnotations(["key1": "value1"])
-                .endMetadata()
-                .build()
+	@Test
+	void 'getAnnotation returns null for non-existing annotation'() {
+		// Given
+		def pod = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("default")
+			.withAnnotations(["key1": "value1"])
+			.endMetadata()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/default/pods/test-pod")
-                .andReturn(200, pod)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/default/pods/test-pod")
+			.andReturn(200, pod)
+			.once()
 
-        // When
-        String value = k8sApiClient.getAnnotation("pod", "test-pod", "non-existing", "default")
+		// When
+		String value = k8sApiClient.getAnnotation("pod", "test-pod", "non-existing", "default")
 
-        // Then
-        assertThat(value).isNull()
-    }
+		// Then
+		assertThat(value).isNull()
+	}
 
-    @Test
-    void 'getCurrentContext returns context name'() {
-        // When
-        String context = k8sApiClient.getCurrentContext()
+	@Test
+	void 'getCurrentContext returns context name'() {
+		// When
+		String context = k8sApiClient.getCurrentContext()
 
-        // Then
-        assertThat(context).isNotNull()
-        // Note: Actual value depends on mock client configuration
-    }
+		// Then
+		assertThat(context).isNotNull()
+		// Note: Actual value depends on mock client configuration
+	}
 
-    // ========================================
-    // Wait Operations Tests
-    // ========================================
+	// ========================================
+	// Wait Operations Tests
+	// ========================================
 
-    @Test
-    void 'waitForResourcePhase waits for pod to reach Running phase'() {
-        // Given
-        def podRunning = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewStatus()
-                .withPhase("Running")
-                .endStatus()
-                .build()
+	@Test
+	void 'waitForResourcePhase waits for pod to reach Running phase'() {
+		// Given
+		def podRunning = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewStatus()
+			.withPhase("Running")
+			.endStatus()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/pods/test-pod")
-                .andReturn(200, podRunning)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/pods/test-pod")
+			.andReturn(200, podRunning)
+			.once()
 
-        // When
-        k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 5, 1)
+		// When
+		k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 5, 1)
 
-        // Then - No exception means success
-    }
+		// Then - No exception means success
+	}
 
-    @Test
-    void 'waitForResourcePhase retries until phase is reached'() {
-        // Given
-        def podPending = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewStatus()
-                .withPhase("Pending")
-                .endStatus()
-                .build()
+	@Test
+	void 'waitForResourcePhase retries until phase is reached'() {
+		// Given
+		def podPending = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewStatus()
+			.withPhase("Pending")
+			.endStatus()
+			.build()
 
-        def podRunning = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewStatus()
-                .withPhase("Running")
-                .endStatus()
-                .build()
+		def podRunning = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewStatus()
+			.withPhase("Running")
+			.endStatus()
+			.build()
 
-        // First two requests return Pending
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/pods/test-pod")
-                .andReturn(200, podPending)
-                .once()
+		// First two requests return Pending
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/pods/test-pod")
+			.andReturn(200, podPending)
+			.once()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/pods/test-pod")
-                .andReturn(200, podPending)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/pods/test-pod")
+			.andReturn(200, podPending)
+			.once()
 
-        // Third request returns Running
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/pods/test-pod")
-                .andReturn(200, podRunning)
-                .once()
+		// Third request returns Running
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/pods/test-pod")
+			.andReturn(200, podRunning)
+			.once()
 
-        // When
-        k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 10, 1)
+		// When
+		k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 10, 1)
 
-        // Then - No exception means success
-    }
+		// Then - No exception means success
+	}
 
-    @Test
-    void 'waitForResourcePhase throws exception on timeout'() {
-        // Given
-        def podPending = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewStatus()
-                .withPhase("Pending")
-                .endStatus()
-                .build()
+	@Test
+	void 'waitForResourcePhase throws exception on timeout'() {
+		// Given
+		def podPending = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewStatus()
+			.withPhase("Pending")
+			.endStatus()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/pods/test-pod")
-                .andReturn(200, podPending)
-                .always()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/pods/test-pod")
+			.andReturn(200, podPending)
+			.always()
 
-        // When/Then
-        def exception = shouldFail(RuntimeException) {
-            k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 2, 1)
-        }
-        assertThat(exception.message).contains("Timeout reached")
-    }
+		// When/Then
+		def exception = shouldFail(RuntimeException) {
+			k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 2, 1)
+		}
+		assertThat(exception.message).contains("Timeout reached")
+	}
 
-    @Test
-    void 'waitForResourcePhase with default timeout'() {
-        // Given
-        def podRunning = new PodBuilder()
-                .withNewMetadata()
-                .withName("test-pod")
-                .withNamespace("test-ns")
-                .endMetadata()
-                .withNewStatus()
-                .withPhase("Running")
-                .endStatus()
-                .build()
+	@Test
+	void 'waitForResourcePhase with default timeout'() {
+		// Given
+		def podRunning = new PodBuilder()
+			.withNewMetadata()
+			.withName("test-pod")
+			.withNamespace("test-ns")
+			.endMetadata()
+			.withNewStatus()
+			.withPhase("Running")
+			.endStatus()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/api/v1/namespaces/test-ns/pods/test-pod")
-                .andReturn(200, podRunning)
-                .always()
+		server.expect()
+			.get()
+			.withPath("/api/v1/namespaces/test-ns/pods/test-pod")
+			.andReturn(200, podRunning)
+			.always()
 
-        // When
-        k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running")
+		// When
+		k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running")
 
-        // Then - No exception means success
-    }
+		// Then - No exception means success
+	}
 
-    @Test
-    void 'waitForResourcePhase validates parameters'() {
-        // When/Then
-        def exception = shouldFail(IllegalArgumentException) {
-            k8sApiClient.waitForResourcePhase("", "test-pod", "test-ns", "Running", 60, 1)
-        }
-        assertThat(exception.message).contains("Resource type")
+	@Test
+	void 'waitForResourcePhase validates parameters'() {
+		// When/Then
+		def exception = shouldFail(IllegalArgumentException) {
+			k8sApiClient.waitForResourcePhase("", "test-pod", "test-ns", "Running", 60, 1)
+		}
+		assertThat(exception.message).contains("Resource type")
 
-        exception = shouldFail(IllegalArgumentException) {
-            k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 0, 1)
-        }
-        assertThat(exception.message).contains("Timeout")
+		exception = shouldFail(IllegalArgumentException) {
+			k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 0, 1)
+		}
+		assertThat(exception.message).contains("Timeout")
 
-        exception = shouldFail(IllegalArgumentException) {
-            k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 60, 0)
-        }
-        assertThat(exception.message).contains("check interval")
-    }
+		exception = shouldFail(IllegalArgumentException) {
+			k8sApiClient.waitForResourcePhase("pod", "test-pod", "test-ns", "Running", 60, 0)
+		}
+		assertThat(exception.message).contains("check interval")
+	}
 
-    // ========================================
-    // Edge Cases and Error Handling Tests
-    // ========================================
+	// ========================================
+	// Edge Cases and Error Handling Tests
+	// ========================================
 
-    @Test
-    void 'resolves default namespace for empty string'() {
-        // Given
-        server.expect()
-                .post()
-                .withPath("/api/v1/namespaces/default/secrets")
-                .andReturn(201, new SecretBuilder()
-                        .withNewMetadata()
-                        .withName("test-secret")
-                        .withNamespace("default")
-                        .endMetadata()
-                        .withType("Opaque")
-                        .build())
-                .once()
+	@Test
+	void 'resolves default namespace for empty string'() {
+		// Given
+		server.expect()
+			.post()
+			.withPath("/api/v1/namespaces/default/secrets")
+			.andReturn(201, new SecretBuilder()
+				.withNewMetadata()
+				.withName("test-secret")
+				.withNamespace("default")
+				.endMetadata()
+				.withType("Opaque")
+				.build())
+			.once()
 
-        // When
-        k8sApiClient.createSecret("Opaque", "test-secret", "", new Tuple2("key", "value"))
+		// When
+		k8sApiClient.createSecret("Opaque", "test-secret", "", new Tuple2("key", "value"))
 
-        // Then - Verify default namespace was used
-    }
+		// Then - Verify default namespace was used
+	}
 
-    @Test
-    void 'handles multiple resource types in getResourceClient'() {
-        // Test covered indirectly by other tests, but we can verify deployment
-        // Given
-        def deployment = new io.fabric8.kubernetes.api.model.apps.DeploymentBuilder()
-                .withNewMetadata()
-                .withName("test-deploy")
-                .withNamespace("default")
-                .endMetadata()
-                .build()
+	@Test
+	void 'handles multiple resource types in getResourceClient'() {
+		// Test covered indirectly by other tests, but we can verify deployment
+		// Given
+		def deployment = new io.fabric8.kubernetes.api.model.apps.DeploymentBuilder()
+			.withNewMetadata()
+			.withName("test-deploy")
+			.withNamespace("default")
+			.endMetadata()
+			.build()
 
-        server.expect()
-                .get()
-                .withPath("/apis/apps/v1/namespaces/default/deployments/test-deploy")
-                .andReturn(200, deployment)
-                .once()
+		server.expect()
+			.get()
+			.withPath("/apis/apps/v1/namespaces/default/deployments/test-deploy")
+			.andReturn(200, deployment)
+			.once()
 
-        server.expect()
-                .delete()
-                .withPath("/apis/apps/v1/namespaces/default/deployments/test-deploy")
-                .andReturn(200, new StatusBuilder().build())
-                .once()
+		server.expect()
+			.delete()
+			.withPath("/apis/apps/v1/namespaces/default/deployments/test-deploy")
+			.andReturn(200, new StatusBuilder().build())
+			.once()
 
-        // When
-        k8sApiClient.delete("deployment", "default", "test-deploy")
+		// When
+		k8sApiClient.delete("deployment", "default", "test-deploy")
 
-        // Then - Verify delete was called for deployment
-    }
+		// Then - Verify delete was called for deployment
+	}
 
-    @Test
-    void 'CustomResource class is immutable'() {
-        // When
-        def cr = new K8sClient.CustomResource("test-ns", "test-name")
+	@Test
+	void 'CustomResource class is immutable'() {
+		// When
+		def cr = new K8sClient.CustomResource("test-ns", "test-name")
 
-        // Then
-        assertThat(cr.namespace).isEqualTo("test-ns")
-        assertThat(cr.name).isEqualTo("test-name")
-    }
+		// Then
+		assertThat(cr.namespace).isEqualTo("test-ns")
+		assertThat(cr.name).isEqualTo("test-name")
+	}
 }


### PR DESCRIPTION
## Pull request overview

This PR adds OpenShift-aware namespace provisioning by creating OpenShift `Project` resources when `application.openshift` is enabled, and aligns password handling/output with the configured `application.password`.

**Changes:**
- Extend `K8sClient#createNamespace` to create an OpenShift `Project` instead of a Kubernetes `Namespace` when OpenShift mode is enabled.
- Add/extend tests covering OpenShift vs. Kubernetes behavior and the null-config fallback.
- Switch to the Fabric8 `openshift-client` dependency (and bump Fabric8 version), and propagate `application.password` into the welcome screen and stored secret.

