### PR TITLE
Fix/remove petclinic test from prefix

### DIFF
--- a/src/test/groovy/com/cloudogu/gitops/integration/TestK8sHelper.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/integration/TestK8sHelper.groovy
@@ -32,7 +32,9 @@ class TestK8sHelper {
 	static final Set<String> FATAL_CONTAINER_WAITING_REASONS = ['CrashLoopBackOff',
 	                                                            'CreateContainerConfigError',
 	                                                            'CreateContainerError',
+	                                                            'ErrImagePull',
 	                                                            'ImageInspectError',
+	                                                            'ImagePullBackOff',
 	                                                            'InvalidImageName',
 	                                                            'RunContainerError'] as Set
 

--- a/src/test/groovy/com/cloudogu/gitops/integration/profiles/PrefixProfileTestIT.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/integration/profiles/PrefixProfileTestIT.groovy
@@ -36,7 +36,7 @@ class PrefixProfileTestIT extends ProfileTestSetup {
 		log.info "###### Integration test for Prefix ######"
 
 		try {
-			TestK8sHelper.waitForAllPodsRunningInNamespace(exampleStagingNs, "", 40, TimeUnit.MINUTES)
+			TestK8sHelper.waitForAllPodsRunningInNamespace(certManagerNs, "", 40, TimeUnit.MINUTES)
 		} catch (ConditionTimeoutException timeoutEx) {
 			TestK8sHelper.dumpNamespacesAndPods()
 			fail('Cluster not ready, sth false.', timeoutEx)


### PR DESCRIPTION
## Description
This PR adjusts the full-prefix integration test so it no longer blocks on the PetClinic staging namespace during profile readiness checks.

The prefix profile test now waits for the prefixed cert-manager namespace instead of my-prefix-example-apps-staging. This keeps the test focused on validating the prefixed platform setup and avoids coupling it to PetClinic application image availability or Jenkins build timing.

It also treats ErrImagePull and ImagePullBackOff as fatal pod states in the Kubernetes test helper, so image pull problems fail fast with useful diagnostics instead of hanging until the full Awaitility timeout expires.

## Changes

- Change PrefixProfileTestIT readiness wait from my-prefix-example- apps-staging to my-prefix-cert-manager

- Add ErrImagePull and ImagePullBackOff to fatal container waiting reasons