### PR TITLE
remove .localhost from petclinic example

### DIFF
--- a/scripts/dev/prepare_two_registries.sh
+++ b/scripts/dev/prepare_two_registries.sh
@@ -45,7 +45,7 @@ content:
     - \${config.application.namePrefix}example-apps-staging
   variables:
     petclinic:
-      baseDomain: "petclinic.localhost"
+      baseDomain: "petclinic"
     images:
       kubectl: "localhost:30000/proxy/kubectl:latest"
       helm: "localhost:30000/proxy/helm:latest"

--- a/src/main/resources/application-content-examples.yaml
+++ b/src/main/resources/application-content-examples.yaml
@@ -47,7 +47,7 @@ content:
     - ${config.application.namePrefix}example-apps-staging
   variables:
     petclinic:
-      baseDomain: "petclinic.localhost"
+      baseDomain: "petclinic"
     images:
       kubectl: "alpine/kubectl:latest"
       helm: "ghcr.io/cloudogu/helm:latest"

--- a/src/main/resources/application-full-prefix.yaml
+++ b/src/main/resources/application-full-prefix.yaml
@@ -55,7 +55,7 @@ content:
     - ${config.application.namePrefix}example-apps-staging
   variables:
     petclinic:
-      baseDomain: "petclinic.localhost"
+      baseDomain: "petclinic"
     images:
       kubectl: "alpine/kubectl:latest"
       helm: "ghcr.io/cloudogu/helm:latest"

--- a/src/main/resources/application-full.yaml
+++ b/src/main/resources/application-full.yaml
@@ -54,7 +54,7 @@ content:
     - ${config.application.namePrefix}example-apps-staging
   variables:
     petclinic:
-      baseDomain: "petclinic.localhost"
+      baseDomain: "petclinic"
     images:
       kubectl: "alpine/kubectl:latest"
       helm: "ghcr.io/cloudogu/helm:latest"

--- a/src/main/resources/application-operator-content-examples.yaml
+++ b/src/main/resources/application-operator-content-examples.yaml
@@ -47,7 +47,7 @@ content:
     - ${config.application.namePrefix}example-apps-staging
   variables:
     petclinic:
-      baseDomain: "petclinic.localhost"
+      baseDomain: "petclinic"
     images:
       kubectl: "alpine/kubectl:latest"
       helm: "ghcr.io/cloudogu/helm:latest"

--- a/src/main/resources/application-operator-full.yaml
+++ b/src/main/resources/application-operator-full.yaml
@@ -56,7 +56,7 @@ content:
     - ${config.application.namePrefix}example-apps-staging
   variables:
     petclinic:
-      baseDomain: "petclinic.localhost"
+      baseDomain: "petclinic"
     images:
       kubectl: "alpine/kubectl:latest"
       helm: "ghcr.io/cloudogu/helm:latest"

--- a/src/main/resources/application-single-namespace-example.yaml
+++ b/src/main/resources/application-single-namespace-example.yaml
@@ -48,7 +48,7 @@ content:
 
   variables:
     petclinic:
-      baseDomain: "petclinic.localhost"
+      baseDomain: "petclinic"
     images:
       kubectl: "alpine/kubectl:latest"
       helm: "ghcr.io/cloudogu/helm:latest"


### PR DESCRIPTION
## Pull request overview

This PR updates the shipped example configurations to remove the `.localhost` suffix from the Petclinic `baseDomain`, affecting how Petclinic ingress hostnames are generated in the provided example profiles and a dev helper script.

**Changes:**
- Changed `content.variables.petclinic.baseDomain` from `petclinic.localhost` to `petclinic` in multiple example config YAMLs.
- Updated the generated local config snippet in `scripts/dev/prepare_two_registries.sh` to use the same new Petclinic `baseDomain`.
