### PR TITLE
This PR updates K8sClient to resolve custom resources via the Kubernetes Discovery API 

### DIFF
--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -646,7 +646,7 @@ class K8sClient {
 			HasMetadata existingResource = resourceClient.get() as HasMetadata
 
 			if (!existingResource) {
-				throw new KubernetesApiResourceNotFoundException("$resource/$name")
+throw new RuntimeException("Resource $resource/$name not found")
 			}
 
 			def existingLabels = existingResource.metadata?.labels ?: [:]

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -646,7 +646,7 @@ class K8sClient {
 			HasMetadata existingResource = resourceClient.get() as HasMetadata
 
 			if (!existingResource) {
-				throw new RuntimeException("Resource $resource/$name not found")
+				throw new KubernetesApiResourceNotFoundException("$resource/$name")
 			}
 
 			def existingLabels = existingResource.metadata?.labels ?: [:]
@@ -1147,6 +1147,7 @@ class K8sClient {
 
 
 			default:
+				log.debug("Seraching CRD resourceType=${resourceType} with name=${name}, ns=${ns} ++++++++++++++")
 				return getCustomResourceClient(resourceType, name, ns)
 		}
 	}
@@ -1155,43 +1156,76 @@ class K8sClient {
 	private getCustomResourceClient(String resourceType, String name, String namespace) {
 		String normalized = resourceType.toLowerCase()
 
-		def crd = client.apiextensions()
-			.v1()
-			.customResourceDefinitions()
-			.list()
-			.items
-			.find { crd ->
-				crd.spec.names.kind?.equalsIgnoreCase(resourceType) || crd.spec.names.plural?.equalsIgnoreCase(normalized) ||
-					crd.spec.names.singular?.equalsIgnoreCase(normalized) ||
-					crd.spec.names.shortNames?.any { it.equalsIgnoreCase(normalized) }
-			}
+		// Resolve via the Kubernetes Discovery API (/apis, /apis/<group>/<version>) instead
+		// of listing CustomResourceDefinitions. Avoids the cluster-wide
+		// "list customresourcedefinitions.apiextensions.k8s.io" permission, which is not
+		// always available (e.g. namespace-scoped service accounts).
+		Map match = findApiResourceViaDiscovery(normalized, resourceType)
 
-		if (!crd) {
-			throw new RuntimeException("No CRD found for custom resource type '${resourceType}'")
+		if (!match) {
+			throw new KubernetesApiResourceNotFoundException(resourceType)
 		}
 
-		def version = crd.spec.versions.find { it.storage && it.served }?.name ?: crd.spec.versions.find { it.storage }?.name ?: crd.spec.versions.find { it.served }?.name
-		log.debug("Using CRD ${crd.metadata.name} with version ${version}, kind=${crd.spec.names.kind}, plural=${crd.spec.names.plural}")
-
-		if (!version) {
-			throw new RuntimeException("No served version found for CRD '${crd.metadata.name}'")
-		}
+		log.debug("Resolved '${resourceType}' via discovery to ${match.group}/${match.version} kind=${match.kind} plural=${match.plural}")
 
 		ResourceDefinitionContext context = new ResourceDefinitionContext.Builder()
-			.withGroup(crd.spec.group)
-			.withVersion(version)
-			.withKind(crd.spec.names.kind)
-			.withPlural(crd.spec.names.plural)
-			.withNamespaced(crd.spec.scope == "Namespaced")
+			.withGroup(match.group as String)
+			.withVersion(match.version as String)
+			.withKind(match.kind as String)
+			.withPlural(match.plural as String)
+			.withNamespaced(match.namespaced as boolean)
 			.build()
 
 		def resourceClient = client.genericKubernetesResources(context)
+		return match.namespaced ? resourceClient.inNamespace(namespace).withName(name) : resourceClient.withName(name)
+	}
 
-		if (crd.spec.scope == "Namespaced") {
-			return resourceClient.inNamespace(namespace).withName(name)
+	@CompileStatic(TypeCheckingMode.SKIP)
+	private Map findApiResourceViaDiscovery(String normalized, String original) {
+		def apiGroups
+		try {
+			apiGroups = client.getApiGroups()?.groups ?: []
+		} catch (Exception e) {
+			log.warn("Failed to discover API groups: ${e.message}")
+			return null
 		}
 
-		return resourceClient.withName(name)
+		for (def group : apiGroups) {
+			List<String> versions = []
+			if (group.preferredVersion?.version) {
+				versions << (group.preferredVersion.version as String)
+			}
+			group.versions?.each { v ->
+				if (v.version && !(v.version in versions)) {
+					versions << (v.version as String)
+				}
+			}
+
+			for (String version : versions) {
+				def resources
+				try {
+					resources = client.getApiResources("${group.name}/${version}")?.resources ?: []
+				} catch (Exception e) {
+					log.trace("Failed to fetch ${group.name}/${version}: ${e.message}")
+					continue
+				}
+
+				def resolvedResult = resources.find { res ->
+					!res.name?.contains('/') && (res.kind?.equalsIgnoreCase(original) || res.name?.equalsIgnoreCase(normalized) ||
+						res.singularName?.equalsIgnoreCase(normalized) ||
+						res.shortNames?.any { it.equalsIgnoreCase(normalized) })
+				}
+
+				if (resolvedResult) {
+					return [group     : group.name as String,
+					        version   : version,
+					        kind      : resolvedResult.kind as String,
+					        plural    : resolvedResult.name as String,
+					        namespaced: resolvedResult.namespaced as boolean]
+				}
+			}
+		}
+		return null
 	}
 
 	/**
@@ -1346,5 +1380,11 @@ class K8sClient {
 	static class CustomResource {
 		String namespace
 		String name
+	}
+
+	static class KubernetesApiResourceNotFoundException extends RuntimeException {
+		KubernetesApiResourceNotFoundException(String resourceType) {
+			super("No API resource found for custom resource type '${resourceType}'")
+		}
 	}
 }

--- a/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
+++ b/src/main/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClient.groovy
@@ -1147,7 +1147,7 @@ throw new RuntimeException("Resource $resource/$name not found")
 
 
 			default:
-				log.debug("Seraching CRD resourceType=${resourceType} with name=${name}, ns=${ns} ++++++++++++++")
+log.debug("Searching API resource via discovery for resourceType=${resourceType}, name=${name}, ns=${ns}")
 				return getCustomResourceClient(resourceType, name, ns)
 		}
 	}

--- a/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/infrastructure/kubernetes/api/K8sClientTest.groovy
@@ -1383,4 +1383,87 @@ metadata:
 		assertThat(cr.namespace).isEqualTo("test-ns")
 		assertThat(cr.name).isEqualTo("test-name")
 	}
+
+	@Test
+	void 'waitForResourcePhase resolves ArgoCD custom resource via discovery'() {
+		// Given
+		server.expect()
+			.get()
+			.withPath("/apis")
+			.andReturn(200, [groups: [[name            : "argoproj.io",
+			                           preferredVersion: [version: "v1beta1"],
+			                           versions        : [[version: "v1beta1"]]]]])
+			.once()
+
+		server.expect()
+			.get()
+			.withPath("/apis/argoproj.io/v1beta1")
+			.andReturn(200, [resources: [[name        : "argocds",
+			                              singularName: "argocd",
+			                              namespaced  : true,
+			                              kind        : "ArgoCD",
+			                              shortNames  : []]]])
+			.once()
+
+		GenericKubernetesResource argocdResource = new GenericKubernetesResourceBuilder()
+			.withApiVersion("argoproj.io/v1beta1")
+			.withKind("ArgoCD")
+			.withNewMetadata()
+			.withName("argocd")
+			.withNamespace("argocd")
+			.endMetadata()
+			.addToAdditionalProperties("status", [phase: "Available"])
+			.build()
+
+		boolean argocdResourceWasRequested = false
+
+		server.expect()
+			.get()
+			.withPath("/apis/argoproj.io/v1beta1/namespaces/argocd/argocds/argocd")
+			.andReply(200, { request ->
+				argocdResourceWasRequested = true
+				return argocdResource
+			})
+			.once()
+
+		// When
+		k8sApiClient.waitForResourcePhase("argocd", "argocd", "argocd", "Available", 5, 1)
+
+		// Then
+		assertThat(argocdResourceWasRequested).isTrue()
+		assertThat(argocdResource.apiVersion).isEqualTo("argoproj.io/v1beta1")
+		assertThat(argocdResource.kind).isEqualTo("ArgoCD")
+		assertThat(argocdResource.metadata.name).isEqualTo("argocd")
+		assertThat(argocdResource.metadata.namespace).isEqualTo("argocd")
+	}
+
+	@Test
+	void 'throws KubernetesApiResourceNotFoundException when custom resource cannot be resolved'() {
+		// Given
+		server.expect()
+			.get()
+			.withPath("/apis")
+			.andReturn(200, [groups: [[name            : "argoproj.io",
+			                           preferredVersion: [version: "v1beta1"],
+			                           versions        : [[version: "v1beta1"]]]]])
+			.once()
+
+		server.expect()
+			.get()
+			.withPath("/apis/argoproj.io/v1beta1")
+			.andReturn(200, [resources: [[name        : "argocds",
+			                              singularName: "argocd",
+			                              namespaced  : true,
+			                              kind        : "ArgoCD",
+			                              shortNames  : []]]])
+			.once()
+
+		// When/Then
+		def exception = shouldFail(K8sClient.KubernetesApiResourceNotFoundException) {
+			k8sApiClient.getAnnotation("does-not-exist", "some-resource", "some-annotation", "argocd")
+		}
+
+		assertThat(exception.message)
+			.isEqualTo("No API resource found for custom resource type 'does-not-exist'")
+	}
 }


### PR DESCRIPTION
## Pull request overview

This PR updates `K8sClient` to resolve custom resources via the Kubernetes Discovery API (`/apis`, `/apis/<group>/<version>`) instead of listing `CustomResourceDefinitions`, reducing the need for cluster-wide CRD list permissions.

**Changes:**
- Replace CRD-list-based custom resource resolution with Discovery API-based resolution and build `ResourceDefinitionContext` from discovered group/version/resource metadata.
- Introduce `KubernetesApiResourceNotFoundException` for cases where an API resource cannot be resolved via discovery.
- Add tests to verify discovery-based resolution for ArgoCD CRs and the exception behavior when resolution fails.
