### PR TITLE
Add secret-based full profile with integration coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     parameters {
         booleanParam(defaultValue: false, name: 'forcePushImage', description: 'Pushes the image with the current git commit as tag, even when it is on a branch')
         booleanParam(defaultValue: false, name: 'noCache', description: 'Builds the docker image without cache')
-        choice(name: 'chooseProfile', choices: ['full', 'minimal', 'all-profiles', 'full-prefix', 'content-examples', 'operator-full','operator-mandants'], description: 'Starts GOP with given profile only and execute tests which belongs to profile.')
+        choice(name: 'chooseProfile', choices: ['full', 'full-secrets', 'minimal', 'all-profiles', 'full-prefix', 'content-examples', 'operator-full','operator-mandants'], description: 'Starts GOP with given profile only and execute tests which belongs to profile.')
     }
 
     environment {
@@ -115,7 +115,7 @@ pipeline {
                             def profiles = []
 
                             if (isTriggeredByTimer() || params.chooseProfile == 'all-profiles' || env.BRANCH_NAME == 'main') {
-                                profiles = ['minimal', 'full', 'full-prefix', 'content-examples', 'operator-full','operator-mandants']
+                                profiles = ['minimal', 'full', 'full-secrets', 'full-prefix', 'content-examples', 'operator-full','operator-mandants']
                             } else if (env.BRANCH_NAME == 'develop') {
                                 profiles = ['full-prefix', 'operator-mandants', 'operator-full']
                             } else {
@@ -174,6 +174,16 @@ pipeline {
 
                             profiles.each { profile ->
                                 withK3dCluster(profile) {
+
+                                    if (profile == 'full-secrets') {
+                                        docker.image("${env.GOLANG_IMAGE}").inside(env.INTEGRATION_TEST_DOCKER_ARGS) {
+                                            sh '''
+                                                apk add --no-cache kubectl
+                                                kubectl create namespace gop-job --dry-run=client -o yaml | kubectl apply -f -
+                                                kubectl apply -f ./scripts/dev/gop-secrets.yaml
+                                            '''
+                                        }
+                                    }
 
                                     if (profile.startsWith('operator')) {
                                         docker.image("${env.GOLANG_IMAGE}").inside(env.INTEGRATION_TEST_DOCKER_ARGS) {

--- a/src/main/resources/application-full-secrets.yaml
+++ b/src/main/resources/application-full-secrets.yaml
@@ -1,5 +1,5 @@
 # $schema: https://raw.githubusercontent.com/cloudogu/gitops-playground/main/docs/configuration.schema.json
-# Keep this profile in sync with application-full.yaml. It should only differ in credential references.
+# Keep this profile in sync with application-full.yaml. It only adds settings required to exercise Secret-based credentials.
 application:
   "yes": true
   baseUrl: http://localhost
@@ -31,6 +31,7 @@ jenkins:
     secretNamespace: gop-job
 registry:
   active: true
+  createImagePullSecrets: true
   credentials:
     secretName: registry-credentials
     secretNamespace: gop-job

--- a/src/main/resources/application-full-secrets.yaml
+++ b/src/main/resources/application-full-secrets.yaml
@@ -1,0 +1,80 @@
+# $schema: https://raw.githubusercontent.com/cloudogu/gitops-playground/main/docs/configuration.schema.json
+# Keep this profile in sync with application-full.yaml. It should only differ in credential references.
+application:
+  "yes": true
+  baseUrl: http://localhost
+  credentials:
+    secretName: argocd-credentials
+    secretNamespace: gop-job
+scm:
+  scmManager:
+    credentials:
+      secretName: scm-tenant-credentials
+      secretNamespace: gop-job
+features:
+  certManager:
+    active: true
+  argocd:
+    active: true
+    operator: false
+  ingress:
+    active: true
+  monitoring:
+    active: true
+  secrets:
+    vault:
+      mode: "dev"
+jenkins:
+  active: true
+  credentials:
+    secretName: jenkins-credentials
+    secretNamespace: gop-job
+registry:
+  active: true
+  credentials:
+    secretName: registry-credentials
+    secretNamespace: gop-job
+content:
+  repos:
+    - url: https://github.com/cloudogu/gitops-build-lib
+      target: 3rd-party-dependencies/gitops-build-lib
+      overwriteMode: RESET
+    - url: https://github.com/cloudogu/ces-build-lib
+      target: 3rd-party-dependencies/ces-build-lib
+      overwriteMode: RESET
+    - url: https://github.com/cloudogu/spring-boot-helm-chart
+      target: 3rd-party-dependencies/spring-boot-helm-chart
+      overwriteMode: RESET
+    - url: https://github.com/cloudogu/spring-petclinic
+      target: argocd/petclinic-plain
+      ref: feature/gitops_ready
+      targetRef: main
+      overwriteMode: UPGRADE
+      createJenkinsJob: true
+    - url: https://github.com/cloudogu/spring-petclinic
+      target: argocd/petclinic-helm
+      ref: feature/gitops_ready
+      targetRef: main
+      overwriteMode: UPGRADE
+      createJenkinsJob: true
+    - url: https://github.com/cloudogu/gitops-examples
+      path: example-apps-via-content-loader/
+      ref: main
+      templating: true
+      type: FOLDER_BASED
+      overwriteMode: UPGRADE
+
+  namespaces:
+    - ${config.application.namePrefix}example-apps-production
+    - ${config.application.namePrefix}example-apps-staging
+  variables:
+    petclinic:
+      baseDomain: "petclinic"
+    images:
+      kubectl: "alpine/kubectl:latest"
+      helm: "ghcr.io/cloudogu/helm:latest"
+      kubeval: "ghcr.io/cloudogu/helm:latest"
+      helmKubeval: "ghcr.io/cloudogu/helm:latest"
+      yamllint: "cytopia/yamllint:1.25-0.7"
+      petclinic: "eclipse-temurin:17-jre"
+      maven: ""

--- a/src/test/java/com/cloudogu/gitops/integration/profiles/FullSecretsProfileTestIT.java
+++ b/src/test/java/com/cloudogu/gitops/integration/profiles/FullSecretsProfileTestIT.java
@@ -1,0 +1,127 @@
+package com.cloudogu.gitops.integration.profiles;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the full-secrets profile resolves credentials from Kubernetes Secrets and passes them to consumers.
+ */
+@Slf4j
+@EnabledIfSystemProperty(named = "micronaut.environments", matches = "full-secrets")
+public class FullSecretsProfileTestIT extends ProfileTestSetup {
+
+	private static final String SOURCE_NAMESPACE = "gop-job";
+
+	@BeforeAll
+	static void labelMyTest() {
+		log.info("########### K8S CREDENTIAL TESTS PROFILE full-secrets ###########");
+	}
+
+	@Test
+	void usesApplicationCredentialsFromSecret() {
+		try (KubernetesClient client = new KubernetesClientBuilder().build()) {
+			Secret source = secret(client, SOURCE_NAMESPACE, "argocd-credentials");
+			String expectedUsername = secretValue(source, "username");
+			String expectedPassword = secretValue(source, "password");
+
+			Secret argocdSecret = secret(client, "argocd", "argocd-secret");
+			assertThat(BCrypt.checkpw(expectedPassword, secretValue(argocdSecret, "admin.password"))).isTrue();
+
+			assertCredentials(
+				secret(client, "monitoring", "grafana-admin-credentials"),
+				"admin-user",
+				"admin-password",
+				expectedUsername,
+				expectedPassword
+			);
+			assertCredentials(
+				secret(client, "secrets", "vault-user-credentials"),
+				"username",
+				"password",
+				expectedUsername,
+				expectedPassword
+			);
+		}
+	}
+
+	@Test
+	void usesJenkinsCredentialsFromSecret() {
+		try (KubernetesClient client = new KubernetesClientBuilder().build()) {
+			Secret source = secret(client, SOURCE_NAMESPACE, "jenkins-credentials");
+			assertCredentials(
+				secret(client, "jenkins", "jenkins-credentials"),
+				"jenkins-admin-user",
+				"jenkins-admin-password",
+				secretValue(source, "username"),
+				secretValue(source, "password")
+			);
+		}
+	}
+
+	@Test
+	void usesScmManagerCredentialsFromSecret() {
+		try (KubernetesClient client = new KubernetesClientBuilder().build()) {
+			Secret source = secret(client, SOURCE_NAMESPACE, "scm-tenant-credentials");
+			assertCredentials(
+				secret(client, "scm-manager", "scm-manager-credentials"),
+				"SCM_WEBAPP_INITIALUSER",
+				"SCM_WEBAPP_INITIALPASSWORD",
+				secretValue(source, "username"),
+				secretValue(source, "password")
+			);
+		}
+	}
+
+	@Test
+	void usesRegistryCredentialsFromSecret() {
+		try (KubernetesClient client = new KubernetesClientBuilder().build()) {
+			Secret source = secret(client, SOURCE_NAMESPACE, "registry-credentials");
+			String dockerConfig = secretValue(secret(client, "jenkins", "proxy-registry"), ".dockerconfigjson");
+
+			assertThat(dockerConfig)
+				.contains(secretValue(source, "username"))
+				.contains(secretValue(source, "password"));
+		}
+	}
+
+	private static void assertCredentials(
+		Secret secret,
+		String usernameKey,
+		String passwordKey,
+		String expectedUsername,
+		String expectedPassword
+	) {
+		assertThat(secretValue(secret, usernameKey)).isEqualTo(expectedUsername);
+		assertThat(secretValue(secret, passwordKey)).isEqualTo(expectedPassword);
+	}
+
+	private static Secret secret(KubernetesClient client, String namespace, String name) {
+		Secret secret = client.secrets().inNamespace(namespace).withName(name).get();
+		assertThat(secret)
+			.as("Secret %s/%s", namespace, name)
+			.isNotNull();
+		return secret;
+	}
+
+	private static String secretValue(Secret secret, String key) {
+		if (secret.getStringData() != null && secret.getStringData().containsKey(key)) {
+			return secret.getStringData().get(key);
+		}
+
+		assertThat(secret.getData())
+			.as("Secret %s/%s data", secret.getMetadata().getNamespace(), secret.getMetadata().getName())
+			.containsKey(key);
+		return new String(Base64.getDecoder().decode(secret.getData().get(key)), StandardCharsets.UTF_8);
+	}
+}


### PR DESCRIPTION
## Summary

Adds a dedicated `full-secrets` profile to verify Kubernetes Secret based credentials without changing the existing `full` profile.

## Changes

* Add `application-full-secrets.yaml`
* Configure Secret references for Application, SCM-Manager, Jenkins and Registry
* Enable registry image pull secret creation for credential verification
* Add `full-secrets` to the integration-test profiles
* Prepare required source Secrets in CI
* Add `FullSecretsProfileTestIT`

## Verification

The integration test verifies that credentials from the source Secrets in `gop-job` are used by the corresponding consumers, including Jenkins, SCM-Manager, ArgoCD, Grafana, Vault and Registry.

The existing `full` profile and its integration tests remain unchanged.
