### PR TITLE
establishing compatibility with Apple architecture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,18 @@
                     <groupId>org.apache.groovy</groupId>
                     <artifactId>groovy-test</artifactId>
                 </exclusion>
+                <!-- jline 2.14.6 (via groovy-groovysh) bundles Jansi 1.x with an x86-only macOS
+                native lib. On Apple Silicon (arm64) picocli's reflective AnsiConsole check then
+                dies with UnsatisfiedLinkError (picocli only catches Exception, not Error).
+                groovysh/jline are unused in tests, so exclude them. -->
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-groovysh</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/scripts/dev/mirror_images_to_registry.sh
+++ b/scripts/dev/mirror_images_to_registry.sh
@@ -29,7 +29,7 @@ CERT_MANAGER_CA_INJECTOR="docker://quay.io/jetstack/cert-manager-cainjector:v1.1
 CERT_MANAGER_WEBHOOK="docker://quay.io/jetstack/cert-manager-webhook:v1.16.1"
 
 KUBECTL_IMAGE="docker://alpine/kubectl:latest"
-TEMURIN_IMAGE="docker://eclipse-temurin:17-jre-alpine"
+TEMURIN_IMAGE="docker://eclipse-temurin:17-jre"
 HELM_IMAGE="docker://ghcr.io/cloudogu/helm:latest"
 MVN_IMAGE="docker://maven:3-eclipse-temurin-17-alpine"
 YAMLLINT_IMAGE="docker://cytopia/yamllint:latest"
@@ -98,7 +98,7 @@ if [[ -n $HARBOR ]]; then
 
     # Needed for the builds to work with proxy-registry
     skopeo copy $KUBECTL_IMAGE --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/proxy/alpine/kubectl:latest
-    skopeo copy $TEMURIN_IMAGE --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/proxy/eclipse-temurin:17-jre-alpine
+    skopeo copy $TEMURIN_IMAGE --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/proxy/eclipse-temurin:17-jre
     skopeo copy $HELM_IMAGE  --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/proxy/helm:latest
     skopeo copy $MVN_IMAGE  --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/proxy/maven:3-eclipse-temurin-17-alpine
     skopeo copy $YAMLLINT_IMAGE  --dest-creds Proxy:Proxy12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/proxy/yamllint:latest
@@ -129,7 +129,7 @@ skopeo copy $CERT_MANAGER_WEBHOOK --dest-creds admin:Harbor12345 --dest-tls-veri
 
 # Needed for the builds to work with proxy-registry
 skopeo copy $KUBECTL_IMAGE --dest-creds admin:Harbor12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/library/alpine/kubectl:latest
-skopeo copy $TEMURIN_IMAGE --dest-creds admin:Harbor12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/library/eclipse-temurin:17-jre-alpine
+skopeo copy $TEMURIN_IMAGE --dest-creds admin:Harbor12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/library/eclipse-temurin:17-jre
 skopeo copy $HELM_IMAGE  --dest-creds admin:Harbor12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/library/helm:latest
 skopeo copy $MVN_IMAGE  --dest-creds admin:Harbor12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/library/maven:3-eclipse-temurin-17-alpine
 skopeo copy $YAMLLINT_IMAGE  --dest-creds admin:Harbor12345 --dest-tls-verify=false  $REGISTRY_DOCKER_BASE_URL/library/yamllint:latest

--- a/scripts/dev/prepare_two_registries.sh
+++ b/scripts/dev/prepare_two_registries.sh
@@ -52,7 +52,7 @@ content:
       kubeval: "localhost:30000/proxy/helm:latest"
       helmKubeval: "localhost:30000/proxy/helm:latest"
       yamllint: "localhost:30000/proxy/cytopia/yamllint:latest"
-      petclinic: "localhost:30000/proxy/eclipse-temurin:17-jre-alpine"
+      petclinic: "localhost:30000/proxy/eclipse-temurin:17-jre"
       maven: "localhost:30000/proxy/maven:3-eclipse-temurin-17-alpine"
 registry:
   internalPort: 30000

--- a/src/main/resources/application-content-examples.yaml
+++ b/src/main/resources/application-content-examples.yaml
@@ -54,5 +54,5 @@ content:
       kubeval: "ghcr.io/cloudogu/helm:latest"
       helmKubeval: "ghcr.io/cloudogu/helm:latest"
       yamllint: "cytopia/yamllint:1.25-0.7"
-      petclinic: "eclipse-temurin:17-jre-alpine"
+      petclinic: "eclipse-temurin:17-jre"
       maven: ""

