### PR TITLE
Prevent SCM-Manager Argo CD Tracking Collisions in Multi-Tenant Setups

### DIFF
--- a/argocd/cluster-resources/apps/argocd/argocd/values.ftl.yaml
+++ b/argocd/cluster-resources/apps/argocd/argocd/values.ftl.yaml
@@ -70,6 +70,7 @@ argo-cd:
     cm:
       timeout.reconciliation: 15s
       repository.check.interval: 30s
+      application.resourceTrackingMethod: annotation
 
   notifications:
     # secrets are created dynamically in groovy, so they are not stored in git

--- a/argocd/cluster-resources/apps/argocd/operator/argocd.ftl.yaml
+++ b/argocd/cluster-resources/apps/argocd/operator/argocd.ftl.yaml
@@ -4,6 +4,8 @@ metadata:
   name: argocd
   namespace: "${config.application.namePrefix}${config.features.argocd.namespace}"
 spec:
+  extraConfig:
+    application.resourceTrackingMethod: annotation
   applicationSet:
     enabled: true
     resources:

--- a/src/main/groovy/com/cloudogu/gitops/application/orchestration/GitHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/application/orchestration/GitHandler.groovy
@@ -110,18 +110,22 @@ class GitHandler {
 
 	private void setupExternalRepositoriesIfPossible() {
 		final String namePrefix = (config.application.namePrefix ?: "").trim()
-		final boolean skipInternalScmRepositorySetup = shouldSkipRepositorySetupForInternalScmManager()
+		final boolean repositorySetupBlockedByInternalScmBootstrap = isRepositorySetupBlockedByInternalScmBootstrap()
 
 		log.info(
-			"Evaluating external repository setup: centralConfigured={}, tenantConfigured={}, namePrefix='{}', skipInternalScmRepositorySetup={}",
+			"Evaluating repository setup: centralConfigured={}, tenantConfigured={}, namePrefix='{}', repositorySetupBlockedByInternalScmBootstrap={}",
 			central != null,
 			tenant != null,
 			namePrefix,
-			skipInternalScmRepositorySetup
+			repositorySetupBlockedByInternalScmBootstrap
 		)
 
-		if (skipInternalScmRepositorySetup) {
-			log.info("Skipping external repository setup because internal SCM-Manager is not deployed yet. namePrefix='{}'", namePrefix)
+		if (repositorySetupBlockedByInternalScmBootstrap) {
+			log.info(
+				"Skipping repository setup because the configured internal SCM-Manager is not deployed yet. " +
+					"Repository setup can continue immediately when an external SCM-Manager is configured. namePrefix='{}'",
+				namePrefix
+			)
 			return
 		}
 
@@ -134,8 +138,7 @@ class GitHandler {
 			setupRepos(tenant, namePrefix)
 		}
 	}
-
-	private boolean shouldSkipRepositorySetupForInternalScmManager() {
+	private boolean isRepositorySetupBlockedByInternalScmBootstrap() {
 		config.scm.scmProviderType == ScmProviderType.SCM_MANAGER && config.scm.scmManager?.internal
 	}
 

--- a/src/main/groovy/com/cloudogu/gitops/application/orchestration/GitHandler.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/application/orchestration/GitHandler.groovy
@@ -110,16 +110,27 @@ class GitHandler {
 
 	private void setupExternalRepositoriesIfPossible() {
 		final String namePrefix = (config.application.namePrefix ?: "").trim()
+		final boolean skipInternalScmRepositorySetup = shouldSkipRepositorySetupForInternalScmManager()
 
-		if (shouldSkipRepositorySetupForInternalScmManager()) {
-			log.debug("Skipping repository setup in GitHandler because internal SCM-Manager is not deployed yet.")
+		log.info(
+			"Evaluating external repository setup: centralConfigured={}, tenantConfigured={}, namePrefix='{}', skipInternalScmRepositorySetup={}",
+			central != null,
+			tenant != null,
+			namePrefix,
+			skipInternalScmRepositorySetup
+		)
+
+		if (skipInternalScmRepositorySetup) {
+			log.info("Skipping external repository setup because internal SCM-Manager is not deployed yet. namePrefix='{}'", namePrefix)
 			return
 		}
 
 		if (central) {
+			log.info("Setting up central and tenant repositories. namePrefix='{}'", namePrefix)
 			setupRepos(central, namePrefix)
 			setupRepos(tenant, namePrefix)
 		} else {
+			log.info("Setting up tenant repositories only. namePrefix='{}'", namePrefix)
 			setupRepos(tenant, namePrefix)
 		}
 	}

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
@@ -38,6 +38,7 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 	void deployFeature(String repoURL, String repoName, String chartOrPath, String version, String namespace,
 		String releaseName, Path helmValuesPath, RepoType repoType) {
 		log.trace("Deploying helm chart via ArgoCD: ${releaseName}. Reading values from ${helmValuesPath}")
+
 		def namePrefix = config.application.namePrefix
 		def shallCreateNamespace = config.features['argocd']['operator'] ? "CreateNamespace=false" : "CreateNamespace=true"
 
@@ -47,7 +48,9 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		String project = "cluster-resources"
 		String namespaceName = "${namePrefix}" + config.features.argocd.namespace
 		String featureName = repoName
-		//DedicatedInstances
+		boolean isScmManager = featureName == 'scm-manager'
+
+		// DedicatedInstances
 		if (config.multiTenant.useDedicatedInstance) {
 			repoName = "${config.application.namePrefix}${repoName}"
 			namespaceName = "${config.multiTenant.centralArgocdNamespace}"
@@ -61,40 +64,69 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		String repoRoot = clusterResourcesRepo.getAbsoluteLocalRepoTmpDir()
 		Path.of(repoRoot, featurePath).toFile().mkdirs()
 
-		// 1) GOP-managed values (may be overwritten each run)
+		// 1) GOP-managed values
 		String gopValuesPath = "${featurePath}/${featureName}-gop-helm.yaml"
-		// relative to repo-root
 		def inlineValues = helmValuesPath.toFile().text
-		clusterResourcesRepo.writeFile(gopValuesPath, inlineValues)
 
-		// 2) User values (must NEVER be overwritten by GOP)
+		// 2) User values
 		String userValuesPath = "${featurePath}/${featureName}-user-values.yaml"
 		Path userValuesAbsPath = Path.of(repoRoot, userValuesPath)
-		if (!userValuesAbsPath.toFile().exists()) {
-			clusterResourcesRepo.writeFile(userValuesPath, "")
+
+		if (isScmManager) {
+			log.info(
+				"Deploying SCM-Manager as bootstrap component: using inline Helm values and omitting self-referencing values source. releaseName='{}', namespace='{}'",
+				releaseName,
+				namespace
+			)
+		} else {
+			// Normal tools keep values in cluster-resources and consume them via $values.
+			clusterResourcesRepo.writeFile(gopValuesPath, inlineValues)
+
+			// User values must NEVER be overwritten by GOP.
+			if (!userValuesAbsPath.toFile().exists()) {
+				clusterResourcesRepo.writeFile(userValuesPath, "")
+			}
 		}
 
-		// 1) helm source (external chart source)
-		def helmSource = [repoURL                         : repoURL,
-		                  (chooseKeyChartOrPath(repoType)): chartOrPath,
-		                  targetRevision                  : version,
-		                  helm                            : [releaseName            : releaseName,
-		                                                     valueFiles             : ["\$values/${gopValuesPath}".toString(),
-		                                                                               "\$values/${userValuesPath}".toString()],
-		                                                     ignoreMissingValueFiles: true]]
+		// 1) Helm source
+		def helmConfig = [
+			releaseName: releaseName
+		]
 
-		// 2) Git source for values
-		//   - repoURL: cluster-resources repo
-		//   - ref: values → used in valueFiles as $values
-		//   - path: apps/<feature> → additional manifests
-		def featureRepoUrl = "${clusterResourcesRepo.gitProvider.repoPrefix()}argocd/cluster-resources.git".toString()
-		def gitSource = [repoURL       : featureRepoUrl,
-		                 targetRevision: "main",
-		                 ref           : "values",
-		                 path          : featurePath,
-		                 directory     : [recurse: true]]
+		if (isScmManager) {
+			// SCM-Manager is a bootstrap component. It must not reference values from the SCM it deploys itself.
+			helmConfig.values = inlineValues
+		} else {
+			helmConfig.valueFiles = [
+				"\$values/${gopValuesPath}".toString(),
+				"\$values/${userValuesPath}".toString()
+			]
+			helmConfig.ignoreMissingValueFiles = true
+		}
 
-		def sources = [helmSource, gitSource]
+		def helmSource = [
+			repoURL                         : repoURL,
+			(chooseKeyChartOrPath(repoType)): chartOrPath,
+			targetRevision                  : version,
+			helm                            : helmConfig
+		]
+
+		// 2) Git source for values and additional manifests.
+		// SCM-Manager must not reference the SCM-Manager repo that it deploys itself.
+		def sources = [helmSource]
+
+		if (!isScmManager) {
+			def featureRepoUrl = "${clusterResourcesRepo.gitProvider.repoPrefix()}argocd/cluster-resources.git".toString()
+			def gitSource = [
+				repoURL       : featureRepoUrl,
+				targetRevision: "main",
+				ref           : "values",
+				path          : featurePath,
+				directory     : [recurse: true]
+			]
+
+			sources << gitSource
+		}
 
 		// Prepare ArgoCD Application YAML
 		def yamlMapper = YAMLMapper.builder()

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
@@ -40,6 +40,7 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		log.trace("Deploying helm chart via ArgoCD: ${releaseName}. Reading values from ${helmValuesPath}")
 
 		def namePrefix = config.application.namePrefix
+		def prefix = (namePrefix ?: '').strip()
 		def shallCreateNamespace = config.features['argocd']['operator'] ? "CreateNamespace=false" : "CreateNamespace=true"
 
 		GitRepo clusterResourcesRepo = gitRepoProvider.getRepo('argocd/cluster-resources', this.gitHandler.resourcesScm)
@@ -50,14 +51,32 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		String featureName = repoName
 		boolean isScmManager = featureName == 'scm-manager'
 
-		// DedicatedInstances
-		if (config.multiTenant.useDedicatedInstance) {
-			repoName = "${config.application.namePrefix}${repoName}"
-			namespaceName = "${config.multiTenant.centralArgocdNamespace}"
-			project = config.application.namePrefix.replaceFirst(/-$/, "")
+		/*
+		 * Important:
+		 * featureName remains unprefixed because it is used for paths like apps/scm-manager.
+		 * repoName becomes the ArgoCD Application metadata.name.
+		 *
+		 * This avoids ArgoCD tracking-id collisions:
+		 *
+		 * central:
+		 *   metadata.name: scm-manager
+		 *
+		 * tenant:
+		 *   metadata.name: tenant1-scm-manager
+		 *
+		 * Without this, both central and tenant resources can get tracking IDs starting with:
+		 *   scm-manager:/...
+		 */
+		if (prefix) {
+			repoName = "${prefix}${repoName}"
 		}
 
-		// Feature-Name -> Ordner under apps/<feature>
+		// DedicatedInstances
+		if (config.multiTenant.useDedicatedInstance) {
+			namespaceName = "${config.multiTenant.centralArgocdNamespace}"
+			project = prefix.replaceFirst(/-$/, "")
+		}
+
 		String featurePath = "apps/${featureName}"
 
 		// --- ensure folders exist before writing files ---
@@ -74,12 +93,13 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 
 		if (isScmManager) {
 			log.info(
-				"Deploying SCM-Manager as bootstrap component: using inline Helm values and omitting self-referencing values source. releaseName='{}', namespace='{}'",
+				"Deploying SCM-Manager as bootstrap component: applicationName='{}', releaseName='{}', namespace='{}', using inline Helm values and omitting self-referencing values source",
+				repoName,
 				releaseName,
 				namespace
 			)
 		} else {
-			// Normal tools keep values in cluster-resources and consume them via $values.
+			// Normal features keep values in cluster-resources and consume them via $values.
 			clusterResourcesRepo.writeFile(gopValuesPath, inlineValues)
 
 			// User values must NEVER be overwritten by GOP.
@@ -94,7 +114,10 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		]
 
 		if (isScmManager) {
-			// SCM-Manager is a bootstrap component. It must not reference values from the SCM it deploys itself.
+			/*
+			 * SCM-Manager is a bootstrap component.
+			 * It must not reference values from the SCM repository that it deploys itself.
+			 */
 			helmConfig.values = inlineValues
 		} else {
 			helmConfig.valueFiles = [
@@ -148,11 +171,21 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		                                                                                         // Create namespaces for helm charts (while not using the argocd-operater mode)
 		                                                                                         shallCreateNamespace]]]])
 
+		/*
+		 * Keep the file path release-based.
+		 *
+		 * For tenant SCM this becomes:
+		 *   apps/argocd/applications/tenant1-scmm.yaml
+		 *
+		 * The important value for ArgoCD tracking is metadata.name above:
+		 *   tenant1-scm-manager
+		 */
 		String appManifestPath = "apps/argocd/applications/${releaseName}.yaml"
 
 		clusterResourcesRepo.writeFile(appManifestPath, yamlResult)
 
-		log.debug("Deploying helm release ${releaseName} basing on chart ${chartOrPath} from ${repoURL}, version " + "${version}, into namespace ${namespace}. Using Argo CD application:\n${yamlResult}")
+		log.debug("Deploying helm release ${releaseName} basing on chart ${chartOrPath} from ${repoURL}, version " +
+			"${version}, into namespace ${namespace}. Using Argo CD application:\n${yamlResult}")
 
 		clusterResourcesRepo.commitAndPush("Added $repoName/$chartOrPath to ArgoCD")
 	}

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
@@ -49,7 +49,7 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		String project = "cluster-resources"
 		String namespaceName = "${namePrefix}" + config.features.argocd.namespace
 		String featureName = repoName
-		boolean isScmManager = featureName == 'scm-manager'
+		boolean bootstrapDeploymentRequired = requiresBootstrapDeployment(featureName)
 
 		/*
 		 * Important:
@@ -91,9 +91,11 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		String userValuesPath = "${featurePath}/${featureName}-user-values.yaml"
 		Path userValuesAbsPath = Path.of(repoRoot, userValuesPath)
 
-		if (isScmManager) {
+		if (bootstrapDeploymentRequired) {
 			log.info(
-				"Deploying SCM-Manager as bootstrap component: applicationName='{}', releaseName='{}', namespace='{}', using inline Helm values and omitting self-referencing values source",
+				"Using bootstrap deployment for feature '{}': applicationName='{}', releaseName='{}', namespace='{}'. " +
+					"Helm values will be embedded into the ArgoCD Application and no external values source will be referenced.",
+				featureName,
 				repoName,
 				releaseName,
 				namespace
@@ -113,11 +115,11 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 			releaseName: releaseName
 		]
 
-		if (isScmManager) {
-			/*
-			 * SCM-Manager is a bootstrap component.
-			 * It must not reference values from the SCM repository that it deploys itself.
-			 */
+		if (bootstrapDeploymentRequired) {
+			log.debug(
+				"Embedding Helm values for bootstrap feature '{}' directly into the ArgoCD Application to avoid a self-referencing values source.",
+				featureName
+			)
 			helmConfig.values = inlineValues
 		} else {
 			helmConfig.valueFiles = [
@@ -198,5 +200,9 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 				break
 			default: throw new RuntimeException("Repo type ${repoType} not implemented for ${this.class.simpleName}")
 		}
+	}
+
+	private boolean requiresBootstrapDeployment(String featureName) {
+		return featureName == 'scm-manager'
 	}
 }

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategy.groovy
@@ -57,15 +57,11 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		 * repoName becomes the ArgoCD Application metadata.name.
 		 *
 		 * This avoids ArgoCD tracking-id collisions:
-		 *
 		 * central:
 		 *   metadata.name: scm-manager
-		 *
 		 * tenant:
 		 *   metadata.name: tenant1-scm-manager
-		 *
-		 * Without this, both central and tenant resources can get tracking IDs starting with:
-		 *   scm-manager:/...
+		 * Without this, both central and tenant resources can get tracking IDs starting with: scm-manager:/...
 		 */
 		if (prefix) {
 			repoName = "${prefix}${repoName}"
@@ -140,7 +136,7 @@ class ArgoCdApplicationStrategy implements DeploymentStrategy {
 		// SCM-Manager must not reference the SCM-Manager repo that it deploys itself.
 		def sources = [helmSource]
 
-		if (!isScmManager) {
+		if (!bootstrapDeploymentRequired) {
 			def featureRepoUrl = "${clusterResourcesRepo.gitProvider.repoPrefix()}argocd/cluster-resources.git".toString()
 			def gitSource = [
 				repoURL       : featureRepoUrl,

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolver.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolver.groovy
@@ -112,11 +112,13 @@ class ScmManagerUrlResolver {
 	}
 
 	private String releaseName() {
-		if (isTenantScmManager()) {
-			return "${config.application.namePrefix}scmm"
+		def prefix = (config.application.namePrefix ?: '').strip()
+
+		if (prefix) {
+			return "${prefix}scmm"
 		}
 
-		return "scmm"
+		return 'scmm'
 	}
 
 	private String serviceName() {
@@ -144,14 +146,4 @@ class ScmManagerUrlResolver {
 		def s = u.toString()
 		s.endsWith('/') ? URI.create(s.substring(0, s.length() - 1)) : u
 	}
-
-	private boolean isTenantScmManager() {
-		def prefix = (config.application.namePrefix ?: "").strip()
-		def namespace = (scmm.namespace ?: "scm-manager").strip()
-
-		return config.multiTenant.useDedicatedInstance &&
-			prefix &&
-			namespace == "${prefix}scm-manager"
-	}
-
 }

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolver.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolver.groovy
@@ -74,6 +74,7 @@ class ScmManagerUrlResolver {
 		withSlash(clientBase()).resolve("api/v2/metrics/prometheus")
 	}
 
+
 	// ---------- Base resolution ----------
 
 	private URI clientBaseRaw() {
@@ -87,7 +88,7 @@ class ScmManagerUrlResolver {
 
 	private URI serviceDnsBase() {
 		def namespace = (scmm.namespace ?: "scm-manager").strip()
-		URI.create("http://scmm.${namespace}.svc.cluster.local")
+		URI.create("http://${serviceName()}.${namespace}.svc.cluster.local")
 	}
 
 	private URI externalBase() {
@@ -104,10 +105,22 @@ class ScmManagerUrlResolver {
 
 		def namespace = (scmm.namespace ?: "scm-manager").strip()
 
-		final def port = k8s.waitForNodePort(releaseName, namespace)
+		final def port = k8s.waitForNodePort(serviceName(), namespace)
 		final def host = net.findClusterBindAddress()
 		cachedClusterBind = new URI("http://${host}:${port}")
 		return cachedClusterBind
+	}
+
+	private String releaseName() {
+		if (isTenantScmManager()) {
+			return "${config.application.namePrefix}scmm"
+		}
+
+		return "scmm"
+	}
+
+	private String serviceName() {
+		return releaseName()
 	}
 
 	// ---------- Helpers ----------
@@ -131,4 +144,14 @@ class ScmManagerUrlResolver {
 		def s = u.toString()
 		s.endsWith('/') ? URI.create(s.substring(0, s.length() - 1)) : u
 	}
+
+	private boolean isTenantScmManager() {
+		def prefix = (config.application.namePrefix ?: "").strip()
+		def namespace = (scmm.namespace ?: "scm-manager").strip()
+
+		return config.multiTenant.useDedicatedInstance &&
+			prefix &&
+			namespace == "${prefix}scm-manager"
+	}
+
 }

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolver.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolver.groovy
@@ -111,18 +111,14 @@ class ScmManagerUrlResolver {
 		return cachedClusterBind
 	}
 
-	private String releaseName() {
+	private String serviceName() {
 		def prefix = (config.application.namePrefix ?: '').strip()
 
 		if (prefix) {
-			return "${prefix}scmm"
+			return "${prefix}${releaseName}"
 		}
 
-		return 'scmm'
-	}
-
-	private String serviceName() {
-		return releaseName()
+		return releaseName
 	}
 
 	// ---------- Helpers ----------

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -513,9 +513,14 @@ class K8sClient {
 	 * @throws RuntimeException if the ConfigMap or key is not found
 	 */
 	String getConfigMap(String mapName, String key) {
-		log.debug("Getting ConfigMap $mapName, key: $key")
+		String namespace = client.namespace ?: DEFAULT_NAMESPACE
 
-		ConfigMap configMap = client.configMaps().inNamespace(DEFAULT_NAMESPACE).withName(mapName).get()
+		log.debug("Getting ConfigMap ${namespace}/${mapName}, key: ${key}")
+
+		ConfigMap configMap = client.configMaps()
+			.inNamespace(namespace)
+			.withName(mapName)
+			.get()
 
 		if (!configMap) {
 			throw new RuntimeException("Could not fetch configmap $mapName")

--- a/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManager.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManager.groovy
@@ -48,7 +48,7 @@ class ScmManager extends Tool {
 		ScmManagerProvider scmManager = getTenantScmManager()
 
 		ScmManagerSetup setup = new ScmManagerSetup(scmManager,
-			deployer)
+			deployer, config)
 
 		setup.setupHelm()
 		setup.waitForScmmAvailable()

--- a/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
@@ -104,7 +104,7 @@ class ScmManagerSetup {
 		def prefix = (config.application.namePrefix ?: '').strip()
 
 		if (prefix) {
-			return "${prefix}scmm"
+			return "${prefix}-scmm"
 		}
 
 		return 'scmm'

--- a/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
@@ -104,7 +104,7 @@ class ScmManagerSetup {
 		def prefix = (config.application.namePrefix ?: '').strip()
 
 		if (prefix) {
-			return "${prefix}-scmm"
+			return "${prefix}scmm"
 		}
 
 		return 'scmm'

--- a/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
@@ -1,5 +1,6 @@
 package com.cloudogu.gitops.tools.core.scmmanager
 
+import com.cloudogu.gitops.config.Config
 import com.cloudogu.gitops.infrastructure.deployment.Deployer
 import com.cloudogu.gitops.infrastructure.deployment.DeploymentStrategy
 import com.cloudogu.gitops.infrastructure.git.providers.scmmanager.ScmManagerProvider
@@ -15,18 +16,20 @@ import groovy.util.logging.Slf4j
 @Slf4j
 class ScmManagerSetup {
 
-	private static final String HELM_VALUES_PATH = "argocd/cluster-resources/apps/scm-manager/templates/values.ftl.yaml"
-	private static final String SCMM_RELEASE_NAME = 'scmm'
+	private static final String HELM_VALUES_PATH = 'argocd/cluster-resources/apps/scm-manager/templates/values.ftl.yaml'
 
 	private final ScmManagerProvider scmManager
 	private final Deployer deployer
+	private final Config config
 
 	private Path tempValuesPath
 
 	ScmManagerSetup(ScmManagerProvider scmManager,
-                    Deployer deployer) {
+		Deployer deployer,
+		Config config) {
 		this.scmManager = scmManager
 		this.deployer = deployer
+		this.config = config
 	}
 
 	void setupHelm() {
@@ -38,7 +41,7 @@ class ScmManagerSetup {
 			helmConfig.chart as String,
 			helmConfig.version as String,
 			this.scmManager.scmmConfig.namespace,
-			SCMM_RELEASE_NAME,
+			scmmReleaseName(),
 			valuesPath,
 			DeploymentStrategy.RepoType.HELM)
 	}
@@ -52,7 +55,7 @@ class ScmManagerSetup {
 			helmConfig.chart as String,
 			helmConfig.version as String,
 			this.scmManager.scmmConfig.namespace,
-			SCMM_RELEASE_NAME,
+			scmmReleaseName(),
 			valuesPath,
 			DeploymentStrategy.RepoType.HELM)
 	}
@@ -63,7 +66,7 @@ class ScmManagerSetup {
 		                                    username   : this.scmManager.scmmConfig.credentials.username,
 		                                    password   : this.scmManager.scmmConfig.credentials.password,
 		                                    helm       : this.scmManager.scmmConfig.helm,
-		                                    releaseName: SCMM_RELEASE_NAME]
+		                                    releaseName: scmmReleaseName()]
 
 		Map templatedMap = TemplatingEngine.templateToMap(HELM_VALUES_PATH, templateVars)
 		Map values = this.scmManager.scmmConfig.helm.values as Map ?: [:]
@@ -72,6 +75,14 @@ class ScmManagerSetup {
 		tempValuesPath = new FileSystemUtils().writeTempFile(mergedMap)
 
 		return tempValuesPath
+	}
+
+	private String scmmReleaseName() {
+		if (config.multiTenant.useDedicatedInstance) {
+			return "${config.application.namePrefix}scmm"
+		}
+
+		return 'scmm'
 	}
 
 	void waitForScmmAvailable(int timeoutSeconds = 180, int intervalMillis = 5000, int startDelay = 0) {
@@ -88,7 +99,7 @@ class ScmManagerSetup {
 				def response = call.execute()
 
 				if (response.successful) {
-					log.info("SCM-Manager is available.")
+					log.info('SCM-Manager is available.')
 					return
 				}
 			} catch (Exception e) {
@@ -111,28 +122,28 @@ class ScmManagerSetup {
 
 		addDefaultUsers()
 
-		log.info("ScmManager Setup finished!")
+		log.info('ScmManager Setup finished!')
 	}
 
 	private void installScmmPlugins() {
 		if (this.scmManager.config.scm.scmManager.skipPlugins) {
-			log.debug("Skipping SCM plugin installation")
+			log.debug('Skipping SCM plugin installation')
 			return
 		}
 
-		List<String> pluginNames = ["scm-mail-plugin",
-		                            "scm-review-plugin",
-		                            "scm-code-editor-plugin",
-		                            "scm-editor-plugin",
-		                            "scm-landingpage-plugin",
-		                            "scm-el-plugin",
-		                            "scm-readme-plugin",
-		                            "scm-webhook-plugin",
-		                            "scm-ci-plugin",
-		                            "scm-metrics-prometheus-plugin"]
+		List<String> pluginNames = ['scm-mail-plugin',
+		                            'scm-review-plugin',
+		                            'scm-code-editor-plugin',
+		                            'scm-editor-plugin',
+		                            'scm-landingpage-plugin',
+		                            'scm-el-plugin',
+		                            'scm-readme-plugin',
+		                            'scm-webhook-plugin',
+		                            'scm-ci-plugin',
+		                            'scm-metrics-prometheus-plugin']
 
 		if (this.scmManager.config.jenkins.active) {
-			pluginNames.add("scm-jenkins-plugin")
+			pluginNames.add('scm-jenkins-plugin')
 		}
 
 		boolean restartForThisPlugin = false
@@ -145,7 +156,7 @@ class ScmManagerSetup {
 			ScmManagerApiClient.handleApiResponse(scmManager.getApiClient().pluginApi().install(pluginName, restartForThisPlugin))
 		}
 
-		log.debug("SCM-Manager plugin installation finished successfully!")
+		log.debug('SCM-Manager plugin installation finished successfully!')
 
 		if (restartForThisPlugin) {
 			waitForScmmAvailable(180, 2000, 100)
@@ -155,32 +166,32 @@ class ScmManagerSetup {
 	private void setSetupConfigs() {
 		def setupConfigs = [enableProxy             : false,
 		                    proxyPort               : 8080,
-		                    proxyServer             : "proxy.mydomain.com",
+		                    proxyServer             : 'proxy.mydomain.com',
 		                    proxyUser               : null,
 		                    proxyPassword           : null,
-		                    realmDescription        : "SONIA :: SCM Manager",
+		                    realmDescription        : 'SONIA :: SCM Manager',
 		                    disableGroupingGrid     : false,
-		                    dateFormat              : "YYYY-MM-DD HH:mm:ss",
+		                    dateFormat              : 'YYYY-MM-DD HH:mm:ss',
 		                    anonymousAccessEnabled  : false,
-		                    anonymousMode           : "OFF",
+		                    anonymousMode           : 'OFF',
 		                    baseUrl                 : this.scmManager.url,
 		                    forceBaseUrl            : false,
 		                    loginAttemptLimit       : -1,
 		                    proxyExcludes           : [],
 		                    skipFailedAuthenticators: false,
-		                    pluginUrl               : "https://plugin-center-api.scm-manager.org/api/v1/plugins/{version}?os={os}&arch={arch}",
+		                    pluginUrl               : 'https://plugin-center-api.scm-manager.org/api/v1/plugins/{version}?os={os}&arch={arch}',
 		                    loginAttemptLimitTimeout: 300,
 		                    enabledXsrfProtection   : true,
-		                    namespaceStrategy       : "CustomNamespaceStrategy",
-		                    loginInfoUrl            : "https://login-info.scm-manager.org/api/v1/login-info",
-		                    releaseFeedUrl          : "https://scm-manager.org/download/rss.xml",
-		                    mailDomainName          : "scm-manager.local",
+		                    namespaceStrategy       : 'CustomNamespaceStrategy',
+		                    loginInfoUrl            : 'https://login-info.scm-manager.org/api/v1/login-info',
+		                    releaseFeedUrl          : 'https://scm-manager.org/download/rss.xml',
+		                    mailDomainName          : 'scm-manager.local',
 		                    adminGroups             : [],
 		                    adminUsers              : []]
 
 		ScmManagerApiClient.handleApiResponse(scmManager.getApiClient().generalApi().setConfig(setupConfigs))
 
-		log.debug("Successfully added SCMM Setup Configs")
+		log.debug('Successfully added SCMM Setup Configs')
 	}
 
 	private void configureJenkinsPlugin() {
@@ -192,7 +203,7 @@ class ScmManagerSetup {
 
 		ScmManagerApiClient.handleApiResponse(this.scmManager.getApiClient().pluginApi().configureJenkinsPlugin(jenkinsPluginConfig))
 
-		log.debug("Successfully configured JenkinsPlugin in SCM-Manager.")
+		log.debug('Successfully configured JenkinsPlugin in SCM-Manager.')
 	}
 
 	private void addDefaultUsers() {
@@ -200,7 +211,7 @@ class ScmManagerSetup {
 
 		addUser(this.scmManager.scmmConfig.gitOpsUsername, this.scmManager.scmmConfig.password)
 		addUser(metricsUsername, this.scmManager.scmmConfig.password)
-		grantUserPermissions(metricsUsername, ["metrics:read"])
+		grantUserPermissions(metricsUsername, ['metrics:read'])
 	}
 
 	private void addUser(String username, String password, String email = 'changeme@test.local') {

--- a/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
@@ -103,11 +103,7 @@ class ScmManagerSetup {
 	private String scmmReleaseName() {
 		def prefix = (config.application.namePrefix ?: '').strip()
 
-		log.info("=====  useDedicatedInstance='{}', prefix='{}'",
-			config.multiTenant.useDedicatedInstance,
-			prefix
-		)
-		if (config.multiTenant.useDedicatedInstance && prefix) {
+		if (prefix) {
 			return "${prefix}scmm"
 		}
 

--- a/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/tools/core/scmmanager/ScmManagerSetup.groovy
@@ -35,13 +35,21 @@ class ScmManagerSetup {
 	void setupHelm() {
 		Path valuesPath = prepareHelmValues()
 		def helmConfig = this.scmManager.scmmConfig.helm
+		String releaseName = scmmReleaseName()
+
+		log.info("Deploying SCM-Manager via Helm with releaseName='{}', namespace='{}', namePrefix='{}', dedicatedInstance={}",
+			releaseName,
+			this.scmManager.scmmConfig.namespace,
+			config.application.namePrefix,
+			config.multiTenant.useDedicatedInstance
+		)
 
 		deployer.helmStrategy.deployFeature(helmConfig.repoURL as String,
 			'scm-manager',
 			helmConfig.chart as String,
 			helmConfig.version as String,
 			this.scmManager.scmmConfig.namespace,
-			scmmReleaseName(),
+			releaseName,
 			valuesPath,
 			DeploymentStrategy.RepoType.HELM)
 	}
@@ -49,24 +57,39 @@ class ScmManagerSetup {
 	void createArgocdApplication() {
 		Path valuesPath = tempValuesPath ?: prepareHelmValues()
 		def helmConfig = this.scmManager.scmmConfig.helm
+		String releaseName = scmmReleaseName()
+
+		log.info("Creating SCM-Manager ArgoCD application with releaseName='{}', namespace='{}', namePrefix='{}', dedicatedInstance={}",
+			releaseName,
+			this.scmManager.scmmConfig.namespace,
+			config.application.namePrefix,
+			config.multiTenant.useDedicatedInstance
+		)
 
 		deployer.argoCdStrategyProvider.get().deployFeature(helmConfig.repoURL as String,
 			'scm-manager',
 			helmConfig.chart as String,
 			helmConfig.version as String,
 			this.scmManager.scmmConfig.namespace,
-			scmmReleaseName(),
+			releaseName,
 			valuesPath,
 			DeploymentStrategy.RepoType.HELM)
 	}
 
 	private Path prepareHelmValues() {
+		String releaseName = scmmReleaseName()
+
+		log.info("Preparing SCM-Manager Helm values with releaseName='{}', namespace='{}'",
+			releaseName,
+			this.scmManager.scmmConfig.namespace
+		)
+
 		Map<String, Object> templateVars = [config     : this.scmManager.config,
 		                                    host       : this.scmManager.scmmConfig.ingress,
 		                                    username   : this.scmManager.scmmConfig.credentials.username,
 		                                    password   : this.scmManager.scmmConfig.credentials.password,
 		                                    helm       : this.scmManager.scmmConfig.helm,
-		                                    releaseName: scmmReleaseName()]
+		                                    releaseName: releaseName]
 
 		Map templatedMap = TemplatingEngine.templateToMap(HELM_VALUES_PATH, templateVars)
 		Map values = this.scmManager.scmmConfig.helm.values as Map ?: [:]
@@ -78,8 +101,14 @@ class ScmManagerSetup {
 	}
 
 	private String scmmReleaseName() {
-		if (config.multiTenant.useDedicatedInstance) {
-			return "${config.application.namePrefix}scmm"
+		def prefix = (config.application.namePrefix ?: '').strip()
+
+		log.info("=====  useDedicatedInstance='{}', prefix='{}'",
+			config.multiTenant.useDedicatedInstance,
+			prefix
+		)
+		if (config.multiTenant.useDedicatedInstance && prefix) {
+			return "${prefix}scmm"
 		}
 
 		return 'scmm'

--- a/src/test/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategyTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategyTest.groovy
@@ -96,6 +96,31 @@ spec:
 	}
 
 	@Test
+	void 'deploys scm-manager as bootstrap application without values source'() {
+		def strategy = createStrategy()
+		File valuesYaml = File.createTempFile('values', 'yaml')
+		valuesYaml.text = """
+fullnameOverride: tenant1-scmm
+service:
+  type: NodePort
+"""
+
+		strategy.deployFeature("repoURL", "scm-manager", "scm-manager", "3.11.6",
+			"tenant1-scm-manager", "tenant1-scmm", valuesYaml.toPath())
+
+		def argoCdApplicationYaml = new File("$localTempDir/apps/argocd/applications/tenant1-scmm.yaml")
+		def result = new YamlSlurper().parse(argoCdApplicationYaml)
+
+		def sources = result['spec']['sources'] as List
+
+		assertThat(sources).hasSize(1)
+		assertThat(sources[0]['repoURL']).isEqualTo('repoURL')
+		assertThat(sources[0]['chart']).isEqualTo('scm-manager')
+		assertThat(sources[0]['helm']['releaseName']).isEqualTo('tenant1-scmm')
+		assertThat(sources[0]['helm']['values'].toString()).contains('fullnameOverride: tenant1-scmm')
+	}
+
+	@Test
 	void 'deploys feature with argocdOperator false, setting CreateNamespace to true'() {
 		def strategy = createStrategy(false)
 		File valuesYaml = File.createTempFile('values', 'yaml')

--- a/src/test/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategyTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/infrastructure/deployment/ArgoCdApplicationStrategyTest.groovy
@@ -33,7 +33,7 @@ class ArgoCdApplicationStrategyTest {
 apiVersion: "argoproj.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: "repoName"
+  name: "foo-repoName"
   namespace: "foo-argocd"
 spec:
   destination:

--- a/src/test/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolverTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/infrastructure/git/providers/scmmanager/ScmManagerUrlResolverTest.groovy
@@ -44,7 +44,7 @@ class ScmManagerUrlResolverTest {
 	// ---------- Client base & API ----------
 	@Test
 	void "clientBase(): internal + outside K8s uses NodePort and appends 'scm' (no trailing slash) and only resolves NodePort once"() {
-		when(k8s.waitForNodePort(eq('scmm'), any())).thenReturn("30080")
+		when(k8s.waitForNodePort(eq('fv40-scmm'), any())).thenReturn("30080")
 		when(net.findClusterBindAddress()).thenReturn("10.0.0.1")
 
 		def r = resolverWith()
@@ -54,14 +54,14 @@ class ScmManagerUrlResolverTest {
 		assertEquals("http://10.0.0.1:30080/scm", base1.toString())
 		assertEquals(base1, base2)
 
-		verify(k8s, times(1)).waitForNodePort("scmm", "scm-manager")
+		verify(k8s, times(1)).waitForNodePort("fv40-scmm", "scm-manager")
 		verify(net, times(1)).findClusterBindAddress()
 		verifyNoMoreInteractions(k8s, net)
 	}
 
 	@Test
 	void "clientApiBase(): appends 'api' to the client base"() {
-		when(k8s.waitForNodePort("scmm", "scm-manager")).thenReturn("30080")
+		when(k8s.waitForNodePort("fv40-scmm", "scm-manager")).thenReturn("30080")
 		when(net.findClusterBindAddress()).thenReturn("10.0.0.1")
 
 		var urlResolver = resolverWith()
@@ -71,7 +71,7 @@ class ScmManagerUrlResolverTest {
 	// ---------- Repo base & URLs ----------
 	@Test
 	void "clientRepoUrl(): trims repoTarget and removes trailing slash"() {
-		when(k8s.waitForNodePort("scmm", "scm-manager")).thenReturn("30080")
+		when(k8s.waitForNodePort("fv40-scmm", "scm-manager")).thenReturn("30080")
 		when(net.findClusterBindAddress()).thenReturn("10.0.0.1")
 
 		var urlResolver = resolverWith()
@@ -83,19 +83,19 @@ class ScmManagerUrlResolverTest {
 	@Test
 	void "inClusterBase(): internal uses service DNS "() {
 		def r = resolverWith(namespace: "custom-ns", internal: true)
-		assertEquals("http://scmm.custom-ns.svc.cluster.local/scm", r.inClusterBase().toString())
+		assertEquals("http://fv40-scmm.custom-ns.svc.cluster.local/scm", r.inClusterBase().toString())
 	}
 
 	@Test
 	void "inClusterBase(): external uses external base + 'scm'"() {
-		var r = resolverWith(internal: false, url: "https://scmm.external")
-		assertEquals("https://scmm.external/scm", r.inClusterBase().toString())
+		var r = resolverWith(internal: false, url: "https://fv40-scmm.external")
+		assertEquals("https://fv40-scmm.external/scm", r.inClusterBase().toString())
 	}
 
 	@Test
 	void "inClusterRepoUrl(): builds full in-cluster repo URL without trailing slash"() {
 		var urlResolver = resolverWith()
-		assertEquals("http://scmm.scm-manager.svc.cluster.local/scm/repo/admin/admin",
+		assertEquals("http://fv40-scmm.scm-manager.svc.cluster.local/scm/repo/admin/admin",
 			urlResolver.inClusterRepoUrl("admin/admin"))
 	}
 
@@ -104,7 +104,7 @@ class ScmManagerUrlResolverTest {
 		// with non-empty namePrefix
 		config.application.namePrefix = 'fv40-'
 		def r1 = resolverWith()
-		assertEquals('http://scmm.scm-manager.svc.cluster.local/scm/repo/fv40-', r1.inClusterRepoPrefix())
+		assertEquals('http://fv40-scmm.scm-manager.svc.cluster.local/scm/repo/fv40-', r1.inClusterRepoPrefix())
 
 		// with empty/blank namePrefix
 		config.application.namePrefix = '   '
@@ -134,7 +134,7 @@ class ScmManagerUrlResolverTest {
 
 	@Test
 	void "nodePortBase(): falls back to default namespace 'scm-manager' when none provided"() {
-		when(k8s.waitForNodePort(eq('scmm'), eq('scm-manager'))).thenReturn("30080")
+		when(k8s.waitForNodePort(eq('fv40-scmm'), eq('scm-manager'))).thenReturn("30080")
 		when(net.findClusterBindAddress()).thenReturn('10.0.0.1')
 
 		def r = resolverWith(namespace: null)
@@ -144,14 +144,14 @@ class ScmManagerUrlResolverTest {
 	// ---------- helpers behavior ----------
 	@Test
 	void "ensureScm(): adds 'scm' if missing and keeps it if present"() {
-		def r1 = resolverWith(internal: false, url: 'https://scmm.localhost')
-		assertEquals('https://scmm.localhost/scm', r1.clientBase().toString())
+		def r1 = resolverWith(internal: false, url: 'https://fv40-scmm.localhost')
+		assertEquals('https://fv40-scmm.localhost/scm', r1.clientBase().toString())
 	}
 
 	// ---------- prometheus endpoint ----------
 	@Test
 	void "prometheusEndpoint(): resolves "() {
-		def r = resolverWith(internal: false, url: 'https://scmm.localhost')
-		assertEquals('https://scmm.localhost/scm/api/v2/metrics/prometheus', r.prometheusEndpoint().toString())
+		def r = resolverWith(internal: false, url: 'https://fv40-scmm.localhost')
+		assertEquals('https://fv40-scmm.localhost/scm/api/v2/metrics/prometheus', r.prometheusEndpoint().toString())
 	}
 }

--- a/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
@@ -756,14 +756,14 @@ class K8sClientTest {
 		def configMap = new ConfigMapBuilder()
 			.withNewMetadata()
 			.withName("my-config")
-			.withNamespace("default")
+			.withNamespace("test")
 			.endMetadata()
 			.withData(["key1": "value1", "key2": "value2"])
 			.build()
 
 		server.expect()
 			.get()
-			.withPath("/api/v1/namespaces/default/configmaps/my-config")
+			.withPath("/api/v1/namespaces/test/configmaps/my-config")
 			.andReturn(200, configMap)
 			.once()
 
@@ -780,14 +780,14 @@ class K8sClientTest {
 		def configMap = new ConfigMapBuilder()
 			.withNewMetadata()
 			.withName("my-config")
-			.withNamespace("default")
+			.withNamespace("test")
 			.endMetadata()
 			.withData(["key1": "value1"])
 			.build()
 
 		server.expect()
 			.get()
-			.withPath("/api/v1/namespaces/default/configmaps/my-config")
+			.withPath("/api/v1/namespaces/test/configmaps/my-config")
 			.andReturn(200, configMap)
 			.once()
 

--- a/src/test/groovy/com/cloudogu/gitops/tools/core/ScmManagerSetupTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/tools/core/ScmManagerSetupTest.groovy
@@ -56,7 +56,7 @@ class ScmManagerSetupTest {
 		when(scmManager.getScmmConfig()).thenReturn(config.scm.scmManager)
 		when(deployer.getHelmStrategy()).thenReturn(helmStrategy)
 
-		ScmManagerSetup scmManagerSetup = new ScmManagerSetup(scmManager, deployer)
+		ScmManagerSetup scmManagerSetup = new ScmManagerSetup(scmManager, deployer, config)
 
 		scmManagerSetup.setupHelm()
 
@@ -86,7 +86,7 @@ class ScmManagerSetupTest {
 
 		when(apiCall.execute()).thenReturn(Response.success(null))
 
-		ScmManagerSetup scmManagerSetup = new ScmManagerSetup(scmManager, deployer)
+		ScmManagerSetup scmManagerSetup = new ScmManagerSetup(scmManager, deployer, config)
 
 		invokePrivateInstallScmmPlugins(scmManagerSetup)
 

--- a/src/test/groovy/com/cloudogu/gitops/tools/core/ScmManagerSetupTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/tools/core/ScmManagerSetupTest.groovy
@@ -58,7 +58,10 @@ class ScmManagerSetupTest {
 
 		ScmManagerSetup scmManagerSetup = new ScmManagerSetup(scmManager, deployer, config)
 
+		//Usually ApplicationConfigurator modify the namePrefix and set it to "namePrefix-"
+		config.application.namePrefix =  "${config.application.namePrefix}-"
 		scmManagerSetup.setupHelm()
+
 
 		verify(helmStrategy).deployFeature(eq('https://packages.scm-manager.org/repository/helm-v2-releases/'),
 			eq('scm-manager'),

--- a/src/test/groovy/com/cloudogu/gitops/tools/core/ScmManagerSetupTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/tools/core/ScmManagerSetupTest.groovy
@@ -65,7 +65,7 @@ class ScmManagerSetupTest {
 			eq('scm-manager'),
 			eq('3.11.2'),
 			eq('scm-manager'),
-			eq('scmm'),
+			eq('test-scmm'),
 			any(),
 			eq(DeploymentStrategy.RepoType.HELM))
 	}


### PR DESCRIPTION
## Pull request overview

Adjusts SCM-Manager/Argo CD naming and bootstrap behavior to avoid Argo CD tracking collisions in prefixed/multi-tenant setups, and fixes Kubernetes ConfigMap retrieval to use the client’s active namespace.

**Changes:**
- Update `K8sClient.getConfigMap()` to read ConfigMaps from `client.namespace` (fallback to default).
- Prefix SCM-Manager Helm/ArgoCD release/service naming using `config.application.namePrefix`, and update related URL resolution + tests.
- Change Argo CD Application generation to (a) prefix `metadata.name` to avoid tracking collisions and (b) special-case SCM-Manager as a bootstrap app (embed Helm values; no self-referencing values git source); also set Argo CD resource tracking method to `annotation`.

