### PR TITLE
Treat succeeded pods as non-fatal in integration tests

### DIFF
--- a/src/test/groovy/com/cloudogu/gitops/integration/TestK8sHelper.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/integration/TestK8sHelper.groovy
@@ -301,12 +301,12 @@ class TestK8sHelper {
 	}
 
 	private static boolean isPodRunning(Pod pod) {
-		return (pod.status?.phase == RUNNING || pod.status?.phase == COMPLETED) && !hasFatalContainerState(pod)
+		return (pod.status?.phase == RUNNING || pod.status?.phase == SUCCEEDED || pod.status?.phase == COMPLETED) && !hasFatalContainerState(pod)
 	}
 
 	private static boolean isPodFatal(Pod pod) {
 		String phase = pod.status?.phase
-		return phase == FAILED || phase == SUCCEEDED || hasFatalContainerState(pod)
+		return phase == FAILED || hasFatalContainerState(pod)
 	}
 
 	private static boolean hasFatalContainerState(Pod pod) {


### PR DESCRIPTION
## Description

This PR updates the Kubernetes integration test helper so pods in Succeeded phase are handled as healthy terminal pods instead of fatal failures.

## Changes

- Accepts Succeeded pods in isPodRunning when their container states are healthy.
- Removes Succeeded from fatal pod phase handling.
- Keeps fatal detection for Failed pods and unrecoverable container states.