--- a/src/main/resources/application-full-prefix.yaml
+++ b/src/main/resources/application-full-prefix.yaml
@@ -62,5 +62,5 @@ content:
       kubeval: "ghcr.io/cloudogu/helm:latest"
       helmKubeval: "ghcr.io/cloudogu/helm:latest"
       yamllint: "cytopia/yamllint:1.25-0.7"
-      petclinic: "eclipse-temurin:17-jre-alpine"
+      petclinic: "eclipse-temurin:17-jre"
       maven: ""

--- a/src/main/resources/application-full.yaml
+++ b/src/main/resources/application-full.yaml
@@ -61,5 +61,5 @@ content:
       kubeval: "ghcr.io/cloudogu/helm:latest"
       helmKubeval: "ghcr.io/cloudogu/helm:latest"
       yamllint: "cytopia/yamllint:1.25-0.7"
-      petclinic: "eclipse-temurin:17-jre-alpine"
+      petclinic: "eclipse-temurin:17-jre"
       maven: ""

--- a/src/main/resources/application-keycloak.yaml
+++ b/src/main/resources/application-keycloak.yaml
@@ -92,5 +92,5 @@ content:
       kubeval: "ghcr.io/cloudogu/helm:latest"
       helmKubeval: "ghcr.io/cloudogu/helm:latest"
       yamllint: "cytopia/yamllint:1.25-0.7"
-      petclinic: "eclipse-temurin:17-jre-alpine"
+      petclinic: "eclipse-temurin:17-jre"
       maven: ""

--- a/src/main/resources/application-operator-content-examples.yaml
+++ b/src/main/resources/application-operator-content-examples.yaml
@@ -54,5 +54,5 @@ content:
       kubeval: "ghcr.io/cloudogu/helm:latest"
       helmKubeval: "ghcr.io/cloudogu/helm:latest"
       yamllint: "cytopia/yamllint:1.25-0.7"
-      petclinic: "eclipse-temurin:17-jre-alpine"
+      petclinic: "eclipse-temurin:17-jre"
       maven: ""

--- a/src/main/resources/application-operator-full.yaml
+++ b/src/main/resources/application-operator-full.yaml
@@ -63,5 +63,5 @@ content:
       kubeval: "ghcr.io/cloudogu/helm:latest"
       helmKubeval: "ghcr.io/cloudogu/helm:latest"
       yamllint: "cytopia/yamllint:1.25-0.7"
-      petclinic: "eclipse-temurin:17-jre-alpine"
+      petclinic: "eclipse-temurin:17-jre"
       maven: ""

--- a/src/test/groovy/com/cloudogu/gitops/tools/core/argocd/ArgoCDTest.groovy
+++ b/src/test/groovy/com/cloudogu/gitops/tools/core/argocd/ArgoCDTest.groovy
@@ -97,7 +97,7 @@ class ArgoCDTest {
                                                kubeval    : 'ghcr.io/cloudogu/helm:4.2.1-1',
                                                helmKubeval: 'ghcr.io/cloudogu/helm:4.2.1-1',
                                                yamllint   : 'cytopia/yamllint:1.25-0.7',
-                                               petclinic  : 'eclipse-temurin:17-jre-alpine',
+                                               petclinic  : 'eclipse-temurin:17-jre',
                                                maven      : '']]],
             features: [argocd    : [operator                 : false,
                                     active                   : true,
@@ -1679,10 +1679,10 @@ class ArgoCDTest {
                       ArgoCDTestContext testContext) {
             super(k8sClient,
                     new HelmClient(helmCommands),
-					new FileSystemUtils(),
-					testContext.gitHandler,
-					new DeploymentModeFactory(),
-					new ArgoCDToolConfigMapper(cfg))
+                    new FileSystemUtils(),
+                    testContext.gitHandler,
+                    new DeploymentModeFactory(),
+                    new ArgoCDToolConfigMapper(cfg))
 
             this.cfg = cfg
             this.tenantProvider = tenantProvider


### PR DESCRIPTION
This PR updates the default “petclinic” base image and test/build dependencies to improve compatibility when running the project on Apple Silicon (arm64), avoiding Alpine/legacy native library issues.

Changes:

Switch petclinic image references from eclipse-temurin:17-jre-alpine to eclipse-temurin:17-jre across example application YAMLs, tests, and dev registry scripts.
Exclude groovy-groovysh and jline from the test-scoped groovy-all dependency to prevent Apple Silicon failures caused by an incompatible bundled native Jansi library.
Minor formatting/indentation cleanup in ArgoCDTest.groovy.