### PR TITLE
fix k8s-debug file permissions in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,6 +154,8 @@ pipeline {
                                           kubectl logs -n "\${namespace}" "\${pod}" --all-containers=true --previous --tail=200 --prefix=true >> '${dumpDir}/container-logs.txt' 2>&1
                                           echo >> '${dumpDir}/container-logs.txt'
                                         done
+
+                                        chown -R ${env.BUILD_USER}:${env.BUILD_GROUP} '${dumpDir}'
                                     """, returnStatus: true)
                                 }
 


### PR DESCRIPTION
## Summary

  This PR fixes a follow-up pipeline issue after failed integration tests.

  When an integration test failed, the pipeline collected Kubernetes debug information under `target/
  k8s-debug/<profile>`. These files were created from inside a Docker container and could remain owned
  by a user/group that the next Maven build could not clean up. As a result, a subsequent pipeline run
  could fail already during `mvn clean` with errors like:

  ```text
  Failed to delete target/k8s-debug/full/cluster-info.txt
``` 

## Changes

  - Adjust ownership of collected Kubernetes debug artifacts after writing them
  - Ensure target/k8s-debug/<profile> can be deleted by later pipeline runs
  - Keep the existing debug artifact collection unchanged